### PR TITLE
feat: 讓 main branch 自動跟 Cloudflare Pages 同步

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -4,7 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'src/lib/version.ts'
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: '22'

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -35,14 +35,6 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Commit version bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/lib/version.ts
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}" || true
-          git push
-
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
@@ -50,4 +42,13 @@ jobs:
           account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           project-name: cyclone-26
           directory: dist
-          git-source: true
+          git-source: false
+
+      - name: Commit version bump
+        if: success()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/lib/version.ts
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git push

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -6,11 +6,17 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  NODE_VERSION: '22'
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -20,8 +26,22 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Bump version
+        id: bump
+        run: |
+          bun run bump:version
+          echo "version=$(cat .version.txt)" >> $GITHUB_OUTPUT
+
       - name: Build
         run: bun run build
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/lib/version.ts
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}" || true
+          git push
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -1,0 +1,33 @@
+name: Cloudflare Pages Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          project-name: cyclone-26
+          directory: dist
+          git-source: true

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
+    "bump:version": "bun scripts/bump-version.ts",
     "deploy": "astro build && wrangler pages deploy dist"
   },
   "devDependencies": {

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+import { readFileSync, writeFileSync } from "node:fs";
+
+const versionFile = "src/lib/version.ts";
+const versionTxtFile = ".version.txt";
+
+const content = readFileSync(versionFile, "utf-8");
+const match = content.match(/VERSION\s*=\s*['"]v(\d+)\.(\d+)\.(\d+)['"]/);
+
+if (!match) {
+  console.error("Could not parse version");
+  process.exit(1);
+}
+
+const [, year, monthDay, patch] = match;
+const now = new Date();
+const yearStr = now.getFullYear().toString();
+const month = (now.getMonth() + 1).toString().padStart(2, "0");
+const day = now.getDate().toString().padStart(2, "0");
+const hour = now.getHours().toString().padStart(2, "0");
+const minute = now.getMinutes().toString().padStart(2, "0");
+
+const newVersion = `v${yearStr}${month}${day}.${hour}${minute}`;
+
+const newContent = content.replace(
+  /VERSION\s*=\s*['"]v[^'"]+['"]/,
+  `VERSION = '${newVersion}'`
+);
+
+writeFileSync(versionFile, newContent);
+writeFileSync(versionTxtFile, newVersion);
+
+console.log(`Bumped to ${newVersion}`);


### PR DESCRIPTION
## Summary

- 新增 `.github/workflows/cloudflare-pages-deploy.yml`，在 `main` 分支 push 時自動觸發 Cloudflare Pages 部署
- 新增 `scripts/bump-version.ts`，每次部署自動更新版本號

## 版本號格式

`v{YYYYMMDD}.{HHmm}`（例如 `v20260408.1430`）

## 需要設定的 Secrets

在 GitHub repo 設定以下 secrets 才會生效：

| Secret | 說明 |
|--------|------|
| `CLOUDFLARE_API_TOKEN` | Cloudflare API Token（需要 Pages Edit 權限） |
| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare Account ID |

## Test plan

- [ ] 合併後 push 到 main 確認自動觸發部署
- [ ] 確認版本號有正確更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)