### PR TITLE
feat(#41): 最新公告系統 — 後台管理 + 前台顯示

### DIFF
--- a/functions/api/admin/announcements/[id].ts
+++ b/functions/api/admin/announcements/[id].ts
@@ -1,0 +1,128 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/announcements/:id — single announcement
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+    const id = context.params?.id;
+
+    const result = await db.execute({
+      sql: `
+        SELECT a.*, u.name AS author_name
+        FROM announcements a
+        LEFT JOIN users u ON u.id = a.author_id AND u.archived_at IS NULL AND u.status = 'active'
+        WHERE a.id = ?
+      `,
+      args: [id],
+    });
+
+    if (result.rows.length === 0) {
+      return new Response(JSON.stringify({ error: '公告不存在' }), { status: 404, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const r = result.rows[0];
+    return new Response(JSON.stringify({
+      ok: true,
+      announcement: {
+        id: r.id,
+        title: r.title,
+        content: r.content,
+        pinned: r.pinned === 1,
+        author_id: r.author_id,
+        author_name: r.author_name,
+        created_at: r.created_at,
+        updated_at: r.updated_at,
+      },
+    }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// PUT /api/admin/announcements/:id — update announcement
+// ---------------------------------------------------------------------------
+
+export const onRequestPut: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+    const id = context.params?.id;
+
+    const body = await context.request.json() as { title?: string; content?: string; pinned?: boolean };
+
+    const updates: string[] = [];
+    const args: (string | number)[] = [];
+
+    if (body.title !== undefined) {
+      updates.push('title = ?');
+      args.push(body.title.trim());
+    }
+    if (body.content !== undefined) {
+      updates.push('content = ?');
+      args.push(body.content.trim());
+    }
+    if (body.pinned !== undefined) {
+      updates.push('pinned = ?');
+      args.push(body.pinned ? 1 : 0);
+    }
+
+    if (updates.length === 0) {
+      return new Response(JSON.stringify({ error: '沒有要更新的欄位' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    updates.push("updated_at = datetime('now')");
+    args.push(id);
+
+    await db.execute({
+      sql: `UPDATE announcements SET ${updates.join(', ')} WHERE id = ?`,
+      args,
+    });
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// DELETE /api/admin/announcements/:id
+// ---------------------------------------------------------------------------
+
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+    const id = context.params?.id;
+
+    await db.execute({ sql: `DELETE FROM announcements WHERE id = ?`, args: [id] });
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), { status: 500, headers: { 'Content-Type': 'application/json' } });
+  }
+};

--- a/functions/api/admin/announcements/index.ts
+++ b/functions/api/admin/announcements/index.ts
@@ -1,0 +1,90 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/announcements — list all announcements
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `
+        SELECT a.*, u.name AS author_name
+        FROM announcements a
+        LEFT JOIN users u ON u.id = a.author_id AND u.archived_at IS NULL AND u.status = 'active'
+        ORDER BY a.pinned DESC, a.created_at DESC
+      `,
+      args: [],
+    });
+
+    const announcements = result.rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      content: r.content,
+      pinned: r.pinned === 1,
+      author_id: r.author_id,
+      author_name: r.author_name,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+    }));
+
+    return new Response(JSON.stringify({ ok: true, announcements }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+// ---------------------------------------------------------------------------
+// POST /api/admin/announcements — create announcement
+// ---------------------------------------------------------------------------
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+
+    const body = await context.request.json() as { title?: string; content?: string; pinned?: boolean };
+    const { title, content, pinned = false } = body;
+
+    if (!title?.trim()) {
+      return new Response(JSON.stringify({ error: '請填寫標題' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+    if (!content?.trim()) {
+      return new Response(JSON.stringify({ error: '請填寫內容' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    const id = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO announcements (id, title, content, pinned, author_id) VALUES (?, ?, ?, ?, ?)`,
+      args: [id, title.trim(), content.trim(), pinned ? 1 : 0, user.id],
+    });
+
+    return new Response(JSON.stringify({ ok: true, id }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/announcements/index.ts
+++ b/functions/api/announcements/index.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@libsql/client/web';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/announcements — public list of latest announcements
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `
+        SELECT a.id, a.title, a.content, a.pinned, a.created_at,
+               u.name AS author_name
+        FROM announcements a
+        LEFT JOIN users u ON u.id = a.author_id AND u.archived_at IS NULL AND u.status = 'active'
+        ORDER BY a.pinned DESC, a.created_at DESC
+        LIMIT 10
+      `,
+      args: [],
+    });
+
+    const announcements = result.rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      content: r.content,
+      pinned: r.pinned === 1,
+      author_name: r.author_name,
+      created_at: r.created_at,
+    }));
+
+    return new Response(JSON.stringify({ ok: true, announcements }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -174,6 +174,18 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+      {
+        sql: `CREATE TABLE IF NOT EXISTS announcements (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          content TEXT NOT NULL,
+          pinned INTEGER DEFAULT 0,
+          author_id TEXT NOT NULL REFERENCES users(id),
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )`,
+        args: [],
+      },
     ]);
 
     // --- Migrations: add missing columns to existing tables ---
@@ -199,6 +211,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     // Index for active/archived filtering (added for admin members management)
     try {
       await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_users_status_archived ON users(status, archived_at)`, args: [] });
+    } catch { /* index already exists */ }
+
+    // announcements index for pinned + created_at ordering
+    try {
+      await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_announcements_pinned ON announcements(pinned DESC, created_at DESC)`, args: [] });
     } catch { /* index already exists */ }
 
     // --- Seed members (from constants) ---

--- a/issues-status.md
+++ b/issues-status.md
@@ -1,0 +1,200 @@
+# Cyclone Workflow Issues 狀態總覽
+
+> 更新時間：2026-04-13
+> 統計：Open 7 / Closed 16 / Total 23
+
+---
+
+## 📊 摘要
+
+| 狀態 | 數量 | 說明 |
+|------|------|------|
+| 🔴 Open | 7 | 進行中或未處理 |
+| 🟢 Closed | 16 | 已完成或已解決 |
+
+| 類型 | 數量 |
+|------|------|
+| enhancement | 11 |
+| bug | 6 |
+| discussion | 5 |
+| privacy | 1 |
+| blocker | 1 |
+| research | 1 |
+| branding | 1 |
+
+---
+
+## 🔴 Open Issues (7)
+
+### #2530 - 🌈Rain [生活黑客], 期待許願樹長成千年神木 :13:
+- **標籤**: enhancement
+- **指派**: 未指派
+- **創建**: 2026-04-13
+- **狀態**: 🔴 Open
+
+**備註**：來自生活黑客社群成員 🌈Rain 的許願樹功能反饋。
+
+---
+
+### #30 - feat: 儀表板功能補齊 + 知識庫 / AI 工具箱 / 許願樹增強
+- **標籤**: enhancement
+- **指派**: @tboydar (Dar)
+- **創建**: 2026-04-11
+- **狀態**: 🔄 PR #35 已提交，等待 review
+
+**需求摘要**：
+| 急迫度 | 項目 | 狀態 |
+|--------|------|------|
+| **高** | AI 工具箱權限修正（陪跑員不應刪除他人投稿） | 🔄 PR #35 |
+| 中 | 儀表板知識貢獻積分 | 🔄 PR #35 |
+| 中 | 週檢核點 (W1/W2/W3 checkbox) | 🔄 PR #35 |
+| 中 | 積分榜全員顯示 | 🔄 PR #35 |
+| 中 | 知識庫成員篩選 | 🔄 PR #35 |
+| 中 | 標籤共用 | 🔄 PR #35 |
+| 中 | 工具箱投稿者顯示 | 🔄 PR #35 |
+| 中 | 許願樹歷程追蹤 | 🔄 PR #35 |
+| 低 | 愛心收藏機制 | 🔄 PR #35 |
+
+**PR**: #35 (branch: `feat/30_dashboard-enhancements`)
+**Code Review**: ✅ 已完成，發現權限驗證等問題需修復
+
+---
+
+### #29 - bug: 導覽列在桌面版螢幕寬度文字被擠壓
+- **標籤**: bug
+- **指派**: @tboydar (Dar)
+- **創建**: 2026-04-11
+- **狀態**: 🔄 PR #34 已提交，等待 review
+
+**問題描述**：桌面版螢幕（13吋筆電、27吋外接螢幕）導覽列文字被壓縮、重疊
+- 手機尺寸正常
+- 問題在中間寬度區段（1280px-1440px）
+
+**PR**: #34 (branch: `fix/29_navbar-desktop-squeeze`)
+**Code Review**: ✅ 已完成，建議考慮 2xl 斷點優化
+
+---
+
+### #23 - feat: Google Analytics 顯示與分析後台 + AI 建議功能
+- **標籤**: enhancement
+- **指派**: 未指派
+- **創建**: 2026-04-11
+- **狀態**: 🔄 PR #26 DRAFT
+
+**需求**：
+1. GA4 數據顯示後台（DAU、MAU、跳出率、停留時間、流量來源）
+2. Gemini AI 分析建議
+3. 用量檢查機制（quota 滿時顯示提示）
+
+**備註**：不急，等核心功能穩定後再處理
+
+**PR**: #26 (branch: `feat/23_gemini-ai-suggestions`)
+**Code Review**: ✅ 已完成，發現 API Key 傳遞方式等安全問題
+
+---
+
+### #22 - fix: OAuth 登入產生重複帳號 + 隊長 Email UNIQUE 衝突
+- **標籤**: bug, enhancement
+- **指派**: 未指派
+- **創建**: 2026-04-10
+- **狀態**: 🔄 主問題已修復，延伸需求待評估
+
+**已修復**：
+- ✅ 重複帳號問題（使用 substring name matching）
+- ✅ 隊長 email 更新
+
+**延伸需求**（來自 @cyclone-tw）：
+- [ ] 新用戶預設為「訪客/待審核」而非直接給陪跑員身份
+- [ ] 後台加入刪除成員功能
+- [ ] 後台修改成員顯示名稱（email 除外）
+
+---
+
+### #15 - feat: 支援深色 / 淺色雙主題切換 (dark / light mode)
+- **標籤**: enhancement, discussion
+- **指派**: 未指派
+- **創建**: 2026-04-09
+- **狀態**: 💬 討論中，子 issue #16 已關閉
+
+**待決定事項**：
+1. 預設模式：dark / light / 跟隨系統？
+2. 切換 UX：按鈕位置、是否有「跟隨系統」選項
+3. 持久化：localStorage / cookie / 不記憶
+4. 品牌一致性：light mode 是否保留霓虹元素？
+5. 實作範圍：全站一次到位或先做首頁？
+
+**相關**: #16（首頁 demo 已完成）
+
+---
+
+### #5 - 🔒 隱私與成員資料公開：同意機制與資料安全盤點
+- **標籤**: discussion, privacy, blocker
+- **指派**: @cyclone-tw
+- **創建**: 2026-04-08
+- **狀態**: 💬 大部分已確認，待確認 AI 管家隔離機制
+
+**已確認**：
+- ✅ 表單已加入公開同意確認
+- ✅ Discord 編號已移除，只保留暱稱
+- ✅ Repo 已設為 public，成員詳細資料僅後台可見
+- ✅ 資料最小化原則同意
+
+**待確認**：
+- [ ] AI 管家對話隔離機制（技術確認中）
+- [ ] Letta 資料保留政策
+
+---
+
+## 🟢 Closed Issues (16)
+
+| # | 標題 | 標籤 | 關閉時間 |
+|---|------|------|----------|
+| #28 | feat: 管理後台增強 — 角色確認、成員管理、顯示名稱修改 | enhancement | 2026-04-11 |
+| #27 | bug: 多項功能異常回報（時間顯示、討論區、Issues 頁面） | bug | 2026-04-11 |
+| #21 | [Fontend] 導行列 RWD 問題 | bug | 2026-04-11 |
+| #20 | [Bug] Google 登入問題 | bug | 2026-04-11 |
+| #18 | feat: 4/9 討論會後需求整理 — cyclone.tw 網站全面改版規劃 | enhancement | 2026-04-10 |
+| #17 | Cyclone 需求清單（討論記錄） | | 2026-04-10 |
+| #16 | feat(theme): 首頁 dark/light 切換 demo | enhancement | 2026-04-11 |
+| #14 | feat: AI Agent 工具知識卡片頁面 (CRUD) | | 2026-04-10 |
+| #12 | [同步] 讓 main branch 自動跟 Cloudflare Pages 同步 | | 2026-04-11 |
+| #10 | feat: ChatBox agent reply markdown rendering support | enhancement | 2026-04-08 |
+| #9 | 🌍 全球 AI 共學專案研究：參考靈感與社群模式 | research | 2026-04-10 |
+| #8 | 🏘️ 生活黑客社群關係釐清：品牌定位與用詞確認 | discussion, branding | 2026-04-10 |
+| #7 | 📊 進度追蹤、時間管理與習慣養成機制設計 | enhancement, discussion | 2026-04-10 |
+| #6 | 📝 CMS 與 Notion 整合評估：讓非技術成員也能更新內容 | enhancement, discussion | 2026-04-11 |
+| #4 | ❓ 內容更新前需確認：缺少資料清單 | | 2026-04-11 |
+| #3 | docs: 全面更新專案用詞與網站內容 | | 2026-04-10 |
+| #1 | feat: Tauri 桌面版應用程式 (macOS/Windows/Linux) | | 2026-04-08 |
+
+---
+
+## 🔗 相關 PR 狀態
+
+| PR | 標題 | Branch | 狀態 | 關聯 Issue |
+|---|------|--------|------|-----------|
+| #35 | 儀表板/知識庫/AI工具/願望清單功能增強 | `feat/30_dashboard-enhancements` | DRAFT | #30 |
+| #34 | 修復 Navbar 桌面版文字擠壓問題 | `fix/29_navbar-desktop-squeeze` | DRAFT | #29 |
+| #31 | 多項功能異常修復（時間顯示、討論區、Issues 頁面） | `copilot/fix-wishlist-time-display` | DRAFT | - |
+| #26 | Gemini AI 分析建議功能 (#23) | `feat/23_gemini-ai-suggestions` | DRAFT | #23 |
+
+---
+
+## 📋 優先處理建議
+
+### 高優先級（影響安全或核心功能）
+1. **PR #35** - 修復 AI 工具 API 權限驗證問題
+2. **PR #26** - 修復 API Key 傳遞方式安全問題
+
+### 中優先級（使用者體驗）
+3. **PR #34** - Navbar RWD 修復
+4. **PR #31** - 時間顯示等 bug 修復
+
+### 待討論
+5. **Issue #22** - 確認延伸需求 scope
+6. **Issue #15** - 深色/淺色主題設計決策
+7. **Issue #5** - AI 管家隱私機制確認
+
+---
+
+*此文件由 Claude Code 自動生成，如需更新請重新執行 `/code-review`*

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -42,6 +42,17 @@ interface RelatedCounts {
   sessions: number;
 }
 
+interface Announcement {
+  id: string;
+  title: string;
+  content: string;
+  pinned: boolean;
+  author_id: string;
+  author_name: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -146,6 +157,13 @@ export default function AdminPanel() {
   const [deleting, setDeleting] = useState<{ user: AdminUser; relatedCounts: RelatedCounts | null; loading: boolean } | null>(null);
   const [roleConfirm, setRoleConfirm] = useState<{ user: AdminUser; role: string; action: 'add' | 'remove' } | null>(null);
 
+  // Announcements
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [announcementLoading, setAnnouncementLoading] = useState(false);
+  const [editingAnnouncement, setEditingAnnouncement] = useState<Announcement | null>(null);
+  const [deletingAnnouncement, setDeletingAnnouncement] = useState<{ id: string; title: string; loading: boolean } | null>(null);
+  const [showAnnouncementModal, setShowAnnouncementModal] = useState(false);
+
   const isAdmin = isRole('admin');
 
   const fetchData = useCallback(async () => {
@@ -153,14 +171,16 @@ export default function AdminPanel() {
     setError(null);
     try {
       const qs = includeArchived ? '?status=all&includeArchived=1' : '?status=all';
-      const [statsRes, usersRes, analyticsRes] = await Promise.all([
+      const [statsRes, usersRes, analyticsRes, announcementsRes] = await Promise.all([
         fetch('/api/admin/stats'),
         fetch(`/api/admin/users${qs}`),
         fetch('/api/admin/analytics'),
+        fetch('/api/admin/announcements'),
       ]);
       const statsData = await statsRes.json();
       const usersData = await usersRes.json();
       const analyticsData = await analyticsRes.json();
+      const announcementsData = await announcementsRes.json();
 
       if (!statsData.ok) throw new Error(statsData.error || '載入統計失敗');
       if (!usersData.ok) throw new Error(usersData.error || '載入成員失敗');
@@ -168,6 +188,7 @@ export default function AdminPanel() {
       setStats(statsData.stats);
       setUsers(usersData.users);
       if (analyticsData.ok) setAnalytics(analyticsData.analytics);
+      if (announcementsData.ok) setAnnouncements(announcementsData.announcements || []);
     } catch (err) {
       setError(err instanceof Error ? err.message : '載入失敗');
     } finally {
@@ -468,6 +489,83 @@ export default function AdminPanel() {
           <span className="text-xs opacity-70">請確認 Google Cloud Console 已啟用 Analytics Data API，且 API Key 有該 API 的使用權限。</span>
         </div>
       )}
+
+      {/* Announcements Management */}
+      <section>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+            最新公告
+          </h2>
+          <button
+            onClick={() => { setEditingAnnouncement(null); setShowAnnouncementModal(true); }}
+            className="text-sm px-3 py-1.5 rounded-lg font-medium text-white transition-opacity hover:opacity-90"
+            style={{ background: 'var(--color-primary)' }}
+          >
+            + 新增公告
+          </button>
+        </div>
+        <div
+          className="rounded-xl overflow-hidden"
+          style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
+        >
+          {announcementLoading ? (
+            <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--color-text-muted)' }}>
+              載入中...
+            </div>
+          ) : announcements.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm" style={{ color: 'var(--color-text-muted)' }}>
+              還沒有公告
+            </div>
+          ) : (
+            <div className="divide-y" style={{ borderColor: 'var(--color-border)' }}>
+              {announcements.map((a) => (
+                <div
+                  key={a.id}
+                  className="flex items-start gap-3 px-4 py-3"
+                  style={{ borderBottom: '1px solid var(--color-border)' }}
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      {a.pinned && (
+                        <span className="text-[10px] font-semibold px-2 py-0.5 rounded-full text-white" style={{ background: '#6C63FF' }}>
+                          📌 置頂
+                        </span>
+                      )}
+                      <span className="font-medium text-sm truncate" style={{ color: 'var(--color-text-primary)' }}>
+                        {a.title}
+                      </span>
+                    </div>
+                    <div className="text-xs mb-1" style={{ color: 'var(--color-text-muted)' }}>
+                      {a.author_name} · {new Date(a.created_at).toLocaleString('zh-TW')}
+                    </div>
+                    <div className="text-xs line-clamp-1" style={{ color: 'var(--color-text-secondary)' }}>
+                      {a.content}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1 shrink-0">
+                    <button
+                      onClick={() => { setEditingAnnouncement(a); setShowAnnouncementModal(true); }}
+                      className="p-2 rounded-lg text-xs transition-opacity hover:opacity-80"
+                      style={{ background: 'var(--color-bg-dark)', color: 'var(--color-text-secondary)', border: '1px solid var(--color-border)' }}
+                      title="編輯"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      onClick={() => setDeletingAnnouncement({ id: a.id, title: a.title, loading: false })}
+                      className="p-2 rounded-lg text-xs transition-opacity hover:opacity-80"
+                      style={{ background: '#E9456020', color: '#E94560', border: '1px solid #E9456040' }}
+                      title="刪除"
+                    >
+                      🗑️
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </section>
 
       {/* Pending Approvals */}
       <section>
@@ -922,6 +1020,83 @@ export default function AdminPanel() {
           </div>
         </Modal>
       )}
+
+      {/* Announcement Form Modal */}
+      {showAnnouncementModal && (
+        <Modal
+          title={editingAnnouncement ? '編輯公告' : '新增公告'}
+          onClose={() => { setShowAnnouncementModal(false); setEditingAnnouncement(null); }}
+        >
+          <AnnouncementForm
+            announcement={editingAnnouncement}
+            onSubmit={async (body) => {
+              const url = editingAnnouncement
+                ? `/api/admin/announcements/${editingAnnouncement.id}`
+                : '/api/admin/announcements';
+              const method = editingAnnouncement ? 'PUT' : 'POST';
+              const res = await fetch(url, {
+                method,
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+              });
+              const data = await res.json();
+              if (!data.ok) throw new Error(data.error || '儲存失敗');
+              setShowAnnouncementModal(false);
+              setEditingAnnouncement(null);
+              fetchData();
+            }}
+            onCancel={() => { setShowAnnouncementModal(false); setEditingAnnouncement(null); }}
+          />
+        </Modal>
+      )}
+
+      {/* Announcement Delete Confirm Modal */}
+      {deletingAnnouncement && (
+        <Modal
+          title="確認刪除公告"
+          onClose={() => setDeletingAnnouncement(null)}
+        >
+          <p className="text-sm mb-4" style={{ color: 'var(--color-text-secondary)' }}>
+            確定要刪除公告「
+            <span className="font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+              {deletingAnnouncement.title}
+            </span>
+            」嗎？此操作無法撤銷。
+          </p>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => setDeletingAnnouncement(null)}
+              className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+              style={{
+                background: 'var(--color-bg-dark)',
+                border: '1px solid var(--color-border)',
+                color: 'var(--color-text-secondary)',
+              }}
+            >
+              取消
+            </button>
+            <button
+              onClick={async () => {
+                setDeletingAnnouncement(prev => prev ? { ...prev, loading: true } : null);
+                try {
+                  const res = await fetch(`/api/admin/announcements/${deletingAnnouncement.id}`, { method: 'DELETE' });
+                  const data = await res.json();
+                  if (!data.ok) throw new Error(data.error || '刪除失敗');
+                  setDeletingAnnouncement(null);
+                  fetchData();
+                } catch (err) {
+                  alert(err instanceof Error ? err.message : '刪除失敗');
+                  setDeletingAnnouncement(null);
+                }
+              }}
+              className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90"
+              style={{ background: '#E94560' }}
+            >
+              確認刪除
+            </button>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }
@@ -1093,6 +1268,91 @@ function EditMemberForm({
         <button
           type="submit"
           disabled={submitting || !name.trim()}
+          className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          style={{ background: 'var(--color-primary)' }}
+        >
+          {submitting ? '儲存中...' : '儲存'}
+        </button>
+      </div>
+      <FormStyles />
+    </form>
+  );
+}
+
+function AnnouncementForm({
+  announcement,
+  onSubmit,
+  onCancel,
+}: {
+  announcement: Announcement | null;
+  onSubmit: (body: { title: string; content: string; pinned: boolean }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState(announcement?.title ?? '');
+  const [content, setContent] = useState(announcement?.content ?? '');
+  const [pinned, setPinned] = useState(announcement?.pinned ?? false);
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!title.trim() || !content.trim()) return;
+        setSubmitting(true);
+        try {
+          await onSubmit({ title: title.trim(), content: content.trim(), pinned });
+        } finally {
+          setSubmitting(false);
+        }
+      }}
+      className="space-y-3"
+    >
+      <FormField label="標題 *">
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="form-input"
+          placeholder="公告標題"
+        />
+      </FormField>
+      <FormField label="內容 *">
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          required
+          rows={4}
+          className="form-input resize-none"
+          placeholder="公告內容"
+        />
+      </FormField>
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={pinned}
+          onChange={(e) => setPinned(e.target.checked)}
+          className="w-4 h-4 accent-[#6C63FF]"
+        />
+        <span className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          📌 置頂公告
+        </span>
+      </label>
+      <div className="flex items-center justify-end gap-2 pt-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-4 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-90"
+          style={{
+            background: 'var(--color-bg-dark)',
+            border: '1px solid var(--color-border)',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          取消
+        </button>
+        <button
+          type="submit"
+          disabled={submitting || !title.trim() || !content.trim()}
           className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ background: 'var(--color-primary)' }}
         >

--- a/src/components/announcements/AnnouncementBanner.tsx
+++ b/src/components/announcements/AnnouncementBanner.tsx
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react';
+
+interface Announcement {
+  id: string;
+  title: string;
+  content: string;
+  pinned: boolean;
+  author_name: string | null;
+  created_at: string;
+}
+
+interface Props {
+  dismissKey?: string;
+}
+
+export default function AnnouncementBanner({ dismissKey = 'announcement-dismissed' }: Props) {
+  const [announcements, setAnnouncements] = useState<Announcement[]>([]);
+  const [dismissed, setDismissed] = useState<string[]>([]);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(dismissKey);
+    if (stored) {
+      try {
+        setDismissed(JSON.parse(stored));
+      } catch {
+        setDismissed([]);
+      }
+    }
+    fetch('/api/announcements')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.ok && data.announcements?.length > 0) {
+          setAnnouncements(data.announcements);
+          setVisible(true);
+        }
+      })
+      .catch(() => {});
+  }, [dismissKey]);
+
+  const active = announcements.filter((a) => !dismissed.includes(a.id));
+
+  if (!visible || active.length === 0) return null;
+
+  const banner = active[0];
+
+  const dismiss = () => {
+    const next = [...dismissed, banner.id];
+    setDismissed(next);
+    localStorage.setItem(dismissKey, JSON.stringify(next));
+    const remaining = announcements.filter((a) => !next.includes(a.id));
+    if (remaining.length > 0) {
+      setAnnouncements(remaining);
+    } else {
+      setVisible(false);
+    }
+  };
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl px-4 py-3 mb-6"
+      style={{
+        background: 'linear-gradient(135deg, #6C63FF20 0%, #00D9FF10 100%)',
+        border: '1px solid #6C63FF40',
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div className="shrink-0 text-xl">📢</div>
+        <div className="flex-1 min-w-0">
+          {banner.pinned && (
+            <span
+              className="text-[10px] font-semibold px-2 py-0.5 rounded-full mr-2"
+              style={{ background: '#6C63FF', color: '#fff' }}
+            >
+              📌 置頂
+            </span>
+          )}
+          <span className="font-medium text-sm" style={{ color: 'var(--color-text-primary)' }}>
+            {banner.title}
+          </span>
+          <div className="text-xs mt-1 line-clamp-2" style={{ color: 'var(--color-text-secondary)' }}>
+            {banner.content}
+          </div>
+          {banner.author_name && (
+            <div className="text-[10px] mt-1" style={{ color: 'var(--color-text-muted)' }}>
+              {banner.author_name} · {new Date(banner.created_at).toLocaleString('zh-TW')}
+            </div>
+          )}
+        </div>
+        <button
+          onClick={dismiss}
+          className="shrink-0 p-1 rounded-lg text-xs transition-opacity hover:opacity-70"
+          style={{ color: 'var(--color-text-muted)', background: 'transparent' }}
+          aria-label="關閉公告"
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,13 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260413.1',
+    date: '2026-04-13 22:20',
+    changes: [
+      'feat(#41): 最新公告系統 — 資料表 + CRUD API + 管理後台 + 首頁橫幅元件',
+    ],
+  },
+  {
     version: 'v20260412.2',
     date: '2026-04-12 18:00',
     changes: [

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import { MEMBERS, WEEKS } from '@/lib/constants';
+import AnnouncementBanner from '@/components/announcements/AnnouncementBanner.tsx';
 
 const features = [
   {
@@ -116,19 +117,7 @@ const memberCount = MEMBERS.length;
 
       <div class="space-y-4">
         <!-- Latest announcement -->
-        <div class="glass rounded-2xl p-6 border-l-4 border-[var(--color-primary)]">
-          <div class="flex items-center gap-2 mb-2">
-            <span class="text-xs text-[var(--color-text-muted)]">2026-04-10</span>
-            <span class="px-2 py-0.5 rounded text-xs font-semibold bg-[var(--color-primary)]/20 text-[var(--color-primary-light)]">重要</span>
-          </div>
-          <h3 class="text-lg font-bold text-[var(--color-text-primary)] mb-2">
-            共學團網站上線！
-          </h3>
-          <p class="text-[var(--color-text-secondary)] text-sm leading-relaxed">
-            歡迎所有成員！網站已正式上線，請先熟悉各頁面功能。4/13（一）為 W1 啟動日，
-            屆時會在啟動會議中對齊學習方向與目標。有任何問題歡迎在討論區提出！
-          </p>
-        </div>
+        <AnnouncementBanner client:load />
       </div>
     </div>
   </section>

--- a/wiki/Claude-Code-101.md
+++ b/wiki/Claude-Code-101.md
@@ -1,0 +1,148 @@
+# Claude Code 新手入門
+
+> 剛安裝好 Claude Code，不知道從哪裡開始？這篇帶你 5 分鐘上手，並瞭解 Cyclone 專案的協作慣例。
+
+---
+
+## 第一步：安裝與登入
+
+### 安裝
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+> 註：Claude Code 本身透過 npm 發布；Cyclone 專案內則統一使用 **Bun**，禁用 npm / pnpm / yarn。
+
+### 登入
+```bash
+claude
+```
+第一次啟動會要求你 **Anthropic Console 登入授權**，照著瀏覽器提示完成即可。
+
+---
+
+## 第二步：進到專案目錄
+
+Cyclone 的 repo 位於：
+```bash
+git clone https://github.com/cyclone-tw/cyclone-workflow.git
+cd cyclone-workflow
+claude
+```
+
+Claude Code 會自動讀取專案根目錄的設定檔，包括：
+- `CLAUDE.md` — Claude Code 專屬規則
+- `AGENTS.md` — 所有 AI（Claude / Codex / Gemini）共用規則
+- `.claude/` — 本地設定與記憶
+
+---
+
+## 第三步：先讀這三本「聖經」
+
+在你開始改程式碼之前，務必先瞭解這三份文件：
+
+| 文件 | 用途 | 為什麼重要 |
+|------|------|-----------|
+| [`AGENTS.md`](../AGENTS.md) | 全 AI 共用規則 | 分支命名、PR 流程、禁止直推 main、風格敏感任務誰來做 |
+| [`CLAUDE.md`](../CLAUDE.md) | Claude Code 專屬 | Changelog 維護、superpowers 使用時機、subagent 路由 |
+| [`wiki/Home.md`](Home) | Wiki 導覽 | 快速找到架構、API、資料庫、權限等文件 |
+
+### 特別注意 🚨
+- **禁止直接 `git push` 到 `main`**，所有變更必須開 branch + 發 PR
+- **風格敏感的 UI 調整**（文案、配色、微動畫）不建議丟給 subagent，由你親自下指令
+- **每次功能變更要同步更新** `src/lib/changelog.ts`
+
+---
+
+## 第四步：常用指令一覽
+
+### 基礎對話
+| 指令 | 效果 |
+|------|------|
+| `claude` | 進入目前目錄的對話模式 |
+| `claude "你的指令"` | 單次執行後退出 |
+| `/clear` | 清空對話紀錄 |
+| `/exit` | 離開 Claude Code |
+
+### 檔案與程式碼
+| 指令 | 效果 |
+|------|------|
+| 直接說「讀 `src/lib/changelog.ts`」 | Claude 會自動讀取 |
+| 直接說「修改 `Navbar.tsx` 的標題」 | Claude 會讀檔、修改、回報 diff |
+| `/commit` | 互動式產生 commit（推薦） |
+
+### Superpowers 技能（本專案常用）
+| 技能 | 何時用 |
+|------|--------|
+| `/plan` | 有 spec 要實作，先規劃再動工 |
+| `/tdd` | 寫新功能或修 bug，先寫測試 |
+| `/review-pr` | 完成一段程式碼，請 AI 幫你 review |
+| `/debug` | 遇到 bug 或測試失敗，系統化排查 |
+| `/verify` | 宣告完成前，請 AI 驗證是否達標 |
+
+---
+
+## 第五步：Cyclone 專案開發流程
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#6C63FF', 'primaryTextColor': '#fff', 'primaryBorderColor': '#6C63FF', 'lineColor': '#00D9FF', 'secondaryColor': '#16213e', 'tertiaryColor': '#1a1a2e' }}}%%
+graph LR
+    Issue["🎫 GitHub Issue"] --> Branch["🌿 開 branch\nfix/29_navbar-desktop-squeeze"]
+    Branch --> Dev["💻 開發 + 測試"]
+    Dev --> Changelog["📝 更新 changelog.ts"]
+    Changelog --> PR["🔃 發 PR Draft"]
+    PR --> Review["👀 Code Review"]
+    Review --> Merge["✅ Merge to main"]
+    Merge --> Deploy["🚀 自動部署"]
+
+    style Issue fill:#1a1a2e,stroke:#E94560,color:#fff
+    style Branch fill:#1a1a2e,stroke:#00D9FF,color:#fff
+    style Dev fill:#1a1a2e,stroke:#6C63FF,color:#fff
+    style PR fill:#1a1a2e,stroke:#4285F4,color:#fff
+    style Merge fill:#00F5A0,color:#1a1a2e
+    style Deploy fill:#6C63FF,color:#fff
+```
+
+### 流程細節
+1. **從 Issue 開始**：每個 branch 都要對應一個 issue，名稱開頭加 issue 編號（例：`fix/29_navbar-desktop-squeeze`）
+2. **開發中測試**：本地跑 `bun run build` 確認能過
+3. **更新 Changelog**：在 `src/lib/changelog.ts` 新增一筆 `ChangelogEntry`
+4. **發 PR**：先開 Draft，確認沒問題再轉 Ready for review
+5. **Code Review**：Claude Code 的 `/review-pr` 或隊友人工 review
+6. **Merge 後自動部署**：push to main 會觸發 Cloudflare Pages 自動部署
+
+---
+
+## 第六步：遇到問題怎麼辦？
+
+| 狀況 | 解決方式 |
+|------|----------|
+| 不知道某個功能在哪 | 問 Claude：「許願樹的 API 在哪裡？」 |
+| 想瞭解資料表結構 | 看 [`wiki/Database.md`](Database) 或問 Claude |
+| build 失敗 | 把錯誤訊息貼給 Claude，或跑 `/debug` |
+| 不確定某個改法對不對 | 先發 PR Draft，再跑 `/review-pr` |
+| 要備份資料庫 | `.dev.vars` 指向 prod，動 DB 前務必先備份 |
+
+---
+
+## 快速查詢表
+
+### 專案資訊
+| 項目 | 內容 |
+|------|------|
+| 技術棧 | Astro + React + TypeScript + Cloudflare Pages |
+| 資料庫 | Turso (LibSQL) |
+| 部署 | push to main → Cloudflare Pages |
+| 線上網站 | https://cyclone.tw |
+
+### 關鍵檔案
+| 檔案 | 用途 |
+|------|------|
+| `src/lib/changelog.ts` | 線上 Changelog 的資料來源 |
+| `src/lib/version.ts` | 版本號（自動更新，勿手動改） |
+| `functions/api/` | Cloudflare Pages Functions API |
+| `src/components/` | React 元件 |
+| `wiki/` | 本 Wiki 所有頁面 |
+
+---
+
+*歡迎加入 Cyclone 開發！有問題直接在 Discord 或 GitHub Issues 發問。*

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -12,6 +12,7 @@ graph TD
     Intro --> Gantt["甘特圖時程"]
     Intro --> Architecture["架構概覽"]
     Intro --> Roles["角色與權限"]
+    Intro --> Claude101["Claude Code 入門"]
 
     Dev --> API["API 文件"]
     Dev --> Database["資料庫 Schema"]
@@ -34,6 +35,7 @@ graph TD
 ## 專案文件
 
 ### 入門
+- [Claude Code 入門](Claude-Code-101) — 剛安裝好 Claude Code 必讀
 - [甘特圖時程](Gantt) — Issue 追蹤與時程規劃
 - [架構概覽](Architecture) — 技術棧、目錄結構、資料流
 - [角色與權限](Roles) — RBAC 階級與功能對應


### PR DESCRIPTION
## Summary

- 新增 `announcements` 資料庫表（標題、內容、置頂、作者、時間戳記）
- 後台 CRUD API (`/api/admin/announcements`) — 隊長/行政可管理公告
- 前台公開 API (`/api/announcements`) — 所有使用者可查看最新公告
- AdminPanel 新增「公告管理」Tab（新增/編輯/刪除/置頂）
- 前台首頁或導覽列顯示最新公告

Closes #41

## Test plan

- [ ] `announcements` 表建立成功
- [ ] 後台 CRUD API 全部可用（新增/讀取/編輯/刪除）
- [ ] AdminPanel 公告管理 Tab 功能正常
- [ ] 前台可顯示最新公告（置頂優先）
- [ ] 權限驗證：僅 admin+ 角色可管理，一般使用者只能看
- [ ] 錄製 E2E 測試影片

🤖 Generated with [Claude Code](https://claude.com/claude-code)