### PR TITLE
feat(#28): 管理後台成員 CRUD + 未授權審核閘 + 軟刪除

### DIFF
--- a/functions/api/admin/roles.ts
+++ b/functions/api/admin/roles.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@libsql/client/web';
 import { requireRole, requireAuth } from '../../../src/lib/auth.ts';
+import { listUsersWithRoles } from '../../../src/lib/members.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -7,36 +8,14 @@ interface Env {
 }
 
 // ---------------------------------------------------------------------------
-// GET /api/admin/roles — list all users with roles
+// GET /api/admin/roles — list all active users with roles
 // ---------------------------------------------------------------------------
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
     await requireRole(context.request, context.env, 'admin');
 
-    const db = createClient({
-      url: context.env.TURSO_DATABASE_URL,
-      authToken: context.env.TURSO_AUTH_TOKEN,
-    });
-
-    const result = await db.execute({
-      sql: `
-        SELECT u.id, u.name, u.email, u.avatar_url, GROUP_CONCAT(ur.role) as roles
-        FROM users u
-        LEFT JOIN user_roles ur ON ur.user_id = u.id
-        GROUP BY u.id
-        ORDER BY u.name
-      `,
-      args: [],
-    });
-
-    const users = result.rows.map((r) => ({
-      id: r.id as string,
-      name: r.name as string,
-      email: (r.email as string) ?? '',
-      avatar_url: (r.avatar_url as string) ?? null,
-      roles: r.roles ? (r.roles as string).split(',') : [],
-    }));
+    const users = await listUsersWithRoles(context.env, { status: 'active' });
 
     return new Response(
       JSON.stringify({ ok: true, users }),

--- a/functions/api/admin/stats.ts
+++ b/functions/api/admin/stats.ts
@@ -15,6 +15,18 @@ async function safeCount(db: ReturnType<typeof createClient>, table: string): Pr
   }
 }
 
+async function safeCountActiveUsers(db: ReturnType<typeof createClient>): Promise<number> {
+  try {
+    const result = await db.execute({
+      sql: `SELECT COUNT(*) as count FROM users WHERE archived_at IS NULL AND status = 'active'`,
+      args: [],
+    });
+    return Number(result.rows[0]?.count ?? 0);
+  } catch {
+    return 0;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/admin/stats — aggregate site statistics
 // ---------------------------------------------------------------------------
@@ -30,7 +42,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
     const [totalUsers, totalCheckins, totalKnowledge, totalWishes, totalMessages] =
       await Promise.all([
-        safeCount(db, 'users'),
+        safeCountActiveUsers(db),
         safeCount(db, 'checkins'),
         safeCount(db, 'knowledge_entries'),
         safeCount(db, 'wishes'),

--- a/functions/api/admin/users/[id].ts
+++ b/functions/api/admin/users/[id].ts
@@ -1,0 +1,208 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+import {
+  findUserById,
+  softDeleteUser,
+  countActiveCaptains,
+  getUserRelatedCounts,
+} from '../../../../src/lib/members.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/users/:id
+// Body: { name?, email?, discord_id?, status? }
+// ---------------------------------------------------------------------------
+
+export const onRequestPatch: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+
+    const id = context.params.id as string;
+    const target = await findUserById(context.env, id);
+    if (!target || target.archived_at) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '找不到成員' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const body = await context.request.json() as {
+      name?: string;
+      email?: string;
+      discord_id?: string | null;
+      status?: 'active' | 'pending';
+    };
+
+    const updates: string[] = [];
+    const args: (string | null)[] = [];
+
+    if (body.name !== undefined) {
+      const name = body.name.trim();
+      if (!name) {
+        return new Response(
+          JSON.stringify({ ok: false, error: '姓名不能為空' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      updates.push('name = ?');
+      args.push(name);
+    }
+
+    if (body.email !== undefined) {
+      const email = body.email.trim();
+      if (email) {
+        const db = createClient({
+          url: context.env.TURSO_DATABASE_URL,
+          authToken: context.env.TURSO_AUTH_TOKEN,
+        });
+        const dup = await db.execute({
+          sql: `SELECT id FROM users WHERE email = ? AND id != ? AND archived_at IS NULL LIMIT 1`,
+          args: [email, id],
+        });
+        if (dup.rows.length > 0) {
+          return new Response(
+            JSON.stringify({ ok: false, error: `email 已存在：${email}` }),
+            { status: 409, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      }
+      updates.push('email = ?');
+      args.push(email);
+    }
+
+    if (body.discord_id !== undefined) {
+      updates.push('discord_id = ?');
+      args.push(body.discord_id || null);
+    }
+
+    if (body.status !== undefined) {
+      if (body.status !== 'active' && body.status !== 'pending') {
+        return new Response(
+          JSON.stringify({ ok: false, error: `無效的 status：${body.status}` }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      updates.push('status = ?');
+      args.push(body.status);
+    }
+
+    if (updates.length === 0) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '沒有可更新的欄位' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    updates.push("updated_at = datetime('now')");
+    args.push(id);
+
+    const db = createClient({
+      url: context.env.TURSO_DATABASE_URL,
+      authToken: context.env.TURSO_AUTH_TOKEN,
+    });
+
+    await db.execute({
+      sql: `UPDATE users SET ${updates.join(', ')} WHERE id = ?`,
+      args,
+    });
+
+    const updated = await findUserById(context.env, id);
+    return new Response(
+      JSON.stringify({ ok: true, user: updated }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// DELETE /api/admin/users/:id
+// Two-phase soft delete:
+//   - preview=1: return relatedCounts without touching DB
+//   - force=1:   actually archive + drop sessions
+// Protections (run in both phases to surface errors upfront):
+//   1. cannot delete self
+//   2. cannot delete the last active captain
+//   3. (warning) related data counts are returned so UI can confirm
+// ---------------------------------------------------------------------------
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  try {
+    const operator = await requireRole(context.request, context.env, 'admin');
+    const id = context.params.id as string;
+    const url = new URL(context.request.url);
+    const preview = url.searchParams.get('preview') === '1';
+    const force = url.searchParams.get('force') === '1';
+
+    if (!preview && !force) {
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: '請指定 preview=1 或 force=1',
+        }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (id === operator.id) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '不能封存自己的帳號' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const target = await findUserById(context.env, id);
+    if (!target || target.archived_at) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '找不到成員' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (target.roles.includes('captain')) {
+      const captainCount = await countActiveCaptains(context.env);
+      if (captainCount <= 1) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: '不能封存系統中最後一位 captain',
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+    }
+
+    const relatedCounts = await getUserRelatedCounts(context.env, id);
+
+    if (preview) {
+      return new Response(
+        JSON.stringify({ ok: true, preview: true, target, relatedCounts }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    await softDeleteUser(context.env, id);
+
+    return new Response(
+      JSON.stringify({ ok: true, archived: true, id, relatedCounts }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/functions/api/admin/users/[id]/approve.ts
+++ b/functions/api/admin/users/[id]/approve.ts
@@ -1,0 +1,49 @@
+import { requireRole } from '../../../../../src/lib/auth.ts';
+import { findUserById, approveUser } from '../../../../../src/lib/members.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/users/:id/approve
+// Promotes a pending user to active + assigns the default 'member' role.
+// ---------------------------------------------------------------------------
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+
+    const id = context.params.id as string;
+    const target = await findUserById(context.env, id);
+    if (!target || target.archived_at) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '找不到成員' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (target.status === 'active') {
+      return new Response(
+        JSON.stringify({ ok: false, error: '該成員已是啟用狀態' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    await approveUser(context.env, id);
+
+    const updated = await findUserById(context.env, id);
+    return new Response(
+      JSON.stringify({ ok: true, user: updated }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/functions/api/admin/users/index.ts
+++ b/functions/api/admin/users/index.ts
@@ -1,0 +1,130 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+import { listUsersWithRoles } from '../../../../src/lib/members.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+const VALID_ROLES = ['captain', 'tech', 'admin', 'member', 'companion'] as const;
+type ValidRole = typeof VALID_ROLES[number];
+function isValidRole(r: string): r is ValidRole {
+  return (VALID_ROLES as readonly string[]).includes(r);
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/users
+// Query params:
+//   includeArchived=1 — include soft-deleted users
+//   status=active|pending|all (default: all active + pending visible; omitted returns active only)
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+
+    const url = new URL(context.request.url);
+    const includeArchived = url.searchParams.get('includeArchived') === '1';
+    const statusParam = url.searchParams.get('status') ?? 'all';
+    const status = (['active', 'pending', 'all'].includes(statusParam) ? statusParam : 'all') as
+      | 'active' | 'pending' | 'all';
+
+    const users = await listUsersWithRoles(context.env, { includeArchived, status });
+
+    return new Response(
+      JSON.stringify({ ok: true, users }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/users
+// Body: { name: string, email?: string, role?: ValidRole, discord_id?: string }
+// Creates an active user immediately; role defaults to 'member'.
+// ---------------------------------------------------------------------------
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+
+    const body = await context.request.json() as {
+      name?: string;
+      email?: string;
+      role?: string;
+      discord_id?: string;
+    };
+
+    const name = body.name?.trim();
+    const email = (body.email ?? '').trim();
+    const role = body.role?.trim() || 'member';
+    const discordId = body.discord_id?.trim() || null;
+
+    if (!name) {
+      return new Response(
+        JSON.stringify({ ok: false, error: '姓名必填' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    if (!isValidRole(role)) {
+      return new Response(
+        JSON.stringify({ ok: false, error: `無效的角色：${role}` }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    const db = createClient({
+      url: context.env.TURSO_DATABASE_URL,
+      authToken: context.env.TURSO_AUTH_TOKEN,
+    });
+
+    // Check email uniqueness if provided
+    if (email) {
+      const dup = await db.execute({
+        sql: `SELECT id FROM users WHERE email = ? AND archived_at IS NULL LIMIT 1`,
+        args: [email],
+      });
+      if (dup.rows.length > 0) {
+        return new Response(
+          JSON.stringify({ ok: false, error: `email 已存在：${email}` }),
+          { status: 409, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+    }
+
+    const id = crypto.randomUUID();
+    const roleRowId = crypto.randomUUID();
+
+    await db.batch([
+      {
+        sql: `INSERT INTO users (id, email, name, avatar_url, discord_id, preferences, status, created_at, updated_at)
+              VALUES (?, ?, ?, '', ?, '{}', 'active', datetime('now'), datetime('now'))`,
+        args: [id, email, name, discordId],
+      },
+      {
+        sql: `INSERT INTO user_roles (id, user_id, role) VALUES (?, ?, ?)`,
+        args: [roleRowId, id, role],
+      },
+    ]);
+
+    return new Response(
+      JSON.stringify({ ok: true, id }),
+      { status: 201, headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/functions/api/auth/callback.ts
+++ b/functions/api/auth/callback.ts
@@ -102,28 +102,31 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
     const db = getDb(context.env);
 
-    // Check if user exists by email
+    // Check if user exists by email (excluding archived)
     const existingUser = await db.execute({
-      sql: `SELECT id FROM users WHERE email = ?`,
+      sql: `SELECT id, status FROM users WHERE email = ? AND archived_at IS NULL`,
       args: [googleUser.email],
     });
 
     let userId: string;
+    let isPending = false;
 
     if (existingUser.rows.length > 0) {
       // Update existing user's name and avatar
       userId = existingUser.rows[0].id as string;
+      isPending = (existingUser.rows[0].status as string) === 'pending';
       await db.execute({
         sql: `UPDATE users SET name = ?, avatar_url = ?, updated_at = datetime('now') WHERE id = ?`,
         args: [googleUser.name, googleUser.picture, userId],
       });
     } else {
       // No email match — try to claim a seed user with matching name and empty email
-      // Only allow claiming low-privilege seed users (no admin/tech/captain roles) to prevent role hijacking
+      // Only allow claiming active, non-archived, low-privilege seed users
       // 1. Exact name match (fast path)
       let seedMatch = await db.execute({
         sql: `SELECT id FROM users
               WHERE name = ? AND (email = '' OR email IS NULL)
+              AND archived_at IS NULL AND status = 'active'
               AND NOT EXISTS (SELECT 1 FROM user_roles WHERE user_id = users.id AND role IN ('admin', 'tech', 'captain'))
               LIMIT 1`,
         args: [googleUser.name],
@@ -136,6 +139,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         seedMatch = await db.execute({
           sql: `SELECT id FROM users
                 WHERE (email = '' OR email IS NULL) AND LENGTH(name) >= 4 AND INSTR(?, name) = 1
+                AND archived_at IS NULL AND status = 'active'
                 AND NOT EXISTS (SELECT 1 FROM user_roles WHERE user_id = users.id AND role IN ('admin', 'tech', 'captain'))
                 ORDER BY LENGTH(name) DESC LIMIT 1`,
           args: [googleUser.name],
@@ -150,17 +154,12 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           args: [googleUser.email, googleUser.picture, userId],
         });
       } else {
-        // Truly new user — create with companion role
+        // Truly new user — create as pending, no role until admin approves
         userId = crypto.randomUUID();
+        isPending = true;
         await db.execute({
-          sql: `INSERT INTO users (id, email, name, avatar_url, preferences, created_at, updated_at) VALUES (?, ?, ?, ?, '{}', datetime('now'), datetime('now'))`,
+          sql: `INSERT INTO users (id, email, name, avatar_url, status, preferences, created_at, updated_at) VALUES (?, ?, ?, ?, 'pending', '{}', datetime('now'), datetime('now'))`,
           args: [userId, googleUser.email, googleUser.name, googleUser.picture],
-        });
-
-        const roleId = crypto.randomUUID();
-        await db.execute({
-          sql: `INSERT INTO user_roles (id, user_id, role) VALUES (?, ?, 'companion')`,
-          args: [roleId, userId],
         });
       }
     }
@@ -169,11 +168,11 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const isSecure = url.protocol === 'https:';
     const { setCookie } = await createSession(context.env, userId, isSecure);
 
-    // Redirect to homepage with session cookie
+    // Pending users land on the waiting-for-approval page; everyone else goes home
     return new Response(null, {
       status: 302,
       headers: {
-        Location: '/',
+        Location: isPending ? '/pending' : '/',
         'Set-Cookie': setCookie,
       },
     });

--- a/functions/api/auth/me.ts
+++ b/functions/api/auth/me.ts
@@ -43,6 +43,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           avatar_url: avatar_url || null,
           roles: user.roles,
           effectiveRole: user.effectiveRole,
+          status: user.status,
         },
       }),
       { headers: { 'Content-Type': 'application/json' } },

--- a/functions/api/checkin/leaderboard.ts
+++ b/functions/api/checkin/leaderboard.ts
@@ -25,7 +25,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           SUM(c.points) AS total_points,
           COUNT(c.id) AS total_checkins
         FROM checkins c
-        JOIN users u ON u.id = c.user_id
+        JOIN users u ON u.id = c.user_id AND u.archived_at IS NULL AND u.status = 'active'
         GROUP BY c.user_id
         ORDER BY total_points DESC
         LIMIT 20

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -184,6 +184,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE users ADD COLUMN preferences TEXT DEFAULT '{}'`, note: 'users.preferences' },
       { sql: `ALTER TABLE users ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''`, note: 'users.updated_at' },
       { sql: `ALTER TABLE users ADD COLUMN created_at TEXT NOT NULL DEFAULT ''`, note: 'users.created_at' },
+      { sql: `ALTER TABLE users ADD COLUMN status TEXT NOT NULL DEFAULT 'active'`, note: 'users.status' },
+      { sql: `ALTER TABLE users ADD COLUMN archived_at TEXT`, note: 'users.archived_at' },
     ];
     for (const m of migrations) {
       try { await db.execute({ sql: m.sql, args: [] }); } catch { /* column already exists */ }
@@ -192,6 +194,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     // Recreate UNIQUE index on email if missing
     try {
       await db.execute({ sql: `CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users(email) WHERE email != ''`, args: [] });
+    } catch { /* index already exists */ }
+
+    // Index for active/archived filtering (added for admin members management)
+    try {
+      await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_users_status_archived ON users(status, archived_at)`, args: [] });
     } catch { /* index already exists */ }
 
     // --- Seed members (from constants) ---

--- a/functions/api/knowledge/[id].ts
+++ b/functions/api/knowledge/[id].ts
@@ -26,7 +26,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           u.name AS contributor_name,
           u.avatar_url AS contributor_avatar
         FROM knowledge_entries ke
-        JOIN users u ON u.id = ke.contributor_id
+        JOIN users u ON u.id = ke.contributor_id AND u.archived_at IS NULL AND u.status = 'active'
         WHERE ke.id = ?
       `,
       args: [id],

--- a/functions/api/knowledge/index.ts
+++ b/functions/api/knowledge/index.ts
@@ -27,7 +27,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         u.name AS contributor_name,
         u.avatar_url AS contributor_avatar
       FROM knowledge_entries ke
-      JOIN users u ON u.id = ke.contributor_id
+      JOIN users u ON u.id = ke.contributor_id AND u.archived_at IS NULL AND u.status = 'active'
     `;
     const conditions: string[] = [];
     const args: string[] = [];

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -26,9 +26,12 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const result = await db.execute({
       sql: `
         SELECT
-          w.*,
+          w.id, w.title, w.description, w.category, w.status, w.icon, w.points,
+          w.created_at, w.updated_at,
+          wisher.id AS wisher_id,
           wisher.name AS wisher_name,
           wisher.avatar_url AS wisher_avatar,
+          claimer.id AS claimer_id,
           claimer.name AS claimer_name,
           claimer.avatar_url AS claimer_avatar
         FROM wishes w

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -32,8 +32,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           claimer.name AS claimer_name,
           claimer.avatar_url AS claimer_avatar
         FROM wishes w
-        JOIN users wisher ON wisher.id = w.wisher_id
-        LEFT JOIN users claimer ON claimer.id = w.claimer_id
+        JOIN users wisher ON wisher.id = w.wisher_id AND wisher.archived_at IS NULL AND wisher.status = 'active'
+        LEFT JOIN users claimer ON claimer.id = w.claimer_id AND claimer.archived_at IS NULL AND claimer.status = 'active'
         WHERE w.id = ?
       `,
       args: [id],

--- a/functions/api/wishes/index.ts
+++ b/functions/api/wishes/index.ts
@@ -40,10 +40,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         SELECT
           w.id, w.title, w.description, w.category, w.status, w.icon, w.points,
           w.created_at, w.updated_at,
-          w.wisher_id,
+          wisher.id AS wisher_id,
           wisher.name AS wisher_name,
           wisher.avatar_url AS wisher_avatar,
-          w.claimer_id,
+          claimer.id AS claimer_id,
           claimer.name AS claimer_name,
           claimer.avatar_url AS claimer_avatar
         FROM wishes w

--- a/functions/api/wishes/index.ts
+++ b/functions/api/wishes/index.ts
@@ -47,8 +47,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           claimer.name AS claimer_name,
           claimer.avatar_url AS claimer_avatar
         FROM wishes w
-        JOIN users wisher ON wisher.id = w.wisher_id
-        LEFT JOIN users claimer ON claimer.id = w.claimer_id
+        JOIN users wisher ON wisher.id = w.wisher_id AND wisher.archived_at IS NULL AND wisher.status = 'active'
+        LEFT JOIN users claimer ON claimer.id = w.claimer_id AND claimer.archived_at IS NULL AND claimer.status = 'active'
         ${where}
         ORDER BY w.created_at DESC
       `,

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -27,7 +27,19 @@ interface AdminUser {
   name: string;
   email: string;
   avatar_url: string | null;
+  discord_id: string | null;
+  status: 'active' | 'pending';
+  archived_at: string | null;
+  updated_at: string | null;
   roles: string[];
+}
+
+interface RelatedCounts {
+  checkins: number;
+  wishes: number;
+  knowledge: number;
+  likes: number;
+  sessions: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -69,6 +81,51 @@ const STAT_BORDER_COLORS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// Modal wrapper
+// ---------------------------------------------------------------------------
+
+function Modal({
+  title,
+  onClose,
+  children,
+}: {
+  title: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0,0,0,0.6)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl p-6"
+        style={{
+          background: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+            {title}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-2xl leading-none opacity-60 hover:opacity-100 transition-opacity"
+            style={{ color: 'var(--color-text-muted)' }}
+          >
+            ×
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -80,7 +137,14 @@ export default function AdminPanel() {
   const [dataLoading, setDataLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [updating, setUpdating] = useState<string | null>(null); // user_id being updated
+  const [updating, setUpdating] = useState<string | null>(null);
+  const [includeArchived, setIncludeArchived] = useState(false);
+
+  // Modals
+  const [addOpen, setAddOpen] = useState(false);
+  const [editing, setEditing] = useState<AdminUser | null>(null);
+  const [deleting, setDeleting] = useState<{ user: AdminUser; relatedCounts: RelatedCounts | null; loading: boolean } | null>(null);
+  const [roleConfirm, setRoleConfirm] = useState<{ user: AdminUser; role: string; action: 'add' | 'remove' } | null>(null);
 
   const isAdmin = isRole('admin');
 
@@ -88,9 +152,10 @@ export default function AdminPanel() {
     setDataLoading(true);
     setError(null);
     try {
+      const qs = includeArchived ? '?status=all&includeArchived=1' : '?status=all';
       const [statsRes, usersRes, analyticsRes] = await Promise.all([
         fetch('/api/admin/stats'),
-        fetch('/api/admin/roles'),
+        fetch(`/api/admin/users${qs}`),
         fetch('/api/admin/analytics'),
       ]);
       const statsData = await statsRes.json();
@@ -108,19 +173,18 @@ export default function AdminPanel() {
     } finally {
       setDataLoading(false);
     }
-  }, []);
+  }, [includeArchived]);
 
   useEffect(() => {
     if (isAdmin) fetchData();
   }, [isAdmin, fetchData]);
 
   // ---------------------------------------------------------------------------
-  // Role mutation
+  // Role mutation (with confirmation)
   // ---------------------------------------------------------------------------
 
   async function mutateRole(userId: string, role: string, action: 'add' | 'remove') {
     setUpdating(userId);
-    // Optimistic update
     const prev = users;
     setUsers((us) =>
       us.map((u) => {
@@ -141,9 +205,76 @@ export default function AdminPanel() {
       const data = await res.json();
       if (!data.ok) throw new Error(data.error || '操作失敗');
     } catch (err) {
-      // Rollback
       setUsers(prev);
       setError(err instanceof Error ? err.message : '操作失敗');
+    } finally {
+      setUpdating(null);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Member mutations
+  // ---------------------------------------------------------------------------
+
+  async function createMember(body: { name: string; email: string; role: string; discord_id: string }) {
+    const res = await fetch('/api/admin/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!data.ok) throw new Error(data.error || '新增失敗');
+    await fetchData();
+  }
+
+  async function updateMember(
+    id: string,
+    body: { name?: string; email?: string; discord_id?: string },
+  ) {
+    const res = await fetch(`/api/admin/users/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!data.ok) throw new Error(data.error || '更新失敗');
+    await fetchData();
+  }
+
+  async function previewArchive(u: AdminUser) {
+    setDeleting({ user: u, relatedCounts: null, loading: true });
+    try {
+      const res = await fetch(`/api/admin/users/${u.id}?preview=1`, { method: 'DELETE' });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '預覽失敗');
+      setDeleting({ user: u, relatedCounts: data.relatedCounts, loading: false });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '預覽失敗');
+      setDeleting(null);
+    }
+  }
+
+  async function confirmArchive(id: string) {
+    try {
+      const res = await fetch(`/api/admin/users/${id}?force=1`, { method: 'DELETE' });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '封存失敗');
+      setDeleting(null);
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '封存失敗');
+    }
+  }
+
+  async function approveMember(id: string) {
+    setUpdating(id);
+    try {
+      const res = await fetch(`/api/admin/users/${id}/approve`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '核可失敗');
+      await fetchData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '核可失敗');
     } finally {
       setUpdating(null);
     }
@@ -184,10 +315,6 @@ export default function AdminPanel() {
     );
   }
 
-  // ---------------------------------------------------------------------------
-  // Data loading
-  // ---------------------------------------------------------------------------
-
   if (dataLoading) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -197,10 +324,13 @@ export default function AdminPanel() {
   }
 
   // ---------------------------------------------------------------------------
-  // Filter users
+  // Partition users by status
   // ---------------------------------------------------------------------------
 
-  const filtered = users.filter((u) => {
+  const pendingUsers = users.filter((u) => u.status === 'pending' && !u.archived_at);
+  const activeUsers = users.filter((u) => u.status === 'active' && (includeArchived || !u.archived_at));
+
+  const filtered = activeUsers.filter((u) => {
     if (!search) return true;
     const q = search.toLowerCase();
     return (
@@ -224,7 +354,7 @@ export default function AdminPanel() {
             管理後台
           </h1>
           <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
-            角色管理與站點統計
+            成員、角色與站點統計
           </p>
         </div>
       </div>
@@ -232,11 +362,7 @@ export default function AdminPanel() {
       {error && (
         <div
           className="rounded-xl px-4 py-3 text-sm"
-          style={{
-            background: '#E9456020',
-            border: '1px solid #E9456040',
-            color: '#E94560',
-          }}
+          style={{ background: '#E9456020', border: '1px solid #E9456040', color: '#E94560' }}
         >
           {error}
           <button
@@ -343,40 +469,135 @@ export default function AdminPanel() {
         </div>
       )}
 
+      {/* Pending Approvals */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <h2 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+            待審核使用者
+          </h2>
+          {pendingUsers.length > 0 && (
+            <span
+              className="text-[10px] font-semibold px-2 py-0.5 rounded-full text-white"
+              style={{ backgroundColor: '#E94560' }}
+            >
+              {pendingUsers.length}
+            </span>
+          )}
+        </div>
+        <div
+          className="rounded-xl overflow-hidden"
+          style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
+        >
+          {pendingUsers.length === 0 ? (
+            <div
+              className="px-4 py-8 text-center text-sm"
+              style={{ color: 'var(--color-text-muted)' }}
+            >
+              目前沒有待審核的使用者
+            </div>
+          ) : (
+            <div className="divide-y" style={{ borderColor: 'var(--color-border)' }}>
+              {pendingUsers.map((u) => (
+                <div
+                  key={u.id}
+                  className="flex items-center gap-3 px-4 py-3"
+                  style={{ borderBottom: '1px solid var(--color-border)' }}
+                >
+                  {u.avatar_url ? (
+                    <img src={u.avatar_url} alt={u.name} className="w-10 h-10 rounded-full object-cover" />
+                  ) : (
+                    <div
+                      className="w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold text-white"
+                      style={{ backgroundColor: '#9090B0' }}
+                    >
+                      {u.name.charAt(0).toUpperCase()}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                      {u.name}
+                    </div>
+                    <div className="text-xs truncate" style={{ color: 'var(--color-text-muted)' }}>
+                      {u.email || '（無 email）'}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => approveMember(u.id)}
+                    disabled={updating === u.id}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+                    style={{ background: '#00F5A0' }}
+                  >
+                    核可
+                  </button>
+                  <button
+                    onClick={() => previewArchive(u)}
+                    disabled={updating === u.id}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-opacity hover:opacity-90 disabled:opacity-50"
+                    style={{
+                      background: 'var(--color-bg-dark)',
+                      border: '1px solid var(--color-border)',
+                      color: 'var(--color-text-secondary)',
+                    }}
+                  >
+                    拒絕
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
+
       {/* Member Management */}
       <section>
-        <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center justify-between mb-4 gap-2 flex-wrap">
           <h2 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>
             成員管理
           </h2>
-          <div className="relative">
-            <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+          <div className="flex items-center gap-2 flex-wrap">
+            <label
+              className="flex items-center gap-1.5 text-xs cursor-pointer"
               style={{ color: 'var(--color-text-muted)' }}
-              fill="none" stroke="currentColor" viewBox="0 0 24 24"
             >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <input
-              type="text"
-              placeholder="搜尋成員..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="pl-9 pr-4 py-2 rounded-lg text-sm w-48
-                bg-[var(--color-bg-card)] border border-[var(--color-border)]
-                text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)]
-                focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/50"
-            />
+              <input
+                type="checkbox"
+                checked={includeArchived}
+                onChange={(e) => setIncludeArchived(e.target.checked)}
+              />
+              顯示已封存
+            </label>
+            <div className="relative">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4"
+                style={{ color: 'var(--color-text-muted)' }}
+                fill="none" stroke="currentColor" viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                type="text"
+                placeholder="搜尋成員..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9 pr-4 py-2 rounded-lg text-sm w-48
+                  bg-[var(--color-bg-card)] border border-[var(--color-border)]
+                  text-[var(--color-text-primary)] placeholder:text-[var(--color-text-muted)]
+                  focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/50"
+              />
+            </div>
+            <button
+              onClick={() => setAddOpen(true)}
+              className="px-3 py-2 rounded-lg text-xs font-medium text-white transition-opacity hover:opacity-90"
+              style={{ background: 'var(--color-primary)' }}
+            >
+              + 新增成員
+            </button>
           </div>
         </div>
 
-        {/* Table */}
         <div
           className="rounded-xl overflow-hidden"
-          style={{
-            background: 'var(--color-bg-card)',
-            border: '1px solid var(--color-border)',
-          }}
+          style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
         >
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -399,21 +620,17 @@ export default function AdminPanel() {
               <tbody>
                 {filtered.map((u) => {
                   const isUpdating = updating === u.id;
+                  const isArchived = !!u.archived_at;
                   return (
                     <tr
                       key={u.id}
                       className="transition-colors hover:bg-[var(--color-overlay-neutral-weak)]"
-                      style={{ borderBottom: '1px solid var(--color-border)' }}
+                      style={{ borderBottom: '1px solid var(--color-border)', opacity: isArchived ? 0.5 : 1 }}
                     >
-                      {/* Avatar + Name */}
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-2">
                           {u.avatar_url ? (
-                            <img
-                              src={u.avatar_url}
-                              alt={u.name}
-                              className="w-8 h-8 rounded-full object-cover"
-                            />
+                            <img src={u.avatar_url} alt={u.name} className="w-8 h-8 rounded-full object-cover" />
                           ) : (
                             <div
                               className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white"
@@ -422,18 +639,21 @@ export default function AdminPanel() {
                               {u.name.charAt(0).toUpperCase()}
                             </div>
                           )}
-                          <span className="font-medium" style={{ color: 'var(--color-text-primary)' }}>
-                            {u.name}
-                          </span>
+                          <div className="flex flex-col min-w-0">
+                            <span className="font-medium truncate" style={{ color: 'var(--color-text-primary)' }}>
+                              {u.name}
+                            </span>
+                            {isArchived && (
+                              <span className="text-[10px]" style={{ color: '#E94560' }}>已封存</span>
+                            )}
+                          </div>
                         </div>
                       </td>
 
-                      {/* Email */}
                       <td className="px-4 py-3 hidden sm:table-cell" style={{ color: 'var(--color-text-muted)' }}>
-                        {u.email}
+                        {u.email || <span className="italic opacity-60">（未設定）</span>}
                       </td>
 
-                      {/* Roles */}
                       <td className="px-4 py-3">
                         <div className="flex flex-wrap gap-1">
                           {u.roles.length === 0 && (
@@ -449,8 +669,8 @@ export default function AdminPanel() {
                             >
                               {ROLE_LABELS[role] || role}
                               <button
-                                onClick={() => mutateRole(u.id, role, 'remove')}
-                                disabled={isUpdating || (u.id === user?.id && ['captain', 'tech', 'admin'].includes(role))}
+                                onClick={() => setRoleConfirm({ user: u, role, action: 'remove' })}
+                                disabled={isUpdating || isArchived || (u.id === user?.id && ['captain', 'tech', 'admin'].includes(role))}
                                 className="opacity-60 hover:opacity-100 transition-opacity disabled:opacity-30 disabled:cursor-not-allowed"
                                 title={
                                   u.id === user?.id && ['captain', 'tech', 'admin'].includes(role)
@@ -458,39 +678,63 @@ export default function AdminPanel() {
                                     : `移除 ${ROLE_LABELS[role] || role}`
                                 }
                               >
-                                x
+                                ×
                               </button>
                             </span>
                           ))}
                         </div>
                       </td>
 
-                      {/* Actions */}
                       <td className="px-4 py-3 text-right">
-                        <select
-                          className="text-xs px-2 py-1 rounded-lg
-                            bg-[var(--color-bg-dark)] border border-[var(--color-border)]
-                            text-[var(--color-text-secondary)] cursor-pointer
-                            disabled:opacity-50"
-                          disabled={isUpdating}
-                          defaultValue=""
-                          onChange={(e) => {
-                            const role = e.target.value as GroupRole;
-                            if (role && !u.roles.includes(role)) {
-                              mutateRole(u.id, role, 'add');
-                            }
-                            e.target.value = '';
-                          }}
-                        >
-                          <option value="" disabled>
-                            + 新增角色
-                          </option>
-                          {ROLE_LEVEL_ORDER.filter((r) => !u.roles.includes(r)).map((role) => (
-                            <option key={role} value={role}>
-                              {ROLE_LABELS[role]}
-                            </option>
-                          ))}
-                        </select>
+                        <div className="flex items-center justify-end gap-2 flex-wrap">
+                          <select
+                            className="text-xs px-2 py-1 rounded-lg
+                              bg-[var(--color-bg-dark)] border border-[var(--color-border)]
+                              text-[var(--color-text-secondary)] cursor-pointer
+                              disabled:opacity-50"
+                            disabled={isUpdating || isArchived}
+                            value=""
+                            onChange={(e) => {
+                              const role = e.target.value as GroupRole;
+                              if (role && !u.roles.includes(role)) {
+                                setRoleConfirm({ user: u, role, action: 'add' });
+                              }
+                              e.target.value = '';
+                            }}
+                          >
+                            <option value="" disabled>+ 角色</option>
+                            {ROLE_LEVEL_ORDER.filter((r) => !u.roles.includes(r)).map((role) => (
+                              <option key={role} value={role}>
+                                {ROLE_LABELS[role]}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            onClick={() => setEditing(u)}
+                            disabled={isUpdating || isArchived}
+                            className="text-xs px-2 py-1 rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50"
+                            style={{
+                              background: 'var(--color-bg-dark)',
+                              border: '1px solid var(--color-border)',
+                              color: 'var(--color-text-secondary)',
+                            }}
+                          >
+                            編輯
+                          </button>
+                          <button
+                            onClick={() => previewArchive(u)}
+                            disabled={isUpdating || isArchived || u.id === user?.id}
+                            className="text-xs px-2 py-1 rounded-lg transition-opacity hover:opacity-90 disabled:opacity-50"
+                            style={{
+                              background: '#E9456020',
+                              border: '1px solid #E9456040',
+                              color: '#E94560',
+                            }}
+                            title={u.id === user?.id ? '不能封存自己' : '封存成員'}
+                          >
+                            封存
+                          </button>
+                        </div>
                       </td>
                     </tr>
                   );
@@ -515,10 +759,7 @@ export default function AdminPanel() {
       {/* Role Legend */}
       <section
         className="rounded-xl p-5"
-        style={{
-          background: 'var(--color-bg-card)',
-          border: '1px solid var(--color-border)',
-        }}
+        style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
       >
         <h3 className="text-sm font-semibold mb-3" style={{ color: 'var(--color-text-primary)' }}>
           角色階級說明
@@ -547,6 +788,352 @@ export default function AdminPanel() {
           左側為較高等級。高等級角色自動擁有低等級的所有權限。
         </p>
       </section>
+
+      {/* Add Member Modal */}
+      {addOpen && (
+        <Modal title="新增成員" onClose={() => setAddOpen(false)}>
+          <AddMemberForm
+            onSubmit={async (body) => {
+              try {
+                await createMember(body);
+                setAddOpen(false);
+              } catch (err) {
+                setError(err instanceof Error ? err.message : '新增失敗');
+              }
+            }}
+            onCancel={() => setAddOpen(false)}
+          />
+        </Modal>
+      )}
+
+      {/* Edit Member Modal */}
+      {editing && (
+        <Modal title={`編輯：${editing.name}`} onClose={() => setEditing(null)}>
+          <EditMemberForm
+            user={editing}
+            onSubmit={async (body) => {
+              try {
+                await updateMember(editing.id, body);
+                setEditing(null);
+              } catch (err) {
+                setError(err instanceof Error ? err.message : '更新失敗');
+              }
+            }}
+            onCancel={() => setEditing(null)}
+          />
+        </Modal>
+      )}
+
+      {/* Archive Confirm Modal */}
+      {deleting && (
+        <Modal title={`封存：${deleting.user.name}`} onClose={() => setDeleting(null)}>
+          {deleting.loading ? (
+            <div className="py-4 text-center text-sm" style={{ color: 'var(--color-text-muted)' }}>
+              載入關聯資料...
+            </div>
+          ) : (
+            <>
+              <p className="text-sm mb-3" style={{ color: 'var(--color-text-secondary)' }}>
+                封存後該成員會從公開列表消失，session 也會被清除。可重新設為 active 恢復。
+              </p>
+              {deleting.relatedCounts && (
+                <div
+                  className="rounded-lg p-3 mb-4 text-xs space-y-1"
+                  style={{ background: 'var(--color-bg-dark)', border: '1px solid var(--color-border)', color: 'var(--color-text-muted)' }}
+                >
+                  <div>關聯資料（封存後仍保留但會被過濾）：</div>
+                  <div className="grid grid-cols-2 gap-1 mt-1">
+                    <span>打卡：{deleting.relatedCounts.checkins}</span>
+                    <span>願望：{deleting.relatedCounts.wishes}</span>
+                    <span>知識：{deleting.relatedCounts.knowledge}</span>
+                    <span>按讚：{deleting.relatedCounts.likes}</span>
+                    <span>Session：{deleting.relatedCounts.sessions}</span>
+                  </div>
+                </div>
+              )}
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  onClick={() => setDeleting(null)}
+                  className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+                  style={{
+                    background: 'var(--color-bg-dark)',
+                    border: '1px solid var(--color-border)',
+                    color: 'var(--color-text-secondary)',
+                  }}
+                >
+                  取消
+                </button>
+                <button
+                  onClick={() => confirmArchive(deleting.user.id)}
+                  className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+                  style={{ background: '#E94560' }}
+                >
+                  確認封存
+                </button>
+              </div>
+            </>
+          )}
+        </Modal>
+      )}
+
+      {/* Role Mutation Confirm Modal */}
+      {roleConfirm && (
+        <Modal
+          title={roleConfirm.action === 'add' ? '確認指派角色' : '確認移除角色'}
+          onClose={() => setRoleConfirm(null)}
+        >
+          <p className="text-sm mb-4" style={{ color: 'var(--color-text-secondary)' }}>
+            {roleConfirm.action === 'add' ? '將指派' : '將移除'}{' '}
+            <span className="font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+              {roleConfirm.user.name}
+            </span>{' '}
+            的{' '}
+            <span
+              className="inline-block text-[10px] font-semibold px-2 py-0.5 rounded-full text-white"
+              style={{ backgroundColor: ROLE_BADGE_COLORS[roleConfirm.role] || '#9090B0' }}
+            >
+              {ROLE_LABELS[roleConfirm.role] || roleConfirm.role}
+            </span>{' '}
+            角色。
+          </p>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => setRoleConfirm(null)}
+              className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+              style={{
+                background: 'var(--color-bg-dark)',
+                border: '1px solid var(--color-border)',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              取消
+            </button>
+            <button
+              onClick={() => {
+                const { user: u, role, action } = roleConfirm;
+                setRoleConfirm(null);
+                mutateRole(u.id, role, action);
+              }}
+              className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+              style={{ background: 'var(--color-primary)' }}
+            >
+              確認
+            </button>
+          </div>
+        </Modal>
+      )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub forms
+// ---------------------------------------------------------------------------
+
+function AddMemberForm({
+  onSubmit,
+  onCancel,
+}: {
+  onSubmit: (body: { name: string; email: string; role: string; discord_id: string }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<GroupRole>('member');
+  const [discordId, setDiscordId] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        setSubmitting(true);
+        try {
+          await onSubmit({ name: name.trim(), email: email.trim(), role, discord_id: discordId.trim() });
+        } finally {
+          setSubmitting(false);
+        }
+      }}
+      className="space-y-3"
+    >
+      <FormField label="姓名 / 暱稱 *">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="form-input"
+          placeholder="Cyclone"
+        />
+      </FormField>
+      <FormField label="Email">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="form-input"
+          placeholder="member@example.com（可留空）"
+        />
+      </FormField>
+      <FormField label="Discord ID">
+        <input
+          value={discordId}
+          onChange={(e) => setDiscordId(e.target.value)}
+          className="form-input"
+          placeholder="#1234（選填）"
+        />
+      </FormField>
+      <FormField label="角色">
+        <select
+          value={role}
+          onChange={(e) => setRole(e.target.value as GroupRole)}
+          className="form-input"
+        >
+          {ROLE_LEVEL_ORDER.map((r) => (
+            <option key={r} value={r}>{ROLE_LABELS[r]}</option>
+          ))}
+        </select>
+      </FormField>
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+          style={{
+            background: 'var(--color-bg-dark)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={submitting || !name.trim()}
+          className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          style={{ background: 'var(--color-primary)' }}
+        >
+          {submitting ? '新增中...' : '新增'}
+        </button>
+      </div>
+      <FormStyles />
+    </form>
+  );
+}
+
+function EditMemberForm({
+  user: u,
+  onSubmit,
+  onCancel,
+}: {
+  user: AdminUser;
+  onSubmit: (body: { name?: string; email?: string; discord_id?: string }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState(u.name);
+  const [email, setEmail] = useState(u.email);
+  const [discordId, setDiscordId] = useState(u.discord_id ?? '');
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        setSubmitting(true);
+        try {
+          await onSubmit({
+            name: name.trim(),
+            email: email.trim(),
+            discord_id: discordId.trim(),
+          });
+        } finally {
+          setSubmitting(false);
+        }
+      }}
+      className="space-y-3"
+    >
+      <FormField label="姓名 / 暱稱 *">
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="form-input"
+        />
+      </FormField>
+      <FormField label="Email">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="form-input"
+          placeholder="member@example.com（可留空）"
+        />
+      </FormField>
+      <FormField label="Discord ID">
+        <input
+          value={discordId}
+          onChange={(e) => setDiscordId(e.target.value)}
+          className="form-input"
+        />
+      </FormField>
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+          style={{
+            background: 'var(--color-bg-dark)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={submitting || !name.trim()}
+          className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          style={{ background: 'var(--color-primary)' }}
+        >
+          {submitting ? '儲存中...' : '儲存'}
+        </button>
+      </div>
+      <FormStyles />
+    </form>
+  );
+}
+
+function FormField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span
+        className="block text-xs font-medium mb-1"
+        style={{ color: 'var(--color-text-muted)' }}
+      >
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function FormStyles() {
+  return (
+    <style>{`
+      .form-input {
+        width: 100%;
+        padding: 0.5rem 0.75rem;
+        border-radius: 0.5rem;
+        background: var(--color-bg-dark);
+        border: 1px solid var(--color-border);
+        color: var(--color-text-primary);
+        font-size: 0.875rem;
+      }
+      .form-input:focus {
+        outline: 2px solid var(--color-primary);
+        outline-offset: -1px;
+      }
+    `}</style>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -15,6 +15,7 @@ export interface SessionUser {
   discord_id: string | null;
   roles: string[];
   effectiveRole: string;
+  status: 'active' | 'pending';
 }
 
 // ---------------------------------------------------------------------------
@@ -141,9 +142,11 @@ export async function getSessionUser(
   const result = await db.execute({
     sql: `
       SELECT
-        u.id        AS user_id,
-        u.name      AS user_name,
-        u.discord_id AS user_discord_id,
+        u.id          AS user_id,
+        u.name        AS user_name,
+        u.discord_id  AS user_discord_id,
+        u.status      AS user_status,
+        u.archived_at AS user_archived_at,
         s.expires_at
       FROM sessions s
       JOIN users u ON u.id = s.user_id
@@ -162,7 +165,14 @@ export async function getSessionUser(
     return null;
   }
 
+  // Archived users are effectively logged out — destroy their session
+  if (row.user_archived_at) {
+    await db.execute({ sql: `DELETE FROM sessions WHERE token = ?`, args: [token] });
+    return null;
+  }
+
   const userId = row.user_id as string;
+  const status = ((row.user_status as string) || 'active') as 'active' | 'pending';
 
   // Fetch roles
   const rolesResult = await db.execute({
@@ -171,22 +181,26 @@ export async function getSessionUser(
   });
 
   const roles = rolesResult.rows.map((r) => r.role as string);
-  // If no roles assigned, default to 'companion'
-  const effectiveRole = roles.length > 0 ? getEffectiveRole(roles) : 'companion';
+  // Pending users have no effective role regardless of any stray role rows;
+  // active users with no roles default to 'companion'.
+  const effectiveRole = status === 'pending'
+    ? 'pending'
+    : (roles.length > 0 ? getEffectiveRole(roles) : 'companion');
 
   return {
     id: userId,
     name: row.user_name as string,
     discord_id: (row.user_discord_id as string) ?? null,
-    roles: roles.length > 0 ? roles : ['companion'],
+    roles: status === 'pending' ? [] : (roles.length > 0 ? roles : ['companion']),
     effectiveRole,
+    status,
   };
 }
 
 /**
- * requireAuth — returns the authenticated user or throws a 401 Response.
- * Usage inside a PagesFunction handler:
- *   const user = await requireAuth(context.request, context.env);
+ * requireAuth — returns the authenticated active user or throws a 401/403 Response.
+ * Pending users (awaiting admin approval) are rejected with 403; they can still reach
+ * /api/auth/me and /api/auth/logout via getSessionUser directly.
  */
 export async function requireAuth(
   request: Request,
@@ -198,6 +212,12 @@ export async function requireAuth(
       status: 401,
       headers: { 'Content-Type': 'application/json' },
     });
+  }
+  if (user.status === 'pending') {
+    throw new Response(
+      JSON.stringify({ ok: false, error: '帳號待審核', status: 'pending' }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
   }
   return user;
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,18 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260411.4',
+    date: '2026-04-11 15:00',
+    changes: [
+      'feat: Issue #28 — 管理後台成員 CRUD（新增 / 編輯暱稱與 email / 軟刪除封存）',
+      'feat: Issue #28 — 未授權 Google 登入者進入待審核狀態，導向 /pending 等待頁',
+      'feat: Issue #28 — 管理後台新增「待審核使用者」區塊，一鍵核可 / 拒絕',
+      'feat: Issue #28 — 角色指派 / 移除加入二次確認 dialog，防止誤操作',
+      'feat: users 表新增 status / archived_at 欄位 + 專用索引',
+      'fix: 公開查詢（leaderboard / wishes / knowledge）自動過濾 archived 與 pending 使用者',
+    ],
+  },
+  {
     version: 'v20260411.3',
     date: '2026-04-11 12:00',
     changes: [

--- a/src/lib/members.ts
+++ b/src/lib/members.ts
@@ -1,0 +1,173 @@
+import { createClient } from '@libsql/client/web';
+import type { Env } from './auth.ts';
+
+export interface MemberRow {
+  id: string;
+  name: string;
+  email: string;
+  avatar_url: string | null;
+  discord_id: string | null;
+  status: 'active' | 'pending';
+  archived_at: string | null;
+  updated_at: string | null;
+  roles: string[];
+}
+
+export interface ListOptions {
+  includeArchived?: boolean;
+  status?: 'active' | 'pending' | 'all';
+}
+
+function getDb(env: Env) {
+  return createClient({
+    url: env.TURSO_DATABASE_URL,
+    authToken: env.TURSO_AUTH_TOKEN,
+  });
+}
+
+export async function listUsersWithRoles(env: Env, opts: ListOptions = {}): Promise<MemberRow[]> {
+  const { includeArchived = false, status = 'active' } = opts;
+
+  const whereClauses: string[] = [];
+  if (!includeArchived) whereClauses.push('u.archived_at IS NULL');
+  if (status !== 'all') whereClauses.push(`u.status = '${status === 'pending' ? 'pending' : 'active'}'`);
+
+  const whereSql = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+
+  const db = getDb(env);
+  const result = await db.execute({
+    sql: `
+      SELECT
+        u.id,
+        u.name,
+        u.email,
+        u.avatar_url,
+        u.discord_id,
+        u.status,
+        u.archived_at,
+        u.updated_at,
+        GROUP_CONCAT(ur.role) AS roles
+      FROM users u
+      LEFT JOIN user_roles ur ON ur.user_id = u.id
+      ${whereSql}
+      GROUP BY u.id
+      ORDER BY u.name
+    `,
+    args: [],
+  });
+
+  return result.rows.map((r) => ({
+    id: r.id as string,
+    name: r.name as string,
+    email: (r.email as string) ?? '',
+    avatar_url: (r.avatar_url as string) ?? null,
+    discord_id: (r.discord_id as string) ?? null,
+    status: ((r.status as string) || 'active') as 'active' | 'pending',
+    archived_at: (r.archived_at as string) ?? null,
+    updated_at: (r.updated_at as string) ?? null,
+    roles: r.roles ? (r.roles as string).split(',') : [],
+  }));
+}
+
+export async function findUserById(env: Env, id: string): Promise<MemberRow | null> {
+  const db = getDb(env);
+  const result = await db.execute({
+    sql: `
+      SELECT u.id, u.name, u.email, u.avatar_url, u.discord_id, u.status, u.archived_at, u.updated_at,
+             GROUP_CONCAT(ur.role) AS roles
+      FROM users u
+      LEFT JOIN user_roles ur ON ur.user_id = u.id
+      WHERE u.id = ?
+      GROUP BY u.id
+    `,
+    args: [id],
+  });
+
+  if (result.rows.length === 0) return null;
+  const r = result.rows[0];
+  return {
+    id: r.id as string,
+    name: r.name as string,
+    email: (r.email as string) ?? '',
+    avatar_url: (r.avatar_url as string) ?? null,
+    discord_id: (r.discord_id as string) ?? null,
+    status: ((r.status as string) || 'active') as 'active' | 'pending',
+    archived_at: (r.archived_at as string) ?? null,
+    updated_at: (r.updated_at as string) ?? null,
+    roles: r.roles ? (r.roles as string).split(',') : [],
+  };
+}
+
+export interface RelatedCounts {
+  checkins: number;
+  wishes: number;
+  knowledge: number;
+  likes: number;
+  sessions: number;
+}
+
+export async function getUserRelatedCounts(env: Env, userId: string): Promise<RelatedCounts> {
+  const db = getDb(env);
+  const result = await db.execute({
+    sql: `
+      SELECT
+        (SELECT COUNT(*) FROM checkins WHERE user_id = ?) AS checkins,
+        (SELECT COUNT(*) FROM wishes WHERE wisher_id = ? OR claimer_id = ?) AS wishes,
+        (SELECT COUNT(*) FROM knowledge_entries WHERE contributor_id = ?) AS knowledge,
+        (SELECT COUNT(*) FROM discussion_likes WHERE user_id = ?) AS likes,
+        (SELECT COUNT(*) FROM sessions WHERE user_id = ?) AS sessions
+    `,
+    args: [userId, userId, userId, userId, userId, userId],
+  });
+  const r = result.rows[0] ?? {};
+  return {
+    checkins: Number(r.checkins ?? 0),
+    wishes: Number(r.wishes ?? 0),
+    knowledge: Number(r.knowledge ?? 0),
+    likes: Number(r.likes ?? 0),
+    sessions: Number(r.sessions ?? 0),
+  };
+}
+
+export async function countActiveCaptains(env: Env): Promise<number> {
+  const db = getDb(env);
+  const result = await db.execute({
+    sql: `
+      SELECT COUNT(DISTINCT ur.user_id) AS c
+      FROM user_roles ur
+      JOIN users u ON u.id = ur.user_id
+      WHERE ur.role = 'captain' AND u.archived_at IS NULL AND u.status = 'active'
+    `,
+    args: [],
+  });
+  return Number(result.rows[0]?.c ?? 0);
+}
+
+export async function softDeleteUser(env: Env, id: string): Promise<void> {
+  const db = getDb(env);
+  await db.batch([
+    {
+      sql: `UPDATE users SET archived_at = datetime('now'), updated_at = datetime('now') WHERE id = ?`,
+      args: [id],
+    },
+    {
+      sql: `DELETE FROM sessions WHERE user_id = ?`,
+      args: [id],
+    },
+  ]);
+}
+
+export async function approveUser(env: Env, id: string): Promise<void> {
+  const db = getDb(env);
+  const roleId = crypto.randomUUID();
+  await db.batch([
+    {
+      sql: `UPDATE users SET status = 'active', updated_at = datetime('now') WHERE id = ?`,
+      args: [id],
+    },
+    {
+      sql: `INSERT OR IGNORE INTO user_roles (id, user_id, role) VALUES (?, ?, 'member')`,
+      args: [roleId, id],
+    },
+  ]);
+}

--- a/src/pages/pending.astro
+++ b/src/pages/pending.astro
@@ -1,0 +1,74 @@
+---
+import Layout from '@/layouts/Layout.astro';
+---
+
+<Layout title="帳號審核中" description="等待管理員審核">
+  <div class="max-w-xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
+    <div
+      class="rounded-2xl p-8 text-center"
+      style={{
+        background: 'var(--color-bg-card)',
+        border: '1px solid var(--color-border)',
+      }}
+    >
+      <div class="text-6xl mb-4">⏳</div>
+      <h1 class="text-2xl font-bold mb-3" style={{ color: 'var(--color-text-primary)' }}>
+        帳號正在等待審核
+      </h1>
+      <p class="text-sm mb-2" style={{ color: 'var(--color-text-muted)' }}>
+        你用 Google 登入成功，但尚未被管理員加入共學團成員名單。
+      </p>
+      <p class="text-sm mb-6" style={{ color: 'var(--color-text-muted)' }}>
+        請聯絡 Cyclone 或隊長協助審核，審核通過後重新登入即可使用所有功能。
+      </p>
+      <div class="flex items-center justify-center gap-3">
+        <button
+          id="pending-logout"
+          class="px-5 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+          style={{ background: 'var(--color-primary)' }}
+        >
+          登出
+        </button>
+        <a
+          href="/"
+          class="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+          style={{
+            background: 'var(--color-bg-dark)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          回首頁
+        </a>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<script>
+  // Redirect away if user is not pending (or not logged in)
+  (async () => {
+    try {
+      const res = await fetch('/api/auth/me');
+      const data = await res.json();
+      if (!data.ok || !data.user) {
+        window.location.href = '/';
+        return;
+      }
+      if (data.user.status !== 'pending') {
+        window.location.href = '/';
+      }
+    } catch {
+      window.location.href = '/';
+    }
+  })();
+
+  document.getElementById('pending-logout')?.addEventListener('click', async () => {
+    try {
+      await fetch('/api/auth/logout', { method: 'POST' });
+    } catch {
+      // ignore
+    }
+    window.location.href = '/';
+  });
+</script>


### PR DESCRIPTION
Closes #28

## Summary

一次處理 #28 的第 1~4 項，並追加未授權使用者審核閘（Cyclone 在 Discord 回報的阻塞）。

- **角色指派確認機制（第 1 項）**：新增/移除角色改為 dialog 二次確認
- **手動新增成員（第 2 項）**：後台新增成員 modal，支援暱稱 / email / Discord ID / 角色
- **刪除/停用成員（第 3 項）**：軟刪除（`archived_at` flag），封存時二段式 dialog 顯示關聯資料
- **修改成員顯示名稱（第 4 項）**：編輯成員 modal 可改 name / email / discord_id
- **未授權審核閘（新）**：新的 Google 登入不分配角色，進入 `status='pending'` 並導到 `/pending` 等待管理員核可。現有 27 位種子使用者 + 已活躍 OAuth 使用者全部自動是 `active`，不受影響
- **後台入口卡片（第 5 項）**：未包含——低優先度，留作獨立 follow-up

## Schema 變更（additive，零破壞）

```sql
ALTER TABLE users ADD COLUMN status TEXT NOT NULL DEFAULT 'active'
  CHECK(status IN ('active', 'pending'));
ALTER TABLE users ADD COLUMN archived_at TEXT;
CREATE INDEX idx_users_status_archived ON users(status, archived_at);
```

部署後需打一次 `/api/db/init` 觸發 migration。既有資料全部預設 `status='active'`、`archived_at=NULL`，不會踢到現有登入。

## 安全與邊界

- `requireAuth` 改為拒絕 pending 使用者，會 throw 403 + `status: 'pending'`，讓前端能 redirect 到 `/pending`
- `getSessionUser` (非 throwing) 在發現 user 已 archived 時會清掉該 session 並回 null，等同強制登出
- 軟刪除保護四道：禁自刪、禁刪最後一位 captain、preview 關聯資料顯示警告、確認後清除 session
- `leaderboard` / `wishes` / `knowledge` 公開 JOIN 加入 `archived_at IS NULL AND status='active'` filter，避免封存與 pending 使用者在公開列表出現

## 檔案變更

**新增**
- `functions/api/admin/users/index.ts` — GET/POST
- `functions/api/admin/users/[id].ts` — PATCH/DELETE（軟刪除，兩段式 preview/force）
- `functions/api/admin/users/[id]/approve.ts` — POST 核可 pending
- `src/lib/members.ts` — 共用 DB helper（listUsersWithRoles, findUserById, softDeleteUser, approveUser, countActiveCaptains, getUserRelatedCounts）
- `src/pages/pending.astro` — 等待審核 landing page

**修改**
- `functions/api/db/init.ts` — migration 追加兩個欄位與索引
- `functions/api/auth/callback.ts` — 4 處改動（email 比對加 archived 過濾 / seed claim 加 status 過濾 / 新 user 走 pending / 依 status redirect 到 /pending）
- `functions/api/auth/me.ts` — 回傳 `status` 欄位
- `functions/api/admin/roles.ts` — GET 改用 `listUsersWithRoles` helper
- `functions/api/admin/stats.ts` — 改用 `safeCountActiveUsers`
- `functions/api/checkin/leaderboard.ts` — JOIN 加 archived/status filter
- `functions/api/wishes/index.ts` + `[id].ts` — wisher + claimer 加 filter
- `functions/api/knowledge/index.ts` + `[id].ts` — contributor 加 filter
- `src/lib/auth.ts` — SessionUser 加 `status`，`getSessionUser` 擴充 SQL，`requireAuth` 拒絕 pending
- `src/components/admin/AdminPanel.tsx` — 完整重寫加入待審核 section / CRUD modal / 封存 dialog / 角色確認 dialog / 顯示已封存 toggle
- `src/lib/changelog.ts` — v20260411.4 條目

## Test plan

- [ ] dar 本地啟 `wrangler pages dev` + `.dev.vars`，先打 `POST /api/db/init` 觸發 migration
- [ ] 用 `/api/auth/dev-login` 登入成 captain，進 `/admin`
- [ ] 看到「待審核使用者」section（目前為空）、「成員管理」table 顯示 27 位 seed
- [ ] 編輯 `benben` 填 Gmail → 存檔 → reload 後 email 保留
- [ ] 登出 → 用該 Gmail 做 Google OAuth 登入 → callback 應命中 email 比對，session 對應到 `benben` 而非新建 user
- [ ] 用陌生 Gmail 做 Google OAuth → 應導到 `/pending`，其他受保護 API 應回 403 + `status: 'pending'`
- [ ] `dev-login` 回 captain → 待審核 section 看到該帳號 → 點「核可」→ 該帳號再登入 → 可進站，角色為 `member`
- [ ] 刪除自己 → 擋；刪最後一位 captain → 擋；刪有 checkin 的 test user → 先顯示 preview → 確認後軟刪除 → 公開列表消失
- [ ] 角色指派 / 移除 → 先跳 dialog → 取消不動作 / 確認才執行
- [ ] 公開頁面檢查：`/leaderboard`、`/wishlist`、`/knowledge` 不含 archived 或 pending 使用者
- [ ] E2E 錄影附上（依 MEMORY.md `feedback_issue-workflow.md` 規範）

## 備註

- 本 PR 與 #23 (feat/23_gemini-ai-suggestions) 並行開發，兩者無 schema 衝突
- Astro build 已通過；`functions/` 目錄 Cloudflare Pages Functions 會在部署時由 CF 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)