### PR TITLE
fix: navbar RWD desktop overflow (#21)

### DIFF
--- a/e2e/nav-rwd.spec.ts
+++ b/e2e/nav-rwd.spec.ts
@@ -2,9 +2,11 @@ import { test, expect } from './lambdatest-setup';
 
 /**
  * Issue #21 — Navigation bar RWD tests
+ * Updated for PR #24: desktop nav now uses 3 top-level items + "更多" dropdown
+ *
  * Verifies nav behavior at different viewport sizes:
  * - Mobile/tablet (<1280px): hamburger menu visible, desktop nav hidden
- * - Desktop (>=1280px): desktop nav visible, hamburger hidden
+ * - Desktop (>=1280px): 3 top-level items + "更多" dropdown visible, hamburger hidden
  */
 
 const viewports = [
@@ -49,17 +51,14 @@ for (const vp of viewports) {
       }
     });
 
-    test('all 12 nav items are present', async ({ page }) => {
+    test('logo link is present', async ({ page }) => {
       await page.goto('/');
-
-      // Count total nav links (desktop + mobile menu + logo)
-      const allNavLinks = page.locator('nav a[href]');
-      const count = await allNavLinks.count();
-      // 12 items in desktop OR 12 in mobile menu + 1 logo = at least 12
-      expect(count).toBeGreaterThanOrEqual(12);
+      const logo = page.locator('nav a[href="/"]').first();
+      await expect(logo).toBeVisible();
     });
 
     if (vp.width < 1280) {
+      // ── Mobile/tablet tests ──
       test('hamburger menu opens and shows all nav items', async ({ page }) => {
         await page.goto('/');
 
@@ -73,7 +72,7 @@ for (const vp of viewports) {
         await hamburgerBtn.click();
         await expect(mobileMenu).toBeVisible();
 
-        // Should show nav links inside mobile menu
+        // Should show all 12 nav links inside mobile menu
         const mobileLinks = mobileMenu.locator('a');
         const count = await mobileLinks.count();
         expect(count).toBeGreaterThanOrEqual(10);
@@ -81,6 +80,78 @@ for (const vp of viewports) {
         // Click again to close
         await hamburgerBtn.click();
         await expect(mobileMenu).toBeHidden();
+      });
+    } else {
+      // ── Desktop tests (≥1280px) ──
+      test('shows 3 top-level nav items and "更多" button', async ({ page }) => {
+        await page.goto('/');
+
+        const desktopNav = page.getByTestId('desktop-nav');
+
+        // 3 top-level links: 首頁, 說明, 儀表板
+        const topLevelLinks = desktopNav.locator(':scope > a');
+        const count = await topLevelLinks.count();
+        expect(count).toBe(3);
+
+        // "更多" button exists
+        const moreBtn = page.locator('#more-menu-btn');
+        await expect(moreBtn).toBeVisible();
+      });
+
+      test('"更多" dropdown opens with all 9 items', async ({ page }) => {
+        await page.goto('/');
+
+        const moreBtn = page.locator('#more-menu-btn');
+        const morePanel = page.locator('#more-menu-panel');
+
+        // Dropdown starts hidden
+        await expect(morePanel).toBeHidden();
+
+        // Click to open
+        await moreBtn.click();
+        await expect(morePanel).toBeVisible();
+
+        // Should contain 9 dropdown links (5 功能 + 4 許願&反饋)
+        const dropdownLinks = morePanel.locator('a');
+        const count = await dropdownLinks.count();
+        expect(count).toBe(9);
+
+        // Verify group headers exist
+        await expect(morePanel.getByText('功能')).toBeVisible();
+        await expect(morePanel.getByText('許願 & 反饋')).toBeVisible();
+      });
+
+      test('"更多" dropdown closes on outside click', async ({ page }) => {
+        await page.goto('/');
+
+        const moreBtn = page.locator('#more-menu-btn');
+        const morePanel = page.locator('#more-menu-panel');
+
+        // Open dropdown
+        await moreBtn.click();
+        await expect(morePanel).toBeVisible();
+
+        // Click outside (on the body/main area)
+        await page.locator('main').click();
+        await expect(morePanel).toBeHidden();
+      });
+
+      test('"更多" dropdown chevron rotates on toggle', async ({ page }) => {
+        await page.goto('/');
+
+        const moreBtn = page.locator('#more-menu-btn');
+        const chevron = page.locator('#more-menu-chevron');
+
+        // Initially not rotated
+        await expect(chevron).not.toHaveClass(/rotate-180/);
+
+        // Open — chevron rotates
+        await moreBtn.click();
+        await expect(chevron).toHaveClass(/rotate-180/);
+
+        // Close — chevron resets
+        await moreBtn.click();
+        await expect(chevron).not.toHaveClass(/rotate-180/);
       });
     }
   });

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,25 +69,98 @@ const currentPath = Astro.url.pathname;
     <nav class="fixed top-0 left-0 right-0 z-50 glass border-b border-[var(--color-border)]">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
-          <a href="/" class="flex items-center gap-1.5 text-base 2xl:text-lg font-bold shrink-0">
-            <span class="text-xl 2xl:text-2xl">🌀</span>
-            <span class="gradient-text hidden xl:inline text-sm 2xl:text-base whitespace-nowrap">AI 工作流共學團</span>
+          <a href="/" class="flex items-center gap-2 text-lg font-bold shrink-0">
+            <span class="text-2xl">🌀</span>
+            <span class="gradient-text hidden sm:inline">AI 工作流共學團</span>
           </a>
-          <div data-testid="desktop-nav" class="hidden xl:flex items-center gap-0 2xl:gap-1">
-            {NAV_ITEMS.map((item) => (
+          <div data-testid="desktop-nav" class="hidden xl:flex items-center gap-1">
+            {/* Top-level nav items */}
+            {[
+              { label: '首頁', href: '/', icon: '🏠' },
+              { label: '說明', href: '/readme', icon: '📖' },
+              { label: '儀表板', href: '/dashboard', icon: '📊' },
+            ].map((item) => (
               <a
                 href={item.href}
                 class:list={[
-                  'px-2 py-1.5 2xl:px-3 2xl:py-2 rounded-lg text-xs 2xl:text-sm font-medium transition-colors whitespace-nowrap',
+                  'px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap',
                   currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href))
                     ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary-light)]'
                     : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-overlay-neutral-weak)]',
                 ]}
               >
-                <span class="mr-1">{item.icon}</span>
-                {item.label}
+                <span class="mr-1.5">{item.icon}</span>{item.label}
               </a>
             ))}
+
+            {/* "更多" dropdown */}
+            <div class="relative" id="more-menu-wrapper">
+              <button
+                id="more-menu-btn"
+                class:list={[
+                  'flex items-center gap-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors whitespace-nowrap',
+                  ['/leaderboard','/team','/knowledge','/ai-tools','/agent','/wishlist','/discuss','/issue','/bug'].some(p => currentPath === p || currentPath.startsWith(p + '/'))
+                    ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary-light)]'
+                    : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-overlay-neutral-weak)]',
+                ]}
+              >
+                更多
+                <svg class="w-3.5 h-3.5 transition-transform" id="more-menu-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+
+              {/* Dropdown panel */}
+              <div
+                id="more-menu-panel"
+                class="hidden absolute left-0 top-full mt-2 w-52 rounded-xl shadow-lg py-2 z-50 border border-[var(--color-border)] bg-[var(--color-bg-surface)]"
+              >
+                {/* Group 1: 功能 */}
+                <p class="px-4 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">功能</p>
+                {[
+                  { label: '積分榜', href: '/leaderboard', icon: '🏆' },
+                  { label: '團隊', href: '/team', icon: '👥' },
+                  { label: '知識庫', href: '/knowledge', icon: '📚' },
+                  { label: 'AI工具箱', href: '/ai-tools', icon: '🤖' },
+                  { label: '管家', href: '/agent', icon: '🎩' },
+                ].map((item) => (
+                  <a
+                    href={item.href}
+                    class:list={[
+                      'flex items-center gap-2 px-4 py-2 text-sm transition-colors',
+                      currentPath === item.href || currentPath.startsWith(item.href + '/')
+                        ? 'text-[var(--color-primary-light)] bg-[var(--color-primary)]/10'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-overlay-neutral-weak)]',
+                    ]}
+                  >
+                    <span>{item.icon}</span>{item.label}
+                  </a>
+                ))}
+
+                <div class="my-1 mx-3 border-t border-[var(--color-border)]" />
+
+                {/* Group 2: 許願 & 反饋 */}
+                <p class="px-4 pt-1 pb-1 text-[10px] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">許願 & 反饋</p>
+                {[
+                  { label: '許願樹', href: '/wishlist', icon: '🌳' },
+                  { label: '討論', href: '/discuss', icon: '💬' },
+                  { label: 'Issues', href: '/issue', icon: '📋' },
+                  { label: 'Bug', href: '/bug', icon: '🐛' },
+                ].map((item) => (
+                  <a
+                    href={item.href}
+                    class:list={[
+                      'flex items-center gap-2 px-4 py-2 text-sm transition-colors',
+                      currentPath === item.href || currentPath.startsWith(item.href + '/')
+                        ? 'text-[var(--color-primary-light)] bg-[var(--color-primary)]/10'
+                        : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-overlay-neutral-weak)]',
+                    ]}
+                  >
+                    <span>{item.icon}</span>{item.label}
+                  </a>
+                ))}
+              </div>
+            </div>
           </div>
           <div class="flex items-center gap-1">
             {/* Login button */}
@@ -160,6 +233,23 @@ const currentPath = Astro.url.pathname;
       const btn = document.getElementById('mobile-menu-btn');
       const menu = document.getElementById('mobile-menu');
       btn?.addEventListener('click', () => menu?.classList.toggle('hidden'));
+
+      // "更多" dropdown
+      const moreBtn = document.getElementById('more-menu-btn');
+      const morePanel = document.getElementById('more-menu-panel');
+      const moreChevron = document.getElementById('more-menu-chevron');
+      moreBtn?.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const isOpen = !morePanel?.classList.contains('hidden');
+        morePanel?.classList.toggle('hidden', isOpen);
+        moreChevron?.classList.toggle('rotate-180', !isOpen);
+      });
+      document.addEventListener('click', (e) => {
+        if (!document.getElementById('more-menu-wrapper')?.contains(e.target as Node)) {
+          morePanel?.classList.add('hidden');
+          moreChevron?.classList.remove('rotate-180');
+        }
+      });
 
       // Theme toggle — click flips data-theme and persists to localStorage
       const themeBtn = document.getElementById('theme-toggle');

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -69,22 +69,22 @@ const currentPath = Astro.url.pathname;
     <nav class="fixed top-0 left-0 right-0 z-50 glass border-b border-[var(--color-border)]">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex items-center justify-between h-16">
-          <a href="/" class="flex items-center gap-2 text-lg font-bold">
-            <span class="text-2xl">🌀</span>
-            <span class="gradient-text hidden sm:inline">AI 工作流共學團</span>
+          <a href="/" class="flex items-center gap-1.5 text-base 2xl:text-lg font-bold shrink-0">
+            <span class="text-xl 2xl:text-2xl">🌀</span>
+            <span class="gradient-text hidden xl:inline text-sm 2xl:text-base whitespace-nowrap">AI 工作流共學團</span>
           </a>
-          <div data-testid="desktop-nav" class="hidden xl:flex items-center gap-1">
+          <div data-testid="desktop-nav" class="hidden xl:flex items-center gap-0 2xl:gap-1">
             {NAV_ITEMS.map((item) => (
               <a
                 href={item.href}
                 class:list={[
-                  'px-4 py-2 rounded-lg text-sm font-medium transition-colors',
+                  'px-2 py-1.5 2xl:px-3 2xl:py-2 rounded-lg text-xs 2xl:text-sm font-medium transition-colors whitespace-nowrap',
                   currentPath === item.href || (item.href !== '/' && currentPath.startsWith(item.href))
                     ? 'bg-[var(--color-primary)]/20 text-[var(--color-primary-light)]'
                     : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] hover:bg-[var(--color-overlay-neutral-weak)]',
                 ]}
               >
-                <span class="mr-1.5">{item.icon}</span>
+                <span class="mr-1">{item.icon}</span>
                 {item.label}
               </a>
             ))}


### PR DESCRIPTION
## Summary

- Replace 12 flat desktop nav items with 3 top-level links + a **更多** dropdown
- Dropdown has two grouped sections:
  - **功能**：積分榜、團隊、知識庫、AI工具箱、管家
  - **許願 & 反饋**：許願樹、討論、Issues、Bug
- Dropdown uses solid `bg-surface` background (no opacity/glass effect)
- "更多" button highlights when current page is any child item
- Click outside closes the dropdown
- Mobile hamburger menu unchanged (still shows all items flat)

## Test plan

- [ ] Desktop ≥ 1280px — navbar fits in one row, no overflow
- [ ] Click **更多** → dropdown opens with two sections
- [ ] Navigate to a dropdown page (e.g. `/team`) → "更多" button is highlighted
- [ ] Click outside dropdown → closes correctly
- [ ] Mobile / tablet → hamburger menu still works with all items

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)