### PR TITLE
feat(#15): 深色/淺色主題切換

### DIFF
--- a/issues/15-dark-light-theme/findings.md
+++ b/issues/15-dark-light-theme/findings.md
@@ -1,0 +1,20 @@
+---
+issue: 15
+updated: 2026-04-12
+---
+
+# 深色 / 淺色主題 — Findings
+
+## 研究發現
+
+（開工後填入）
+
+## 決策記錄
+
+（開工後填入）
+
+## 相關檔案路徑
+
+- `src/styles/global.css` — Tailwind v4 @theme 定義
+- `src/layouts/Layout.astro` — 全站 layout
+- `src/components/auth/LoginButton.tsx` — 已有 theme toggle 相關邏輯

--- a/issues/15-dark-light-theme/progress.md
+++ b/issues/15-dark-light-theme/progress.md
@@ -1,0 +1,25 @@
+---
+issue: 15
+updated: 2026-04-12
+---
+
+# 深色 / 淺色主題 — Progress
+
+## 會話日誌
+
+### 2026-04-12 — claude-opus-46
+- 建立 task_plan.md、findings.md、progress.md
+- 建立 branch `feat/15_dark-light-theme`
+- 開立 draft PR
+
+## 交棒筆記
+
+> 最重要的一區。新接手的 AI 請先讀這裡。
+
+**目前狀態**: 規劃完成，**blocked on 前置討論**
+
+**下一步應該**: 先在 GitHub issue #15 完成討論（預設模式、切換位置、light 品牌風格），再開始階段 1
+
+**卡住的事**: 需要人類決策（dark/light 品牌方向、範圍）
+
+**重要上下文**: 這是中型重構，幾乎所有元件都有寫死顏色需要改

--- a/issues/15-dark-light-theme/task_plan.md
+++ b/issues/15-dark-light-theme/task_plan.md
@@ -1,0 +1,84 @@
+---
+issue: 15
+title: 深色 / 淺色雙主題切換 (dark / light mode)
+status: proposed
+phase: planning
+priority: P2
+owner: dar
+created: 2026-04-12
+updated: 2026-04-12
+github_issue: 15
+branch: feat/15_dark-light-theme
+pr: null
+related_files:
+  - src/styles/global.css
+  - src/layouts/Layout.astro
+  - src/components/auth/LoginButton.tsx
+---
+
+# 深色 / 淺色雙主題切換
+
+## 背景
+
+來自 innoblue（生活黑客）的需求。目前全站只有「深色霓虹賽博龐克」風格，所有顏色寫死在 `src/styles/global.css` 的 `@theme` 指令中，沒有 `data-theme` 屬性、沒有 Tailwind `dark:` 變體，沒有任何主題切換基礎建設。
+
+## 目標
+
+1. 全站支援 dark / light 雙主題切換
+2. 預設跟隨系統 `prefers-color-scheme`，手動切換後記憶在 `localStorage`
+3. 不產生 FOUC（頁面渲染前就決定主題）
+4. Light mode 保留品牌主色但調整對比
+
+## 前置討論（GitHub issue #15 需先決定）
+
+- [ ] 預設模式：跟隨系統 / 永遠 dark / 永遠 light
+- [ ] 切換按鈕位置：Navbar 右上 / Footer / 設定頁
+- [ ] Light mode 是否保留 neon glow / glass morphism
+- [ ] 主色 `#6C63FF` / `#E94560` 在白底是否需微調
+- [ ] 範圍：全站一次到位 or 分階段
+
+## 驗收條件
+
+- [ ] Dark mode 外觀與現行一致（不改壞）
+- [ ] Light mode 可讀性良好、對比充足
+- [ ] 切換按鈕正常運作、偏好持久化
+- [ ] 頁面載入無 FOUC
+- [ ] `bun run build` 綠燈
+- [ ] PR draft 開立 + 各頁面雙主題截圖
+- [ ] `src/lib/changelog.ts` 新增 entry
+
+## 階段 checklist
+
+### 階段 1：CSS 變數拆分
+- [ ] `global.css` 把 `@theme` 拆成 `:root`（light）與 `[data-theme="dark"]`（dark）
+- [ ] 確認所有 CSS 變數都有 light/dark 兩組值
+- [ ] 寫死顏色的元件改用 CSS 變數（`text-[#xxx]` → `text-[var(--color-xxx)]`）
+
+### 階段 2：主題切換基礎建設
+- [ ] `Layout.astro` `<head>` 加 inline script 讀 `localStorage` + `prefers-color-scheme`
+- [ ] `<html>` 加 `data-theme` 屬性
+- [ ] 新增 `ThemeToggle` 元件（太陽/月亮 icon）
+
+### 階段 3：全站元件審計
+- [ ] 搜尋所有 inline style 的寫死顏色（`#F0F0FF`、`#9090B0` 等）
+- [ ] 改用語意化 CSS 變數
+- [ ] React island 元件的 inline styles 改用 CSS 變數
+
+### 階段 4：驗證
+- [ ] `bun run build`
+- [ ] 手動切換 dark/light 確認每個頁面
+- [ ] 手機版切換測試
+- [ ] 各頁面截圖歸檔
+
+### 階段 5：PR
+- [ ] 開 draft PR
+- [ ] 自我 review
+- [ ] `src/lib/changelog.ts` 新增 entry
+- [ ] Ready for review
+- [ ] Merge
+
+## 問題 / 假設
+
+- 20+ 個 React island 元件都有 inline style 寫死顏色，改動量大
+- Light mode 的 glass morphism 效果可能需要不同 blur/opacity 參數
+- OG image 目前是 dark 版，是否需要 light 版？


### PR DESCRIPTION
## Summary
- 新增深色/淺色主題切換功能
- 規劃檔案已建立於 `issues/15-dark-light-theme/`

## 規劃狀態
- [x] task_plan.md — 5 階段主題重構計畫
- [x] findings.md — 研究發現模板
- [x] progress.md — 會話日誌與交棒筆記

## 階段
1. CSS 變數拆分（硬編碼 → CSS variables）
2. 主題切換基礎建設（Provider + Toggle）
3. 全站元件審計
4. 驗證
5. PR

## 前置作業
- 需先在 GitHub issue #15 完成討論（預設模式、切換位置、light 品牌風格）

## Test plan
- [ ] 深色/淺色主題可正常切換
- [ ] 所有頁面顏色正確對應主題
- [ ] `bun run build` 綠燈

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)