### PR TITLE
docs(#36): 導入 AGENTS.md + issues/ 檔案式記憶架構

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md — Cyclone-26 協作守則
+
+> 所有 AI 工具請先讀本檔。Claude Code 可補讀 `CLAUDE.md` 取得專屬設定。
+
+## 專案速覽
+
+Cyclone 共學團(19 人)社群網站,部署在 https://cyclone.tw
+
+- **框架**:Astro + React(SSG + Cloudflare Pages Functions)
+- **執行環境**:Bun(禁用 npm / pnpm / yarn / npx)
+- **資料庫**:Turso(libSQL,**單顆 production instance**,無 dev 分離)
+- **部署**:Cloudflare Pages(push 到 main 自動部署)
+- **桌面版**:Tauri(`desktop_app/`,選擇性使用)
+
+延伸閱讀:
+
+- `README.md` — 專案概覽
+- `wiki/Home.md` — wiki 入口
+- `wiki/Architecture.md` — 技術架構細節
+- `wiki/Database.md` — DB schema
+- `wiki/API.md` — API endpoints
+- `wiki/Environment.md` — 環境變數清單
+- `wiki/Features.md` / `wiki/Roles.md` / `wiki/Gantt.md` — 功能、角色、時程
+- `plan0.md` — 原始大規劃(歷史文獻)
+- `issues/` — 當前任務記憶與交棒工作區(見 `issues/README.md`)
+
+## 黃金規則 (Golden Rules)
+
+這 6 條是「被燒過」學來的硬規則,**違反任何一條都會造成明顯傷害**:
+
+1. **禁止直接 push 到 main**。所有變更必須開 PR draft,自我 review 後轉 ready for review 再 merge。
+2. **Branch 命名**:`{type}/{issue-number}_{slug}`,例如 `feat/36_agents-md`、`fix/29_navbar-desktop-squeeze`、`docs/36_agents-md`。`type` 使用 `feat` / `fix` / `docs` / `chore` / `test` / `refactor`。
+3. **修改前先讀 `issues/{number}-*/task_plan.md`**,執行中更新 `progress.md`,完成後打勾 checklist 並把 status 改成 `done`。沒有對應 issue 資料夾的修改 = 臨時探索,不算工作成果。
+4. **Turso 是單顆 production DB**。`.dev.vars` 連到同一顆 DB,**沒有 dev / prod 分離**。動 schema 前先 backup(`turso db shell ... ".dump" > backup.sql`),DROP 任何欄位或 table 前先在 PR 描述寫出影響範圍與回退步驟。<!-- TODO (Dar): 補「哪次 schema change 燒過」的 war story -->
+5. **LEFT JOIN 搭配 WHERE filter 時,SELECT 要從 alias 取欄位**(特別是 id)。從主表取會讓 LEFT 側 null row 拉進主表 id 造成假資料。<!-- TODO (Dar): 補「是哪個 PR / 哪條 query」的 war story -->
+6. **風格敏感任務不要 offload 給 subagent**(UI 文案、配色、微動畫、CSS 調整)。subagent 看不到完整設計脈絡,容易產出「看似合理但和既有風格不一致」的結果。Plan 類、debug 類、search 類、research 類可以 offload;style 類本尊做。<!-- TODO (Dar): 補「哪次 offload 出事」的 war story -->
+
+## 指令速查
+
+```bash
+bun run dev                                # 開發伺服器(Astro,port 4321)
+bun run build                              # 建置到 dist/
+bun run test:e2e                           # Playwright E2E
+bunx wrangler pages dev dist --port 8788   # 本機模擬 Cloudflare Pages Functions
+gh issue list --state open                 # 查當前 open issues
+gh pr list --state open                    # 查當前 open PRs
+```
+
+**禁用**:`npm`、`pnpm`、`yarn`、`npx`、`node <file>`、`ts-node`。一律用 `bun` / `bunx`。
+
+## 完成的定義 (Definition of Done)
+
+宣告「完成」前必須**全部綠燈**,少一項就不算完成:
+
+1. `bun run build` 綠(無 TypeScript 錯誤、無 Astro build 錯誤)
+2. `bun run test:e2e` 綠(若新增 regression 需補對應 spec)
+3. 對應 `issues/{number}-*/task_plan.md` 的 checklist 全部打勾
+4. PR draft **附 E2E 錄影或關鍵畫面截圖**
+5. `src/lib/changelog.ts` 新增一筆 `ChangelogEntry`(version 用當下 bump 的版號,date 用 UTC+8)
+6. PR 轉 ready for review,自我 review 過一次
+
+## 檔案式記憶流程 (Planning with Files)
+
+每個任務用 `issues/{number}-{slug}/` 資料夾管理,內含 3 個 .md 檔:
+
+| 檔案 | 職責 | 讀 | 寫 |
+|------|------|----|----|
+| `task_plan.md` | 靜態計畫(背景 / 目標 / 驗收 / checklist) | 開工時讀全文 | 計畫有變動時改,checklist 進展時打勾 |
+| `findings.md` | 研究發現與決策記錄 | 遇到陌生程式碼時讀 | 學到 non-obvious 技術事實時寫 |
+| `progress.md` | 動態日誌與交棒筆記 | 每次 session 開頭讀交棒筆記 | 每次 session 結束時寫進度 + 交棒筆記 |
+
+**為什麼分 3 檔而不是 1 檔**:讓新接手的 AI 能快速定位 —— 要看「該做什麼」讀 `task_plan`,要看「學過什麼」讀 `findings`,要看「現在進展」讀 `progress`。混在一起會讓交棒時要全文掃一次。
+
+參考設計:[planning-with-files](https://github.com/othmanadi/planning-with-files)(Manus 模式:檔案系統當 AI 的長期記憶)。詳細用法見 `issues/README.md`。
+
+## 交棒守則 (Handoff Protocol)
+
+當你是新接手的 AI(換 session 或換工具):
+
+1. **先看全域狀態**:`git status && git log --oneline -10`
+2. **找到當前 issue**:`ls issues/` 或從 git branch 名推斷(branch 名開頭是 issue number)
+3. **讀 `progress.md` 的「交棒筆記」區**(最高密度的上下文)
+4. **讀 `findings.md` 的「決策記錄」區**(了解為什麼選 A 不選 B,避免重新辯論)
+5. **讀 `task_plan.md` 的 checklist**(看剩下哪些 `- [ ]` 沒打勾)
+6. **有疑問**:寫在 `findings.md` 的「問題 / 假設」區,不要直接動 code
+
+## 禁止事項
+
+- **絕對不 commit**:`.env`、`.dev.vars`、`隊員表單*.csv`、任何內含 API key / Google service account / Turso auth token 的檔案
+- **不要改 `.cursor/rules/*.mdc`**:Cursor 專用 frontmatter 格式,搬走或改格式會讓 Cursor 讀不到
+- **不要 Edit `src/lib/version.ts` 的版本號欄位**:push 到 main 會自動 bump,手動改會被覆蓋
+- **不要預裝 Context7 以外的 MCP server**:使用者有自己的 MCP 偏好
+- **不要把 `.omc/` 內部結構寫進 AGENTS.md / CLAUDE.md**:那是 Claude Code plugin 私有記憶
+- **不要建立 `.ai/` / `.memory/` / `.context/` 新目錄**:所有共享狀態都放 `issues/`
+- **不要預先 refactor**:Bug fix 只改 bug、feature 只做 feature,不順便「清理」周邊程式碼
+- **不要 `--no-verify` 跳 hook、不要 `--force-push` 到 main**
+
+## Superpowers Skills (Claude Code 限定)
+
+本段只給 Claude Code 讀。其他 AI(Codex / Cursor / Goose / Roo / ...)可以跳過本節。
+
+Claude Code 已啟用 `superpowers@claude-plugins-official`。建議在以下情境主動 invoke:
+
+- 有 spec 要實作 → `superpowers:writing-plans`
+- 拿既有 plan 繼續執行 → `superpowers:executing-plans`
+- 宣告完成前 → `superpowers:verification-before-completion`
+- 修 bug → `superpowers:systematic-debugging`
+- 收到 PR review → `superpowers:receiving-code-review`
+
+其他 Claude 專屬設定見 `CLAUDE.md`。
+
+## 相關文件
+
+- `issues/README.md` — issues 資料夾完整使用規則
+- `issues/_template/` — 新 issue 起始樣板
+- `CLAUDE.md` — Claude Code 專屬補充
+- `wiki/` — 架構文件

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,119 +1,44 @@
----
-description: Use Bun instead of Node.js, npm, pnpm, or vite.
-globs: "*.ts, *.tsx, *.html, *.css, *.js, *.jsx, package.json"
-alwaysApply: false
----
+# CLAUDE.md — Claude Code 專屬補充
 
-Default to using Bun instead of Node.js.
+> 本專案**共用規則請先讀 `AGENTS.md`**(跨 AI 共讀主檔)。本檔只記錄 Claude Code 專屬設定。
 
-- Use `bun <file>` instead of `node <file>` or `ts-node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun build <file.html|file.ts|file.css>` instead of `webpack` or `esbuild`
-- Use `bun install` instead of `npm install` or `yarn install` or `pnpm install`
-- Use `bun run <script>` instead of `npm run <script>` or `yarn run <script>` or `pnpm run <script>`
-- Use `bunx <package> <command>` instead of `npx <package> <command>`
-- Bun automatically loads .env, so don't use dotenv.
+## Superpowers
 
-## APIs
+已啟用 `superpowers@claude-plugins-official`(見 `.claude/settings.local.json`)。
 
-- `Bun.serve()` supports WebSockets, HTTPS, and routes. Don't use `express`.
-- `bun:sqlite` for SQLite. Don't use `better-sqlite3`.
-- `Bun.redis` for Redis. Don't use `ioredis`.
-- `Bun.sql` for Postgres. Don't use `pg` or `postgres.js`.
-- `WebSocket` is built-in. Don't use `ws`.
-- Prefer `Bun.file` over `node:fs`'s readFile/writeFile
-- Bun.$`ls` instead of execa.
+建議在以下情境主動 invoke:
 
-## Testing
+- 有 spec 要實作 → `superpowers:writing-plans`
+- 拿既有 plan 繼續執行 → `superpowers:executing-plans`
+- 宣告完成前 → `superpowers:verification-before-completion`
+- 修 bug → `superpowers:systematic-debugging`
+- 收到 PR review → `superpowers:receiving-code-review`
 
-Use `bun test` to run tests.
+## Subagent 路由
 
-```ts#index.test.ts
-import { test, expect } from "bun:test";
+- **可以 offload**:plan 類、search / explore 類、debug 類、research 類
+- **不要 offload**:UI 文案、配色、微動畫、CSS 調整(風格敏感任務,subagent 看不到完整設計脈絡)
 
-test("hello world", () => {
-  expect(1).toBe(1);
-});
-```
+詳細理由見 `AGENTS.md` 黃金規則第 6 條。
 
-## Frontend
+## Hooks
 
-Use HTML imports with `Bun.serve()`. Don't use `vite`. HTML imports fully support React, CSS, Tailwind.
+目前未設定專案層級 hooks。
 
-Server:
+若日後需要加,放在 `.claude/settings.json`(**不是** `settings.local.json`),
+這樣其他使用 Claude Code 的協作者也能共享。
 
-```ts#index.ts
-import index from "./index.html"
+## Changelog 維護
 
-Bun.serve({
-  routes: {
-    "/": index,
-    "/api/users/:id": {
-      GET: (req) => {
-        return new Response(JSON.stringify({ id: req.params.id }));
-      },
-    },
-  },
-  // optional websocket support
-  websocket: {
-    open: (ws) => {
-      ws.send("Hello, world!");
-    },
-    message: (ws, message) => {
-      ws.send(message);
-    },
-    close: (ws) => {
-      // handle close
-    }
-  },
-  development: {
-    hmr: true,
-    console: true,
-  }
-})
-```
+每次功能或修復變更,應同步更新 **`src/lib/changelog.ts`** 的 `CHANGELOG`:
 
-HTML files can import .tsx, .jsx or .js files directly and Bun's bundler will transpile & bundle automatically. `<link>` tags can point to stylesheets and Bun's CSS bundler will bundle.
-
-```html#index.html
-<html>
-  <body>
-    <h1>Hello, world!</h1>
-    <script type="module" src="./frontend.tsx"></script>
-  </body>
-</html>
-```
-
-With the following `frontend.tsx`:
-
-```tsx#frontend.tsx
-import React from "react";
-import { createRoot } from "react-dom/client";
-
-// import .css files directly and it works
-import './index.css';
-
-const root = createRoot(document.body);
-
-export default function Frontend() {
-  return <h1>Hello, world!</h1>;
-}
-
-root.render(<Frontend />);
-```
-
-Then, run index.ts
-
-```sh
-bun --hot ./index.ts
-```
-
-For more information, read the Bun API docs in `node_modules/bun-types/docs/**.mdx`.
-
-## Changelog
-
-每次功能或修復變更，**應同步更新 `src/lib/version.ts`** 的 `CHANGELOG`：
-- 新增一筆 `ChangelogEntry`（version 改為新版本，date 為當下時間）
+- 新增一筆 `ChangelogEntry`(version 用當下 bump 的版號,date 用 UTC+8)
 - 確保 `CHANGELOG[0]` 是最新版本
-- push 到 main 會自動部署 + 自動更新版本號，但 changelog 內容需手動維護
-- 線上 Changelog 頁面：https://cyclone.tw/changelog/（由 `src/lib/version.ts` 的 `CHANGELOG` 陣列生成）
+- push 到 main 會自動部署 + 自動 bump 版本號,但 **changelog 內容需手動維護**
+- 線上 Changelog 頁面:https://cyclone.tw/changelog/(由 `src/lib/changelog.ts` 的 `CHANGELOG` 陣列生成)
+
+> **注意**:不是 `src/lib/version.ts`。那個檔案只存版本號字串,不要手動改它的版本號欄位(自動部署會覆蓋)。PR #11 review 曾因此誤報 missing changelog update。
+
+## 其他規則
+
+見 `AGENTS.md`。

--- a/issues/36-file-based-memory/findings.md
+++ b/issues/36-file-based-memory/findings.md
@@ -1,0 +1,97 @@
+---
+issue: 36
+updated: 2026-04-12
+---
+
+# 多 AI 協作的檔案式記憶與規劃架構 — Findings
+
+## 研究發現
+
+### 1. `CLAUDE.md:115` 指向錯誤的檔案
+
+- `CLAUDE.md:115` 寫「同步更新 `src/lib/version.ts` 的 CHANGELOG」
+- 但實際上 **`src/lib/changelog.ts` 才是 changelog entry 的正確位置**,`src/lib/version.ts` 只存版本號字串
+- 證據:`worklog-20260411-1437.md` 顯示 Issue #23 的變更清單明確列了 `src/lib/changelog.ts`(「新增 v20260411.4 changelog entry」) 和 `src/lib/version.ts`(「版本號更新」)是分開的兩個檔案
+- 後果:`pr-11.md` 的 PR review 因此誤報 "missing changelog update"(score 75,borderline)
+- 本 issue 順便修正這個錯誤
+
+### 2. `CLAUDE.md:17-111` 是 Bun templates 預設塞的,對本專案不適用
+
+- 內容是 `Bun.serve()` + `bun:sqlite` + HTML imports + `Bun.redis` + `Bun.sql` 範例
+- cyclone-26 是 **Astro SSG + Cloudflare Pages Functions**,不使用這些 API
+- 留著會誤導 AI(例如「嘗試用 `bun:sqlite` 連資料庫」而不是走 Turso libSQL client)
+- 指令層級的 Bun 規則(`bun` vs `npm`)由 `.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc` 負責,不需要重複在 CLAUDE.md
+
+### 3. `AGENTS.md` 是 2025 下半年業界標準
+
+- Codex、Cursor、Aider、Continue、Goose、Zed、Windsurf 都會自動 inject `AGENTS.md` 到 AI context
+- 比寫 20 份 `.cursorrules` / `.windsurfrules` / `.goosehints` 高效得多
+- cyclone-26 根目錄現有 20+ 個 AI 工具隱藏資料夾,正是最需要 `AGENTS.md` 的場景
+
+### 4. planning-with-files 基準成績
+
+- Anthropic 評測:檔案式記憶把 pass rate 從 **6.7% 推到 96.7%**
+- 核心機制:把 AI 的 context window 當 RAM、檔案系統當永久磁盤
+- 關鍵:`progress.md` 的「交棒筆記」區讓新接手的 AI 不必重讀全部歷史
+
+### 5. `.omc/` 不應該被暴露到 AGENTS.md
+
+- `.omc/` 是 Claude Code 的 oh-my-claudecode plugin 私有記憶,格式是 JSON(`project-memory.json` 597 行、`state/mission-state.json`、`checkpoints/` 等)
+- 暴露給其他 AI 會讓它們困惑(「這個 project-memory.json 我該讀嗎?格式我不認識」)
+- 保持 `.omc/` 僅由 Claude Code 使用,不寫進 AGENTS.md
+
+### 6. `pr-11.md` 的 review agent 使用統計
+
+- `pr-11.md` 顯示這個專案有使用 oh-my-claudecode 的 PR review 流程
+- 使用了 3 個 Haiku + 5 個 Sonnet + 6 個 Haiku + 1 個 Haiku = 15 個 agent
+- 代表 PR review 在這個專案是「系統化的」而非「人眼掃」—— `receiving-code-review` skill 特別重要
+
+## 決策記錄
+
+### 決策 1:資料夾命名 `issues/` vs `.planning/`
+- **選 `issues/`**(非隱藏目錄)
+- **理由**:AI tool 看得到、和 GitHub Issues 命名一致、延續使用者既有的 `issue-17.md` / `pr-11.md` 根目錄習慣
+- **放棄 `.planning/`**:隱藏目錄違背「希望 AI 看到」的目標,Finder 和部分 AI tool 預設隱藏
+
+### 決策 2:每 issue 用 3 檔還是 1 檔
+- **選 3 檔**(`task_plan.md` + `findings.md` + `progress.md`)
+- **理由**:使用者在 plan mode 明確選擇 planning-with-files 原版結構。3 檔讓新接手的 AI 能快速定位(該做什麼 / 學過什麼 / 現在進展),混在 1 檔需要全文掃
+- **放棄 1 檔**:對日常小 issue 精簡度更高,但犧牲了「快速定位」能力
+
+### 決策 3:GitHub Issues 同步策略
+- **選純本地,frontmatter 放 `github_issue` 連結欄位**
+- **理由**:自動雙向同步需要 GitHub App + rate limit 處理 + conflict resolve,成本極高
+- **放棄自動同步**:不符合「不要 over-engineering」的使用者偏好
+
+### 決策 4:CLAUDE.md 保留還是刪除
+- **選保留,瘦身到 ~60 行**
+- **理由**:`AGENTS.md` 需對所有 AI 中立,不適合講 Claude 專屬的 Superpowers skill invocation。把 Claude 特定的路由放 CLAUDE.md 更乾淨
+- **放棄完全刪除**:會丟失 Claude Code 專屬的最佳設定路由
+
+### 決策 5:Superpowers skills 選幾個
+- **選 5 個**:`writing-plans` / `executing-plans` / `verification-before-completion` / `systematic-debugging` / `receiving-code-review`
+- **理由**:每個都直接對應使用者既有的工作規則(plan 寫作、執行打勾、E2E 驗證、debug 方法、PR review 應對)
+- **放棄的候選**:`test-driven-development`(Astro+Playwright 完整 TDD 太重)、`using-git-worktrees`(已會用,寫進去沒加值)、`subagent-driven-development`(和「不 offload 風格任務」矛盾)、`brainstorming`(有 `/deep-interview` 和 `/omc-plan` 替代)
+
+### 決策 6:不做自訂 skill,用 `issues/_template/` 取代
+- **選 `issues/_template/` 作為輕量「skill」**
+- **理由**:使用者明確反對 over-engineering,一個樣板資料夾解決「新 issue 怎麼開」的問題,不需要打包成 skill
+- **放棄自訂 skill**:等未來多個專案都需要這個模式,再抽成 `~/.claude/skills/cyclone-issue-flow/`
+
+### 決策 7:搬家工作放在另一個 commit
+- **選分 2 個 commit**:commit 1 新架構、commit 2 搬家
+- **理由**:搬家是 mechanical,和新增規則混在一起會讓 PR review 難讀
+- **也可以**:搬家放另一個 PR(另一個 issue)—— 若使用者偏好更小顆 PR
+
+## 相關檔案路徑
+
+- `CLAUDE.md:1-119` — 待重構(刪 L1-14 + L17-111,修 L115)
+- `src/lib/changelog.ts` — changelog entry 的**正確**位置
+- `src/lib/version.ts` — 只存版本號字串(不要手動改)
+- `.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc` — Bun 指令規則(不要動)
+- `.omc/project-memory.json:1-597` — Claude Code 私有記憶(不要暴露)
+- `.claude/settings.local.json` — superpowers 外掛啟用處
+- `wiki/Architecture.md` / `wiki/Database.md` / `wiki/API.md` / `wiki/Environment.md` — AGENTS.md 只 reference 不 copy
+- `issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md` — 根目錄既有的散落規劃文件(待搬家,階段 4)
+- `plan0.md` / `WORKLOG.md` — 歷史文獻,保留不搬
+- `.github/workflows/cloudflare-pages-deploy.yml` / `.github/workflows/tauri-release.yml` — 自動部署設定(不動)

--- a/issues/36-file-based-memory/findings.md
+++ b/issues/36-file-based-memory/findings.md
@@ -78,10 +78,11 @@ updated: 2026-04-12
 - **理由**:使用者明確反對 over-engineering,一個樣板資料夾解決「新 issue 怎麼開」的問題,不需要打包成 skill
 - **放棄自訂 skill**:等未來多個專案都需要這個模式,再抽成 `~/.claude/skills/cyclone-issue-flow/`
 
-### 決策 7:搬家工作放在另一個 commit
-- **選分 2 個 commit**:commit 1 新架構、commit 2 搬家
+### 決策 7:搬家工作獨立成另一個 commit
+- **選把搬家獨立出建立新架構的 commit**(不混在同一個 commit)
 - **理由**:搬家是 mechanical,和新增規則混在一起會讓 PR review 難讀
 - **也可以**:搬家放另一個 PR(另一個 issue)—— 若使用者偏好更小顆 PR
+- **注意**:本決策只規範「搬家不混新架構」,不對 PR 總共多少個 commit 做任何保證(self-correction 系列產生了多個 commit,見 `git log`)
 
 ## 相關檔案路徑
 

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -37,21 +37,46 @@ updated: 2026-04-12
 - `git push -u origin docs/36_agents-md`
 - **Draft PR #37 建立**:https://github.com/cyclone-tw/cyclone-workflow/pull/37
 
-### 2026-04-12 後段 — Claude Opus 4.6 (self-correction)
+### 2026-04-12 後段 — Claude Opus 4.6 (self-correction 1)
 
 - Codex stop-time review 指出:示範 issue 的交棒狀態是過期資訊(task_plan.md 的 pr 還是 null、checkbox 還沒打勾、progress.md 還寫「尚未取得 PR 編號」)
 - Codex 說得對 —— 本 issue 是檔案式記憶架構的第一次 dogfooding,示範 issue 的 progress 本身就是架構是否成立的證據,狀態不即時就失去意義
-- 更新 `task_plan.md`(status: in-progress → review、phase: implementation → verification、pr: null → 37、所有階段 1–3 的 checkbox 打勾)
+- 更新 `task_plan.md`(phase: implementation → verification、pr: null → 37、階段 1–3 的 checkbox 全打勾);順手也把 status 改成 `review`(這步**錯了**,下一輪 self-correction 修正)
 - 更新本檔補「PR #37 建立成功」與交棒筆記
-- 第二個 commit:`docs(#36): update demo issue state to reflect PR #37 creation`
+- commit `1c05655 docs(#36): update demo issue state to reflect PR #37 creation`
+
+### 2026-04-12 後段 — Claude Opus 4.6 (self-correction 2)
+
+- Codex stop-time review 再次指出兩個問題:
+  1. status 改 `review` 太早。按 `issues/README.md` 定義,review = 「實作完成,等 PR review」,但本 PR 還是 draft,而且 AGENTS.md DoD 還有 e2e / 錄影 / changelog entry / ready-for-review / self-review 五項沒達成
+  2. 交棒筆記「下一步應該」寫成「選一個方向」的 4 選 1 選單,但實際上那 4 項(搬家 / 補 TODO / 跨 AI 驗證 / merge)不是 alternatives 而是 sequential prerequisites —— 新接手 AI 看選單會誤以為可跳過 e2e 直接 merge
+- 回改 `task_plan.md` status:`review` → `in-progress`
+- 改寫交棒筆記「下一步」為 8 步 sequential prerequisites,並補上「距離可 merge 還差什麼」DoD 對照表
+- commit `cd0e200 docs(#36): fix handoff guidance — sequential prerequisites, not a menu`
+
+### 2026-04-12 後段 — Claude Opus 4.6 (self-correction 3)
+
+- Codex stop-time review 第三次指出:交棒筆記寫「Draft PR #37 開立(2 個 commit)」,但該文字是在 `cd0e200` 寫入的,push 後 PR 已經變 3 個 commit,count 馬上過期
+- 根本問題:追「當前 PR 有 N 個 commit」本質上會永遠落後 —— 每次追 count 的 commit 本身又讓 count 變舊,chicken-and-egg
+- 解法:**progress.md 永遠不追 count,改列明確 SHA 清單**(新的 commit 不影響已知 SHA,且 `git log` 是真實來源)
+- 順手也補上 `cd0e200` 漏寫進會話日誌、session log 裡 `1c05655` 的描述不準確(寫錯「status review」的後續修正脈絡)
+- commit 由本 session 加入(SHA 會是本 commit 的 hash,見 `git log -1`)
 
 ## 交棒筆記
 
 > 最重要的一區。新接手的 AI 請先讀這裡。
 
-**目前狀態**:Draft PR #37 開立(2 個 commit),處於 verification 階段。**尚未達到 AGENTS.md Definition of Done**,因此 status 還是 `in-progress` 而不是 `review`。
+**目前狀態**:Draft PR #37 開立,處於 verification 階段。**尚未達到 AGENTS.md Definition of Done**,因此 status 還是 `in-progress` 而不是 `review`。
 
-階段 1–3(建立新架構 / build 驗證 / draft PR)完成;階段 4–6 未做。
+階段 1–3(建立新架構 / build 驗證 / draft PR)完成;階段 4–6 未做。已歷經 3 輪 Codex self-correction(見上方會話日誌),交棒文件本身就是架構能否運作的證據。
+
+**當前 PR commit 歷史**(`git log --oneline docs/36_agents-md`,舊到新,最後一筆隨本 session 更新):
+- `99dda4e` — initial architecture(AGENTS.md + issues/)
+- `1c05655` — demo issue self-update(含一處 status 誤判,下一筆修正)
+- `cd0e200` — handoff guidance 改為 sequential prerequisites
+- **本 session 新增的 commit** — 去除 commit count 追蹤,改用 SHA 清單
+
+新接手時請 `git log --oneline origin/docs/36_agents-md` 看最新狀態,不要相信檔內的 count 數字(本檔刻意不追 count 以免 self-staling)。
 
 **距離可 merge 還差什麼**(按 AGENTS.md Definition of Done 對照):
 - [x] `bun run build` 綠
@@ -63,14 +88,14 @@ updated: 2026-04-12
 
 **下一步(必須按順序,不是選單)**:
 
-1. **(可選)階段 4 搬家** —— 若 Dar 決定把 `issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md` 搬進 `issues/`,在本 PR 加第 3 個 commit(或開另一個 issue 延後);與階段 5–8 獨立
-2. **Dar 親手補 TODO** —— `AGENTS.md` L34-38 的 3 條 war story、`task_plan.md` 驗收條件的成功標準、`issues/README.md` 的新 issue 判斷準則。這是 merge 前的 content gate,Dar 的 domain knowledge
+1. **(可選)階段 4 搬家** —— 若 Dar 決定把 `issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md` 搬進 `issues/`,在本 PR 新增 commit(或開另一個 issue 延後);與步驟 2–8 獨立,可任何時間做
+2. **Dar 親手補 TODO** —— `AGENTS.md` 黃金規則第 4-6 條的 war story、`task_plan.md` 驗收條件的成功標準、`issues/README.md` 的新 issue 判斷準則。這是 merge 前的 content gate,Dar 的 domain knowledge
 3. **階段 5 跨 AI 冷啟動驗證** —— 開 Codex CLI / Cursor 問「branch 命名規則」,至少 2 個工具答出 `{type}/{issue-number}_{slug}` 才算架構驗證通過。**是本 issue 的核心驗收**
 4. **跑 `bun run test:e2e`** 確認沒被任何 docs 變更意外 break(理論上不會)
 5. **錄 / 截圖給 PR**:E2E 錄影或關鍵畫面(因為是 docs PR,可用「Codex cold start 答對 branch 命名規則」的 terminal 截圖充數)
-6. **寫 `src/lib/changelog.ts` entry** —— `ChangelogEntry` 新增一筆(version 用當下 bump 版號、date UTC+8),內容「導入 AGENTS.md 與 issues/ 檔案式記憶架構,支援多 AI 協作交棒」。第 4 個 commit
+6. **寫 `src/lib/changelog.ts` entry** —— `ChangelogEntry` 新增一筆(version 用當下 bump 版號、date UTC+8),內容「導入 AGENTS.md 與 issues/ 檔案式記憶架構,支援多 AI 協作交棒」;新增一個 commit
 7. **PR 轉 ready for review** —— 只有到這一步 `task_plan.md` frontmatter status 才能從 `in-progress` 改成 `review`
-8. **Merge** —— 合併後 status → `done`、phase → `done`,填 `pr` 連結已經在,補 `merged_at` 日期註解
+8. **Merge** —— 合併後 status → `done`、phase → `done`,`pr` 連結已經填好,補 `merged_at` 日期註解
 
 **卡住的事**:無(目前沒有 blocker,只是工作沒全做完)
 
@@ -78,8 +103,8 @@ updated: 2026-04-12
 - **GitHub issue**:#36(https://github.com/cyclone-tw/cyclone-workflow/issues/36)
 - **branch**:`docs/36_agents-md`(在 origin 上)
 - **PR**:#37(https://github.com/cyclone-tw/cyclone-workflow/pull/37,draft)
-- **commit**:`99dda4e docs(#36): add AGENTS.md + issues/ file-based memory structure`(9 files, +678 -118)
-- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在 commit 99dda4e**,可加到本 PR 的新 commit 或另開 issue
+- **commit 歷史**:見上方「當前 PR commit 歷史」區(以 SHA 為準,不以 count 為準)
+- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在 `99dda4e`**,可加到本 PR 的新 commit 或另開 issue
 - **TODO 留給 Dar 親自填**:
   - `AGENTS.md` 黃金規則第 4-6 條的 war story(Turso / LEFT JOIN / offload 各是哪次事件)—— 檔內已用 `<!-- TODO (Dar) -->` 標記
   - `task_plan.md` 驗收條件的「成功標準」定義(跨 AI 冷啟動算通過的門檻)

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -1,0 +1,79 @@
+---
+issue: 36
+updated: 2026-04-12
+---
+
+# 多 AI 協作的檔案式記憶與規劃架構 — Progress
+
+## 會話日誌
+
+### 2026-04-12 — Dar + Claude Opus 4.6 (plan mode)
+
+- Dar 提出需求:參考 planning-with-files,建立 issue folder + 調整 `CLAUDE.md` / `AGENTS.md`,讓多 AI 更好交棒,並建立 issue + PR draft
+- 在 plan mode 做了完整研究:
+  - Explore agent 研究 [planning-with-files](https://github.com/othmanadi/planning-with-files) 倉庫(3 檔模式、YAML frontmatter、hooks、Manus 理念、Anthropic 評測 96.7%)
+  - Explore agent 盤點現有 AI 協作設定(CLAUDE.md 119 行、.omc、.claude、20+ AI 工具目錄、wiki/ 9 檔)
+  - Plan agent 設計 `AGENTS.md` 結構、`issues/` 資料夾格式、`CLAUDE.md` 瘦身方案
+- Dar 在 4 個關鍵決策點選擇:
+  1. 資料夾命名 `issues/{n}-{slug}/`(非隱藏)
+  2. 每 issue 用 **3 檔**(task_plan / findings / progress,planning-with-files 原版)
+  3. GitHub sync:純本地,frontmatter 放 `github_issue` 欄位
+  4. CLAUDE.md:瘦身到 ~60 行,只留 Claude 專屬
+- 計畫檔寫入 `~/.claude/plans/lucky-imagining-pixel.md`,`ExitPlanMode` 通過
+
+### 2026-04-12 — Claude Opus 4.6 (implementation)
+
+- 建立 GitHub issue **#36**(https://github.com/cyclone-tw/cyclone-workflow/issues/36)
+- 從 `fix/29_navbar-desktop-squeeze` 切回 `main`(pull 最新),建立 branch **`docs/36_agents-md`**
+- 寫入新檔:
+  - `AGENTS.md`(~150 行,正體中文,跨 AI 共讀主檔)
+  - `CLAUDE.md`(重構,瘦身到 ~50 行,修正 changelog.ts 指向錯誤)
+  - `issues/README.md`(資料夾使用規則)
+  - `issues/_template/task_plan.md`(靜態計畫樣板)
+  - `issues/_template/findings.md`(研究發現樣板)
+  - `issues/_template/progress.md`(動態日誌樣板)
+  - `issues/36-file-based-memory/task_plan.md`(本示範 issue 計畫)
+  - `issues/36-file-based-memory/findings.md`(本示範 issue 研究結果)
+  - `issues/36-file-based-memory/progress.md`(本檔)
+
+## 交棒筆記
+
+> 最重要的一區。新接手的 AI 請先讀這裡。
+
+**目前狀態**:階段 1 檔案建立完成。等待跑 `bun run build` 驗證 → commit → push → draft PR。
+
+**下一步應該**:
+1. `bun run build` 確認綠燈(純 docs 變更,理論上不會 fail,但走完流程)
+2. `git add` 全部新檔
+3. `git commit -m "docs(#36): add AGENTS.md + issues/ file-based memory structure"`
+4. `git push -u origin docs/36_agents-md`
+5. `gh pr create --draft --title "..." --body "..."`
+6. 回報 PR 連結給 Dar
+
+**卡住的事**:無
+
+**重要上下文**:
+- **GitHub issue**:#36(已建立,url:https://github.com/cyclone-tw/cyclone-workflow/issues/36)
+- **branch**:`docs/36_agents-md`(從 main 切出)
+- **PR 編號**:尚未取得(push 後執行 `gh pr create --draft`)
+- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在本 commit**,放階段 4 的另一個 commit 做;或可延後到另一個 issue
+- **TODO 留給 Dar 親自填**:
+  - `AGENTS.md` 黃金規則第 4-6 條的 war story 細節(Turso 哪次事件、LEFT JOIN 是哪個 PR、offload 哪次出事)
+  - `task_plan.md` 驗收條件的「成功標準」定義(跨 AI 冷啟動能答對什麼問題算通過)
+  - `issues/README.md`「什麼時候該開新 issue」的使用者偏好
+- **設計決定全紀錄**:見 `findings.md` 的「決策記錄」區
+- **原始計畫檔**:`~/.claude/plans/lucky-imagining-pixel.md`
+
+## 驗證結果
+
+### bun run build
+- [ ] 待驗證
+
+### bun run test:e2e
+- [ ] 選做,本變更純 docs 不應影響
+
+### 手動檢查
+- [ ] `grep AGENTS.md CLAUDE.md` 應 match(CLAUDE.md reference AGENTS.md)
+- [ ] `grep changelog.ts CLAUDE.md` 應 match(changelog.ts 指向修正)
+- [ ] `head -1 CLAUDE.md` 應是「# CLAUDE.md — Claude Code 專屬補充」
+- [ ] `wc -l CLAUDE.md` 應 < 70(瘦身驗證)

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -68,7 +68,7 @@ updated: 2026-04-12
 - 真正的根本解法:**progress.md 完全不追「當前 PR 的 commit 歷史」**。那是 `git log` 與 `gh pr view` 的工作,不是靜態檔的工作。檔內只記「stable facts」(issue 編號、branch 名、PR 編號、設計決定、session 已發生的事),動態 state 全部 deferred to git/GitHub
 - 移除交棒筆記的「當前 PR commit 歷史」區塊,改為 1 行指向 `git log`
 - 把「progress.md 穩定性原則」寫進 `issues/README.md`,避免未來的 issue 重蹈覆轍
-- 這條規則從 issue #36 的 4 輪 self-correction 學到,值得成為永久規則
+- 這條規則從 issue #36 的 Codex self-correction 系列學到,值得成為永久規則(詳細歷程見 `git log origin/docs/36_agents-md`)
 - commit SHA 見 `git log origin/docs/36_agents-md`(本筆 session 結束時由下一筆 commit 或 `git log` 補)
 
 ## 交棒筆記

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -106,13 +106,13 @@ updated: 2026-04-12
 - **GitHub issue**:#36(https://github.com/cyclone-tw/cyclone-workflow/issues/36)
 - **branch**:`docs/36_agents-md`(在 origin 上)
 - **PR**:#37(https://github.com/cyclone-tw/cyclone-workflow/pull/37,draft)
-- **commit 歷史**:見上方「當前 PR commit 歷史」區(以 SHA 為準,不以 count 為準)
-- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在 `99dda4e`**,可加到本 PR 的新 commit 或另開 issue
+- **commit 狀態**:動態資訊,請跑 `git log --oneline origin/docs/36_agents-md` 或 `gh pr view 37 --json commits` —— 見 `issues/README.md`「progress.md 穩定性原則」
+- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**尚未**搬入 `issues/`,可加到本 PR 的新 commit 或另開 issue
 - **TODO 留給 Dar 親自填**:
   - `AGENTS.md` 黃金規則第 4-6 條的 war story(Turso / LEFT JOIN / offload 各是哪次事件)—— 檔內已用 `<!-- TODO (Dar) -->` 標記
   - `task_plan.md` 驗收條件的「成功標準」定義(跨 AI 冷啟動算通過的門檻)
   - `issues/README.md`「什麼時候該開新 issue」的使用者偏好
-- **設計決定全紀錄**:見 `findings.md` 的「決策記錄」區(7 個決定)
+- **設計決定全紀錄**:見 `findings.md` 的「決策記錄」區
 - **原始計畫檔**:`~/.claude/plans/lucky-imagining-pixel.md`
 
 ## 驗證結果

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -56,11 +56,20 @@ updated: 2026-04-12
 
 ### 2026-04-12 後段 — Claude Opus 4.6 (self-correction 3)
 
-- Codex stop-time review 第三次指出:交棒筆記寫「Draft PR #37 開立(2 個 commit)」,但該文字是在 `cd0e200` 寫入的,push 後 PR 已經變 3 個 commit,count 馬上過期
+- Codex stop-time review 指出:交棒筆記寫「Draft PR #37 開立(2 個 commit)」,但該文字是在 `cd0e200` 寫入的,push 後 PR 已經變 3 個 commit,count 馬上過期
 - 根本問題:追「當前 PR 有 N 個 commit」本質上會永遠落後 —— 每次追 count 的 commit 本身又讓 count 變舊,chicken-and-egg
-- 解法:**progress.md 永遠不追 count,改列明確 SHA 清單**(新的 commit 不影響已知 SHA,且 `git log` 是真實來源)
-- 順手也補上 `cd0e200` 漏寫進會話日誌、session log 裡 `1c05655` 的描述不準確(寫錯「status review」的後續修正脈絡)
-- commit 由本 session 加入(SHA 會是本 commit 的 hash,見 `git log -1`)
+- 嘗試解法:progress.md 不追 count,改列明確 SHA 清單,最後一筆用 placeholder「本 session 新增的 commit」
+- 順手也補上 `cd0e200` 漏寫進會話日誌
+- commit `11b7486 docs(#36): replace commit count tracking with SHA list to avoid self-staling`
+
+### 2026-04-12 後段 — Claude Opus 4.6 (self-correction 4)
+
+- Codex stop-time review 再次指出:SHA 清單同樣不是穩定狀態 —— 清單最後一筆 placeholder「本 session 新增的 commit」在該 commit 落地後就變成過期描述(實際 SHA 是 `11b7486`,但檔內仍是 placeholder)。這是**同一個 chicken-and-egg**,只是換了糖衣
+- 真正的根本解法:**progress.md 完全不追「當前 PR 的 commit 歷史」**。那是 `git log` 與 `gh pr view` 的工作,不是靜態檔的工作。檔內只記「stable facts」(issue 編號、branch 名、PR 編號、設計決定、session 已發生的事),動態 state 全部 deferred to git/GitHub
+- 移除交棒筆記的「當前 PR commit 歷史」區塊,改為 1 行指向 `git log`
+- 把「progress.md 穩定性原則」寫進 `issues/README.md`,避免未來的 issue 重蹈覆轍
+- 這條規則從 issue #36 的 4 輪 self-correction 學到,值得成為永久規則
+- commit SHA 見 `git log origin/docs/36_agents-md`(本筆 session 結束時由下一筆 commit 或 `git log` 補)
 
 ## 交棒筆記
 
@@ -68,15 +77,9 @@ updated: 2026-04-12
 
 **目前狀態**:Draft PR #37 開立,處於 verification 階段。**尚未達到 AGENTS.md Definition of Done**,因此 status 還是 `in-progress` 而不是 `review`。
 
-階段 1–3(建立新架構 / build 驗證 / draft PR)完成;階段 4–6 未做。已歷經 3 輪 Codex self-correction(見上方會話日誌),交棒文件本身就是架構能否運作的證據。
+階段 1–3(建立新架構 / build 驗證 / draft PR)完成;階段 4–6 未做。交棒文件本身就是架構能否運作的證據 —— 歷經多輪 Codex self-correction(見會話日誌),每輪都把一類 staleness pattern 逼出來修掉。
 
-**當前 PR commit 歷史**(`git log --oneline docs/36_agents-md`,舊到新,最後一筆隨本 session 更新):
-- `99dda4e` — initial architecture(AGENTS.md + issues/)
-- `1c05655` — demo issue self-update(含一處 status 誤判,下一筆修正)
-- `cd0e200` — handoff guidance 改為 sequential prerequisites
-- **本 session 新增的 commit** — 去除 commit count 追蹤,改用 SHA 清單
-
-新接手時請 `git log --oneline origin/docs/36_agents-md` 看最新狀態,不要相信檔內的 count 數字(本檔刻意不追 count 以免 self-staling)。
+**Commit 歷史 / PR 當前狀態**:`git log --oneline origin/docs/36_agents-md` 與 `gh pr view 37` —— **git / GitHub 是真實來源,本檔刻意不重複追蹤**(見 `issues/README.md` 的「progress.md 穩定性原則」)。
 
 **距離可 merge 還差什麼**(按 AGENTS.md Definition of Done 對照):
 - [x] `bun run build` 綠

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -26,54 +26,67 @@ updated: 2026-04-12
 - 建立 GitHub issue **#36**(https://github.com/cyclone-tw/cyclone-workflow/issues/36)
 - 從 `fix/29_navbar-desktop-squeeze` 切回 `main`(pull 最新),建立 branch **`docs/36_agents-md`**
 - 寫入新檔:
-  - `AGENTS.md`(~150 行,正體中文,跨 AI 共讀主檔)
-  - `CLAUDE.md`(重構,瘦身到 ~50 行,修正 changelog.ts 指向錯誤)
+  - `AGENTS.md`(117 行,正體中文,跨 AI 共讀主檔)
+  - `CLAUDE.md`(重構,119 → 44 行,修正 changelog.ts 指向錯誤)
   - `issues/README.md`(資料夾使用規則)
-  - `issues/_template/task_plan.md`(靜態計畫樣板)
-  - `issues/_template/findings.md`(研究發現樣板)
-  - `issues/_template/progress.md`(動態日誌樣板)
-  - `issues/36-file-based-memory/task_plan.md`(本示範 issue 計畫)
-  - `issues/36-file-based-memory/findings.md`(本示範 issue 研究結果)
-  - `issues/36-file-based-memory/progress.md`(本檔)
+  - `issues/_template/{task_plan,findings,progress}.md`(3 檔樣板)
+  - `issues/36-file-based-memory/{task_plan,findings,progress}.md`(本示範 issue)
+- `bun run build` 綠(18 頁 1.73s)
+- `grep` sanity check 全過(AGENTS.md 互引、changelog.ts 修正、CLAUDE.md 瘦身)
+- commit `99dda4e` `docs(#36): add AGENTS.md + issues/ file-based memory structure`
+- `git push -u origin docs/36_agents-md`
+- **Draft PR #37 建立**:https://github.com/cyclone-tw/cyclone-workflow/pull/37
+
+### 2026-04-12 後段 — Claude Opus 4.6 (self-correction)
+
+- Codex stop-time review 指出:示範 issue 的交棒狀態是過期資訊(task_plan.md 的 pr 還是 null、checkbox 還沒打勾、progress.md 還寫「尚未取得 PR 編號」)
+- Codex 說得對 —— 本 issue 是檔案式記憶架構的第一次 dogfooding,示範 issue 的 progress 本身就是架構是否成立的證據,狀態不即時就失去意義
+- 更新 `task_plan.md`(status: in-progress → review、phase: implementation → verification、pr: null → 37、所有階段 1–3 的 checkbox 打勾)
+- 更新本檔補「PR #37 建立成功」與交棒筆記
+- 第二個 commit:`docs(#36): update demo issue state to reflect PR #37 creation`
 
 ## 交棒筆記
 
 > 最重要的一區。新接手的 AI 請先讀這裡。
 
-**目前狀態**:階段 1 檔案建立完成。等待跑 `bun run build` 驗證 → commit → push → draft PR。
+**目前狀態**:Draft PR #37 已開立,等 Dar review 與 merge。階段 1–3 全部完成。
 
-**下一步應該**:
-1. `bun run build` 確認綠燈(純 docs 變更,理論上不會 fail,但走完流程)
-2. `git add` 全部新檔
-3. `git commit -m "docs(#36): add AGENTS.md + issues/ file-based memory structure"`
-4. `git push -u origin docs/36_agents-md`
-5. `gh pr create --draft --title "..." --body "..."`
-6. 回報 PR 連結給 Dar
+**下一步應該**(選一個方向,看 Dar 決定):
+1. **補 TODO**:Dar 親自填 `AGENTS.md` 的 war story、`task_plan.md` 的成功標準、`issues/README.md` 的新 issue 判斷準則
+2. **階段 4 搬家**(另一個 commit 在同一個 PR,或另一個 issue):
+   - `git mv issue-17.md issues/17-cyclone-requirements/task_plan.md`
+   - `git mv pr-11.md issues/11-markdown-rendering/findings.md`
+   - `git mv worklog-20260411-1437.md issues/23-gemini-ai-insights/progress.md`
+   - 每檔補 frontmatter
+3. **階段 5 跨 AI 冷啟動驗證**:Codex / Cursor 打開專案問「branch 命名規則」
+4. **階段 6 merge**:PR ready for review → `src/lib/changelog.ts` 新增 entry → merge
 
 **卡住的事**:無
 
 **重要上下文**:
-- **GitHub issue**:#36(已建立,url:https://github.com/cyclone-tw/cyclone-workflow/issues/36)
-- **branch**:`docs/36_agents-md`(從 main 切出)
-- **PR 編號**:尚未取得(push 後執行 `gh pr create --draft`)
-- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在本 commit**,放階段 4 的另一個 commit 做;或可延後到另一個 issue
+- **GitHub issue**:#36(https://github.com/cyclone-tw/cyclone-workflow/issues/36)
+- **branch**:`docs/36_agents-md`(在 origin 上)
+- **PR**:#37(https://github.com/cyclone-tw/cyclone-workflow/pull/37,draft)
+- **commit**:`99dda4e docs(#36): add AGENTS.md + issues/ file-based memory structure`(9 files, +678 -118)
+- **搬家工作**(`issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md`)**不在 commit 99dda4e**,可加到本 PR 的新 commit 或另開 issue
 - **TODO 留給 Dar 親自填**:
-  - `AGENTS.md` 黃金規則第 4-6 條的 war story 細節(Turso 哪次事件、LEFT JOIN 是哪個 PR、offload 哪次出事)
-  - `task_plan.md` 驗收條件的「成功標準」定義(跨 AI 冷啟動能答對什麼問題算通過)
+  - `AGENTS.md` 黃金規則第 4-6 條的 war story(Turso / LEFT JOIN / offload 各是哪次事件)—— 檔內已用 `<!-- TODO (Dar) -->` 標記
+  - `task_plan.md` 驗收條件的「成功標準」定義(跨 AI 冷啟動算通過的門檻)
   - `issues/README.md`「什麼時候該開新 issue」的使用者偏好
-- **設計決定全紀錄**:見 `findings.md` 的「決策記錄」區
+- **設計決定全紀錄**:見 `findings.md` 的「決策記錄」區(7 個決定)
 - **原始計畫檔**:`~/.claude/plans/lucky-imagining-pixel.md`
 
 ## 驗證結果
 
 ### bun run build
-- [ ] 待驗證
+- [x] **Pass**(18 頁全部 build 成功,1.73s,11:07:48 完成)
 
 ### bun run test:e2e
-- [ ] 選做,本變更純 docs 不應影響
+- [ ] 未跑(純 docs 變更,理論上不影響 Playwright specs。PR ready for review 前補跑一次即可)
 
 ### 手動檢查
-- [ ] `grep AGENTS.md CLAUDE.md` 應 match(CLAUDE.md reference AGENTS.md)
-- [ ] `grep changelog.ts CLAUDE.md` 應 match(changelog.ts 指向修正)
-- [ ] `head -1 CLAUDE.md` 應是「# CLAUDE.md — Claude Code 專屬補充」
-- [ ] `wc -l CLAUDE.md` 應 < 70(瘦身驗證)
+- [x] `grep AGENTS.md CLAUDE.md` — 3 處 match(L3 頂部指示、L22 subagent 規則、L44 末尾「其他規則」)
+- [x] `grep changelog.ts CLAUDE.md` — 2 處 match(L33 主文、L38 線上頁面生成器)
+- [x] `head -1 CLAUDE.md` = `# CLAUDE.md — Claude Code 專屬補充`
+- [x] `wc -l CLAUDE.md` = 44 行(< 60 目標)
+- [x] `wc -l AGENTS.md` = 117 行(< 200 目標)

--- a/issues/36-file-based-memory/progress.md
+++ b/issues/36-file-based-memory/progress.md
@@ -49,19 +49,30 @@ updated: 2026-04-12
 
 > 最重要的一區。新接手的 AI 請先讀這裡。
 
-**目前狀態**:Draft PR #37 已開立,等 Dar review 與 merge。階段 1–3 全部完成。
+**目前狀態**:Draft PR #37 開立(2 個 commit),處於 verification 階段。**尚未達到 AGENTS.md Definition of Done**,因此 status 還是 `in-progress` 而不是 `review`。
 
-**下一步應該**(選一個方向,看 Dar 決定):
-1. **補 TODO**:Dar 親自填 `AGENTS.md` 的 war story、`task_plan.md` 的成功標準、`issues/README.md` 的新 issue 判斷準則
-2. **階段 4 搬家**(另一個 commit 在同一個 PR,或另一個 issue):
-   - `git mv issue-17.md issues/17-cyclone-requirements/task_plan.md`
-   - `git mv pr-11.md issues/11-markdown-rendering/findings.md`
-   - `git mv worklog-20260411-1437.md issues/23-gemini-ai-insights/progress.md`
-   - 每檔補 frontmatter
-3. **階段 5 跨 AI 冷啟動驗證**:Codex / Cursor 打開專案問「branch 命名規則」
-4. **階段 6 merge**:PR ready for review → `src/lib/changelog.ts` 新增 entry → merge
+階段 1–3(建立新架構 / build 驗證 / draft PR)完成;階段 4–6 未做。
 
-**卡住的事**:無
+**距離可 merge 還差什麼**(按 AGENTS.md Definition of Done 對照):
+- [x] `bun run build` 綠
+- [ ] `bun run test:e2e` 綠 —— **未跑**
+- [ ] `task_plan.md` checklist 全打勾 —— 階段 4 / 5 / 6 還沒做
+- [ ] PR draft 附 E2E 錄影或截圖 —— **還沒附**
+- [ ] `src/lib/changelog.ts` 新增 entry —— **還沒新增**
+- [ ] PR 轉 ready for review + 自我 review —— 還是 draft
+
+**下一步(必須按順序,不是選單)**:
+
+1. **(可選)階段 4 搬家** —— 若 Dar 決定把 `issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md` 搬進 `issues/`,在本 PR 加第 3 個 commit(或開另一個 issue 延後);與階段 5–8 獨立
+2. **Dar 親手補 TODO** —— `AGENTS.md` L34-38 的 3 條 war story、`task_plan.md` 驗收條件的成功標準、`issues/README.md` 的新 issue 判斷準則。這是 merge 前的 content gate,Dar 的 domain knowledge
+3. **階段 5 跨 AI 冷啟動驗證** —— 開 Codex CLI / Cursor 問「branch 命名規則」,至少 2 個工具答出 `{type}/{issue-number}_{slug}` 才算架構驗證通過。**是本 issue 的核心驗收**
+4. **跑 `bun run test:e2e`** 確認沒被任何 docs 變更意外 break(理論上不會)
+5. **錄 / 截圖給 PR**:E2E 錄影或關鍵畫面(因為是 docs PR,可用「Codex cold start 答對 branch 命名規則」的 terminal 截圖充數)
+6. **寫 `src/lib/changelog.ts` entry** —— `ChangelogEntry` 新增一筆(version 用當下 bump 版號、date UTC+8),內容「導入 AGENTS.md 與 issues/ 檔案式記憶架構,支援多 AI 協作交棒」。第 4 個 commit
+7. **PR 轉 ready for review** —— 只有到這一步 `task_plan.md` frontmatter status 才能從 `in-progress` 改成 `review`
+8. **Merge** —— 合併後 status → `done`、phase → `done`,填 `pr` 連結已經在,補 `merged_at` 日期註解
+
+**卡住的事**:無(目前沒有 blocker,只是工作沒全做完)
 
 **重要上下文**:
 - **GitHub issue**:#36(https://github.com/cyclone-tw/cyclone-workflow/issues/36)

--- a/issues/36-file-based-memory/task_plan.md
+++ b/issues/36-file-based-memory/task_plan.md
@@ -1,15 +1,15 @@
 ---
 issue: 36
 title: 多 AI 協作的檔案式記憶與規劃架構 (planning-with-files)
-status: in-progress
-phase: implementation
+status: review
+phase: verification
 priority: P1
 owner: dar
 created: 2026-04-12
 updated: 2026-04-12
 github_issue: 36
 branch: docs/36_agents-md
-pr: null
+pr: 37
 related_files:
   - AGENTS.md
   - CLAUDE.md
@@ -42,13 +42,13 @@ cyclone-26 同時使用 20+ 個 AI 工具協作(`.claude/` `.cursor/` `.continue
 
 - [x] GitHub issue #36 建立
 - [x] Branch `docs/36_agents-md` 建立(從 main)
-- [ ] `AGENTS.md` 建立完成(< 200 行,正體中文)
-- [ ] `CLAUDE.md` 重構完成(119 → ~60 行,修正 changelog.ts 指向錯誤)
-- [ ] `issues/README.md` 建立
-- [ ] `issues/_template/{task_plan,findings,progress}.md` 建立
-- [ ] `issues/36-file-based-memory/{task_plan,findings,progress}.md` 建立
-- [ ] `bun run build` 綠燈
-- [ ] PR #{N} draft 開立並附連結給 Dar
+- [x] `AGENTS.md` 建立完成(117 行,正體中文)
+- [x] `CLAUDE.md` 重構完成(119 → 44 行,修正 changelog.ts 指向錯誤)
+- [x] `issues/README.md` 建立
+- [x] `issues/_template/{task_plan,findings,progress}.md` 建立
+- [x] `issues/36-file-based-memory/{task_plan,findings,progress}.md` 建立
+- [x] `bun run build` 綠燈(18 頁 1.73s)
+- [x] PR #37 draft 開立並附連結給 Dar(https://github.com/cyclone-tw/cyclone-workflow/pull/37)
 
 <!-- TODO (Dar): 定義「這個架構跑通了」的成功標準。建議自己加 2–3 條:
      例如「換另一個人 / 另一台電腦 cold start 能無縫接手當前 issue」
@@ -56,7 +56,7 @@ cyclone-26 同時使用 20+ 個 AI 工具協作(`.claude/` `.cursor/` `.continue
 
 ## 階段 checklist
 
-### 階段 1:建立新架構(本 commit)
+### 階段 1:建立新架構(commit 99dda4e)
 - [x] 建立 GitHub issue #36
 - [x] 建立 branch `docs/36_agents-md`
 - [x] 寫 `AGENTS.md`
@@ -65,22 +65,23 @@ cyclone-26 同時使用 20+ 個 AI 工具協作(`.claude/` `.cursor/` `.continue
 - [x] 寫 `issues/_template/findings.md`
 - [x] 寫 `issues/_template/progress.md`
 - [x] 寫 `issues/36-file-based-memory/task_plan.md`(本檔)
-- [ ] 寫 `issues/36-file-based-memory/findings.md`
-- [ ] 寫 `issues/36-file-based-memory/progress.md`
-- [ ] 重構 `CLAUDE.md`(瘦身 + 修正 changelog.ts 路徑)
+- [x] 寫 `issues/36-file-based-memory/findings.md`
+- [x] 寫 `issues/36-file-based-memory/progress.md`
+- [x] 重構 `CLAUDE.md`(瘦身 + 修正 changelog.ts 路徑)
 
 ### 階段 2:驗證
-- [ ] `bun run build` 綠
-- [ ] `grep AGENTS.md CLAUDE.md` 有 match
-- [ ] `grep changelog.ts CLAUDE.md` 有 match
-- [ ] `grep -c 'version.ts' CLAUDE.md` 只出現在「不要手動改」的警告
+- [x] `bun run build` 綠(18 頁 1.73s)
+- [x] `grep AGENTS.md CLAUDE.md` 有 3 處 match(L3 / L22 / L44)
+- [x] `grep changelog.ts CLAUDE.md` 有 2 處 match(L33 / L38)
+- [x] `wc -l CLAUDE.md` = 44(< 60 目標)
+- [x] `wc -l AGENTS.md` = 117(< 200 目標)
 
-### 階段 3:PR(本 commit 收尾)
-- [ ] `git add` 全部新檔 + `CLAUDE.md`
-- [ ] `git commit -m "docs(#36): add AGENTS.md + issues/ file-based memory structure"`
-- [ ] `git push -u origin docs/36_agents-md`
-- [ ] `gh pr create --draft`
-- [ ] 回報 PR 連結給 Dar
+### 階段 3:PR(commit 99dda4e + push)
+- [x] `git add` 全部新檔 + `CLAUDE.md`
+- [x] `git commit` 完成
+- [x] `git push -u origin docs/36_agents-md`
+- [x] `gh pr create --draft` → PR #37
+- [x] 回報 PR 連結給 Dar
 
 ### 階段 4:搬家(可另一個 commit,可延後)
 - [ ] `git mv issue-17.md issues/17-cyclone-requirements/task_plan.md` + 補 frontmatter

--- a/issues/36-file-based-memory/task_plan.md
+++ b/issues/36-file-based-memory/task_plan.md
@@ -1,0 +1,107 @@
+---
+issue: 36
+title: 多 AI 協作的檔案式記憶與規劃架構 (planning-with-files)
+status: in-progress
+phase: implementation
+priority: P1
+owner: dar
+created: 2026-04-12
+updated: 2026-04-12
+github_issue: 36
+branch: docs/36_agents-md
+pr: null
+related_files:
+  - AGENTS.md
+  - CLAUDE.md
+  - issues/README.md
+  - issues/_template/task_plan.md
+  - issues/_template/findings.md
+  - issues/_template/progress.md
+---
+
+# 多 AI 協作的檔案式記憶與規劃架構
+
+## 背景
+
+cyclone-26 同時使用 20+ 個 AI 工具協作(`.claude/` `.cursor/` `.continue/` `.goose/` `.roo/` `.crush/` `.qwen/` `.trae/` `.windsurf/` `.kiro/` `.codebuddy/` `.factory/` `.junie/` `.kilocode/` `.kode/` `.neovate/` `.omc/` `.openhands/` `.qoder/` `.zencoder/` 等隱藏資料夾),但跨 AI 共讀的規則**只有 `CLAUDE.md` 一份**,內容還是 Bun templates 預設的 `Bun.serve` / `bun:sqlite` 範例(對 Astro+Cloudflare Pages 本專案完全不適用)。
+
+所有工作流規則(PR draft 流程、Turso 備份、branch 命名、LEFT JOIN 陷阱、不 offload 風格敏感任務)目前只存在個人 Claude memory 裡,**Codex、Cursor、Goose、Roo、Continue 等工具完全看不到**。每次換一個 AI 就要重講一次規則,交棒成本極高。
+
+更嚴重的是 `CLAUDE.md:115` 寫「同步更新 `src/lib/version.ts` 的 CHANGELOG」,但實際上 `src/lib/changelog.ts` 才是 entry 的正確位置 —— `pr-11.md` 的 PR review 因此誤報 "missing changelog update"。
+
+參考 [planning-with-files](https://github.com/othmanadi/planning-with-files) 的 Manus 模式(把檔案系統當 AI 的長期記憶),導入 `AGENTS.md` + `issues/` 檔案式記憶架構。
+
+## 目標
+
+1. **`AGENTS.md`** 成為跨 AI 共讀的單一事實來源(2025 下半年業界標準,Codex / Cursor / Aider / Continue / Goose / Zed / Windsurf 都會自動 inject)
+2. **`issues/{number}-{slug}/`** 資料夾用 3 檔 `task_plan` + `findings` + `progress` 管理任務交棒
+3. **`CLAUDE.md`** 瘦身到 ~60 行,只留 Claude Code 專屬設定(Superpowers 路由、Subagent 規則、Hooks)
+4. **第一個示範 issue**(本 issue 自己)跑通完整流程
+
+## 驗收條件
+
+- [x] GitHub issue #36 建立
+- [x] Branch `docs/36_agents-md` 建立(從 main)
+- [ ] `AGENTS.md` 建立完成(< 200 行,正體中文)
+- [ ] `CLAUDE.md` 重構完成(119 → ~60 行,修正 changelog.ts 指向錯誤)
+- [ ] `issues/README.md` 建立
+- [ ] `issues/_template/{task_plan,findings,progress}.md` 建立
+- [ ] `issues/36-file-based-memory/{task_plan,findings,progress}.md` 建立
+- [ ] `bun run build` 綠燈
+- [ ] PR #{N} draft 開立並附連結給 Dar
+
+<!-- TODO (Dar): 定義「這個架構跑通了」的成功標準。建議自己加 2–3 條:
+     例如「換另一個人 / 另一台電腦 cold start 能無縫接手當前 issue」
+     或「Codex 冷啟動問 branch 命名規則能答出 {type}/{issue-number}_{slug}」 -->
+
+## 階段 checklist
+
+### 階段 1:建立新架構(本 commit)
+- [x] 建立 GitHub issue #36
+- [x] 建立 branch `docs/36_agents-md`
+- [x] 寫 `AGENTS.md`
+- [x] 寫 `issues/README.md`
+- [x] 寫 `issues/_template/task_plan.md`
+- [x] 寫 `issues/_template/findings.md`
+- [x] 寫 `issues/_template/progress.md`
+- [x] 寫 `issues/36-file-based-memory/task_plan.md`(本檔)
+- [ ] 寫 `issues/36-file-based-memory/findings.md`
+- [ ] 寫 `issues/36-file-based-memory/progress.md`
+- [ ] 重構 `CLAUDE.md`(瘦身 + 修正 changelog.ts 路徑)
+
+### 階段 2:驗證
+- [ ] `bun run build` 綠
+- [ ] `grep AGENTS.md CLAUDE.md` 有 match
+- [ ] `grep changelog.ts CLAUDE.md` 有 match
+- [ ] `grep -c 'version.ts' CLAUDE.md` 只出現在「不要手動改」的警告
+
+### 階段 3:PR(本 commit 收尾)
+- [ ] `git add` 全部新檔 + `CLAUDE.md`
+- [ ] `git commit -m "docs(#36): add AGENTS.md + issues/ file-based memory structure"`
+- [ ] `git push -u origin docs/36_agents-md`
+- [ ] `gh pr create --draft`
+- [ ] 回報 PR 連結給 Dar
+
+### 階段 4:搬家(可另一個 commit,可延後)
+- [ ] `git mv issue-17.md issues/17-cyclone-requirements/task_plan.md` + 補 frontmatter
+- [ ] `git mv pr-11.md issues/11-markdown-rendering/findings.md` + 補 frontmatter
+- [ ] `git mv worklog-20260411-1437.md issues/23-gemini-ai-insights/progress.md` + 補 frontmatter
+- [ ] Commit 2
+
+### 階段 5:跨 AI 驗證(人工,可延後)
+- [ ] Claude Code 新 session 問「branch 命名規則」,應答出 `{type}/{issue-number}_{slug}`
+- [ ] Codex CLI cold start 問同樣問題
+- [ ] Cursor 打開專案問同樣問題
+- [ ] 至少 2 個工具答對 = 通過
+
+### 階段 6:Merge
+- [ ] PR ready for review
+- [ ] `src/lib/changelog.ts` 新增 entry(chore bump)
+- [ ] Merge to main
+
+## 問題 / 假設
+
+- **假設**:Codex、Cursor 會自動讀取 `AGENTS.md`。實際驗證前先假設為真,由階段 5 驗證
+- **未決**:要不要把 `WORKLOG.md` 和 `plan0.md` 也搬進 `issues/`?目前保留在根目錄作歷史文獻
+- **未決**:要不要順便清理 20+ 個 AI 工具空目錄(`.agents/` `.codebuddy/` ...)?建議另一個 issue 處理,本 issue 不混進來
+- **未決**:`隊員表單2026-04-10.csv` / `隊員表單2026-04-10-v2.csv` 目前在根目錄 untracked,是否應該加進 `.gitignore`?(敏感個資)

--- a/issues/36-file-based-memory/task_plan.md
+++ b/issues/36-file-based-memory/task_plan.md
@@ -1,7 +1,7 @@
 ---
 issue: 36
 title: 多 AI 協作的檔案式記憶與規劃架構 (planning-with-files)
-status: review
+status: in-progress
 phase: verification
 priority: P1
 owner: dar

--- a/issues/README.md
+++ b/issues/README.md
@@ -107,3 +107,23 @@ issues/
 | `implementation` | 寫 code 中 |
 | `verification` | build / E2E / 手動測試中 |
 | `done` | 全部完成 |
+
+## progress.md 穩定性原則
+
+**禁止在 progress.md 追蹤動態 count 或當前 commit 狀態**。
+
+為什麼:
+
+- 檔案是某個 commit 的一部分,寫入時該 commit 還不存在,無法寫入自己的 SHA
+- 寫「當前 PR 有 N 個 commit」之類的 count,追 count 的 commit 本身會讓 count 立刻變舊 —— chicken-and-egg
+- 任何試圖描述「當前狀態」的清單(commit 歷史、分支 HEAD、尚未 push 的 commit 數)都會永遠落後一步
+- 寫 placeholder「本 session 新增的 commit」一樣會過期,只是換個糖衣
+
+正確做法:
+
+- **會話日誌** 可以記錄 session 內「做了什麼」,commit SHA 由**後續** session 的日誌補上(如需)—— 歷史事實不會過期
+- **當前 PR commit 歷史、分支 HEAD、commit count** 等動態資訊**不寫進檔內**,直接請讀者跑 `git log --oneline origin/{branch}` 或 `gh pr view {N}`
+- 檔內只記 **stable facts**:issue 編號、branch 名、PR 編號、設計決定、session 已發生的事、下一步要做什麼
+- 寫 guidance 時避免 ordinal(「第 N 個 commit」),改用「新增 commit」
+
+這條規則從 issue #36 的 4 輪 Codex self-correction 學到 —— 正因為本 issue 是架構的第一次 dogfood,每一種 staleness pattern 都被逼出來修掉。感謝 Codex stop-time review。

--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,109 @@
+# issues/ — 任務記憶與交棒工作區
+
+每個任務一個資料夾,用 3 個 .md 檔在 AI 之間交棒。
+設計理念參考 [planning-with-files](https://github.com/othmanadi/planning-with-files)(把檔案系統當 AI 的長期記憶)。
+
+## 檔案結構
+
+```
+issues/
+├── README.md                           # 本檔
+├── _template/                          # 新 issue 樣板
+│   ├── task_plan.md
+│   ├── findings.md
+│   └── progress.md
+├── 36-file-based-memory/               # 第一個示範 issue
+│   ├── task_plan.md
+│   ├── findings.md
+│   └── progress.md
+└── 42-add-search/                      # (範例)未來 issue 長這樣
+    ├── task_plan.md
+    ├── findings.md
+    └── progress.md
+```
+
+## 3 個檔案的職責
+
+| 檔案 | 職責 | 什麼時候讀 | 什麼時候寫 |
+|------|------|-----------|-----------|
+| `task_plan.md` | 靜態計畫(背景 / 目標 / 驗收 / checklist) | 開工時讀全文 | 計畫有變動時改,checklist 進展時打勾 |
+| `findings.md` | 研究發現與決策記錄 | 遇到陌生程式碼時讀 | 學到 non-obvious 技術事實時寫 |
+| `progress.md` | 動態日誌與交棒筆記 | 每次 session 開頭讀交棒筆記 | 每次 session 結束時寫進度 + 交棒筆記 |
+
+**為什麼分 3 檔而不是 1 檔**:讓新接手的 AI 能快速定位 —— 要看「該做什麼」讀 `task_plan`,要看「學過什麼」讀 `findings`,要看「現在進展」讀 `progress`。混在一起會讓交棒時要全文掃一次。
+
+## 建立新 issue
+
+1. 複製 `_template/` → 改名 `{number}-{slug}/`(number 對應 GitHub issue 或 PR 編號)
+2. 編輯 3 個檔的 frontmatter:填 `issue`、`title`、`branch`、`github_issue`
+3. 在 `task_plan.md` 填「背景 / 目標 / 驗收條件 / 階段 checklist」
+4. 開始實作,進展寫進 `progress.md`
+
+### 命名規範
+
+- 資料夾名:`{number}-{slug}`
+- slug 用 kebab-case(小寫 + 連字號),2–4 個單字
+- 範例:
+  - `36-file-based-memory`
+  - `17-cyclone-requirements`
+  - `23-gemini-ai-insights`
+- `number` 必須和 GitHub issue / PR 編號對齊(先開的那一個即可)
+
+## 開工時
+
+- 讀 `progress.md` 的「交棒筆記」區(最高密度的上下文)
+- 讀 `task_plan.md` 的 checklist 看剩下什麼
+- frontmatter `status` 改 `in-progress`,`owner` 寫進自己的代號(例如 `dar`、`claude-opus-46`、`codex-gpt5`、`cursor-agent`)
+
+## 完成時
+
+- checklist 全部打勾
+- frontmatter `status` → `done`,`phase` → `done`
+- 填 `pr` 連結
+- **不要刪除資料夾** —— 保留作歷史,未來搜尋「這個功能當初為什麼這樣做」找得到脈絡
+
+## 什麼時候該開新 issue
+
+<!-- TODO (Dar): 依你自己的任務粒度偏好調整這份清單 -->
+
+- 需要修改超過 3 個檔案
+- 需要跨 session 延續(今天做不完)
+- 需要 schema migration、API 變更、設定檔變動
+- 需要回報 stakeholder 進度
+- 需要多個 AI 接力(例如 Claude 起稿 → Codex 補 test → Cursor 修 UI)
+
+## 什麼時候不需要
+
+- typo、一行 CSS 微調
+- 純 `src/lib/changelog.ts` 的 entry 追加
+- 純 version bump
+- 實驗性探索(探索完再決定要不要開 issue)
+
+## 和 GitHub Issues 的關係
+
+**純本地為主,frontmatter 放連結**。
+
+- `task_plan.md` frontmatter 的 `github_issue` 欄位填對應 issue 編號(有就填,沒有就 `null`)
+- **不做自動雙向同步**(成本太高)
+- 要看 GitHub 最新討論用 `gh issue view {n}`
+- 要把本地進度寫回 GitHub 用 `gh issue comment {n} --body "..."`
+
+## 狀態欄位 (frontmatter `status`)
+
+| status | 意思 |
+|--------|------|
+| `proposed` | 構想中,還沒開工 |
+| `in-progress` | 進行中 |
+| `blocked` | 被別的 issue / 外部因素卡住 |
+| `review` | 實作完成,等 PR review |
+| `done` | 已 merge |
+| `archived` | 不做了(廢案),保留作歷史 |
+
+## phase 欄位
+
+| phase | 意思 |
+|-------|------|
+| `planning` | 還在寫計畫 |
+| `implementation` | 寫 code 中 |
+| `verification` | build / E2E / 手動測試中 |
+| `done` | 全部完成 |

--- a/issues/README.md
+++ b/issues/README.md
@@ -126,4 +126,4 @@ issues/
 - 檔內只記 **stable facts**:issue 編號、branch 名、PR 編號、設計決定、session 已發生的事、下一步要做什麼
 - 寫 guidance 時避免 ordinal(「第 N 個 commit」),改用「新增 commit」
 
-這條規則從 issue #36 的 4 輪 Codex self-correction 學到 —— 正因為本 issue 是架構的第一次 dogfood,每一種 staleness pattern 都被逼出來修掉。感謝 Codex stop-time review。
+這條規則從 issue #36 的 Codex self-correction 系列學到 —— 正因為本 issue 是架構的第一次 dogfood,每一種 staleness pattern 都被逼出來修掉。詳細歷程見該 PR 的 commit 記錄。感謝 Codex stop-time review。

--- a/issues/_template/findings.md
+++ b/issues/_template/findings.md
@@ -1,0 +1,28 @@
+---
+issue: 0
+updated: 2026-04-12
+---
+
+# {TITLE} — Findings
+
+## 研究發現
+
+(這個 issue 過程中學到的 non-obvious 技術事實。每一條帶引用檔案路徑與行號。)
+
+- (例:`src/lib/auth.ts:42` 的 `verifySession` 只檢查 cookie,沒驗 CSRF token)
+
+## 決策記錄
+
+(為什麼選 A 不選 B。未來接手者能看懂「為什麼這樣設計」。)
+
+### 決策 1:(決策主題)
+- **選項**:A 或 B
+- **最終選 A**
+- **理由**:(具體理由)
+- **放棄 B 的原因**:(具體原因)
+
+## 相關檔案路徑
+
+(這個 issue 會 touch 或 reference 的關鍵檔案,列出路徑 + 行號 + 簡短說明)
+
+- `path/to/file.ts:LINE` — (用途說明)

--- a/issues/_template/progress.md
+++ b/issues/_template/progress.md
@@ -1,0 +1,40 @@
+---
+issue: 0
+updated: 2026-04-12
+---
+
+# {TITLE} — Progress
+
+## 會話日誌
+
+### YYYY-MM-DD HH:MM — (AI 代號 / 作者)
+
+- (做了什麼)
+- (遇到什麼)
+- (下一步要做什麼)
+
+## 交棒筆記
+
+> 最重要的一區。新接手的 AI 請先讀這裡。
+
+**目前狀態**:(一句話描述當前進度)
+
+**下一步應該**:(具體下一個動作)
+
+**卡住的事**(如果有):(blockers 清單)
+
+**重要上下文**:(新接手需要知道的事實,例如某個 env var 沒設、某個 API 有 rate limit、某個測試 flaky)
+
+## 驗證結果
+
+### bun run build
+- [ ] 未跑 / Pass / Fail
+- (如果 fail,錯誤訊息貼這裡)
+
+### bun run test:e2e
+- [ ] 未跑 / Pass / Fail
+- (failed spec 與原因)
+
+### 手動 E2E
+- [ ] 未跑 / Pass / Fail
+- (測試步驟與結果)

--- a/issues/_template/task_plan.md
+++ b/issues/_template/task_plan.md
@@ -1,0 +1,58 @@
+---
+issue: 0
+title: {TITLE}
+status: proposed          # proposed | in-progress | blocked | review | done | archived
+phase: planning           # planning | implementation | verification | done
+priority: P1              # P0 P1 P2 P3
+owner: dar
+created: 2026-04-12
+updated: 2026-04-12
+github_issue: null
+branch: {type}/{issue-number}_{slug}
+pr: null
+related_files: []
+---
+
+# {TITLE}
+
+## 背景
+
+(為什麼要做這個?問題是什麼?引用相關檔案路徑與行號。)
+
+## 目標
+
+(完成後會有什麼不同?用 2–3 句話說清楚。)
+
+## 驗收條件
+
+- [ ] (具體可驗證的成功標準,例如「頁面載入 < 2s」、「用戶能 X」)
+- [ ] `bun run build` 綠燈
+- [ ] `bun run test:e2e` 綠燈
+- [ ] PR draft 開立 + E2E 錄影/截圖附上
+- [ ] `src/lib/changelog.ts` 新增 entry
+
+## 階段 checklist
+
+### 階段 1:(階段名稱)
+- [ ] (具體任務)
+- [ ] (具體任務)
+
+### 階段 2:(階段名稱)
+- [ ] (具體任務)
+
+### 階段 3:驗證
+- [ ] `bun run build`
+- [ ] `bun run test:e2e`
+- [ ] 手動 E2E 跑過
+- [ ] 錄影/截圖歸檔
+
+### 階段 4:PR
+- [ ] 開 draft PR
+- [ ] 自我 review
+- [ ] `src/lib/changelog.ts` 新增 entry
+- [ ] Ready for review
+- [ ] Merge
+
+## 問題 / 假設
+
+- (目前還不確定的事、未來可能需要回來確認的假設)


### PR DESCRIPTION
## Summary

導入 [planning-with-files](https://github.com/othmanadi/planning-with-files) 的 Manus 模式(把檔案系統當 AI 的長期記憶),讓 20+ 個 AI 工具能共享工作流規則與任務交棒狀態。

Closes #36

- **新增 `AGENTS.md`**(117 行)作為跨 AI 共讀主檔。2025 下半年業界標準,Codex / Cursor / Aider / Continue / Goose / Zed / Windsurf 都會自動 inject。包含黃金規則 6 條、指令速查、Definition of Done、交棒守則、禁止事項
- **新增 `issues/` 檔案式記憶資料夾**,每個任務用 3 檔 `task_plan.md` / `findings.md` / `progress.md` 管理交棒。附 `README.md` 使用規則與 `_template/` 樣板
- **新增 `issues/36-file-based-memory/`** 作為第一個示範 issue(本 PR 自己)
- **重構 `CLAUDE.md`**(119 → 44 行),只留 Claude Code 專屬設定(Superpowers 路由、Subagent 規則、Hooks),頂部指向 `AGENTS.md`
- **修正 `CLAUDE.md:115` 的指向錯誤** —— 原寫「同步更新 `src/lib/version.ts`」,實際上是 `src/lib/changelog.ts`。此錯誤曾導致 PR #11 review 誤報 "missing changelog update"

## 為什麼要這樣做

cyclone-26 同時使用 20+ 個 AI 工具協作(`.claude/` `.cursor/` `.continue/` `.goose/` `.roo/` `.crush/` `.qwen/` `.trae/` `.windsurf/` `.kiro/` `.codebuddy/` `.factory/` `.junie/` `.kilocode/` `.kode/` `.neovate/` `.omc/` `.openhands/` `.qoder/` `.zencoder/` 等),但:

- 跨 AI 共讀的規則**只有 `CLAUDE.md` 一份**,且內容是 Bun templates 預設的 `Bun.serve` / `bun:sqlite` 範例,對 Astro+Cloudflare Pages 本專案不適用
- 所有工作流規則(PR draft、Turso backup、branch 命名、LEFT JOIN 陷阱、不 offload 風格任務)只在個人 Claude memory 裡,Codex / Cursor / Goose 等工具完全看不到
- 每換一個 AI 就要重講一次規則,交棒成本極高

Anthropic 評測:這種檔案式記憶模式把 pass rate 從 **6.7% 推到 96.7%**。

## 變更檔案

| 檔案 | 動作 | 行數 |
|------|------|------|
| `AGENTS.md` | 新建 | 117 |
| `CLAUDE.md` | 重構 | 119 → 44 |
| `issues/README.md` | 新建 | ~120 |
| `issues/_template/{task_plan,findings,progress}.md` | 新建 | 3 檔 |
| `issues/36-file-based-memory/{task_plan,findings,progress}.md` | 新建(示範) | 3 檔 |

9 files changed, 678 insertions(+), 118 deletions(-)

## Test plan

- [x] `bun run build` 綠(18 頁全部 build 成功,1.73s)
- [x] `grep -n "AGENTS.md" CLAUDE.md` 有 3 個 match(CLAUDE.md reference AGENTS.md)
- [x] `grep -n "changelog.ts" CLAUDE.md` 有 match(changelog.ts 指向修正)
- [x] `wc -l CLAUDE.md` = 44(瘦身驗證)
- [x] `wc -l AGENTS.md` = 117(< 200 行目標)
- [ ] 跨 AI 冷啟動驗證:Codex CLI cold start 問「branch 命名規則」,應答出 `{type}/{issue-number}_{slug}`
- [ ] Cursor 打開專案問同樣問題
- [ ] `bun run test:e2e`(選做,純 docs 變更不應影響,但走完流程)

## 後續工作(不在本 PR)

- 根目錄 `issue-17.md` / `pr-11.md` / `worklog-20260411-1437.md` 搬入 `issues/` 對應資料夾(另一個 commit 或另一個 issue)
- 清理 20+ 個 AI 工具空目錄(`.agents/` `.codebuddy/` ...)
- `src/lib/changelog.ts` 新增 chore entry(bump 版本時一起做)

## 給 Dar 親手填的 TODO

檔案裡用 `<!-- TODO (Dar) -->` 標記,建議在 merge 前自己補上:

1. `AGENTS.md` 黃金規則第 4-6 條的 war story 細節(Turso 哪次事件、LEFT JOIN 是哪個 PR、offload 哪次出事)
2. `issues/36-file-based-memory/task_plan.md` 驗收條件的「成功標準」定義
3. `issues/README.md`「什麼時候該開新 issue」的使用者偏好調整

## Ref

- Issue: #36
- 原始計畫檔(本地):`~/.claude/plans/lucky-imagining-pixel.md`
- 設計參考:https://github.com/othmanadi/planning-with-files

🤖 Generated with [Claude Code](https://claude.com/claude-code)