### PR TITLE
fix(#59): 知識庫 + AI 工具箱卡片溢出修正 + 展開/收納

### DIFF
--- a/issues-status.md
+++ b/issues-status.md
@@ -1,7 +1,7 @@
 # Cyclone Workflow Issues 狀態總覽
 
-> 更新時間：2026-04-13
-> 統計：Open 10 / Closed 16 / Total 26
+> 更新時間：2026-04-14 (v2)
+> 統計：Open 14 / Closed 25 / Total 39
 
 ---
 
@@ -9,235 +9,174 @@
 
 | 狀態 | 數量 | 說明 |
 |------|------|------|
-| 🔴 Open | 10 | 進行中或未處理 |
-| 🟢 Closed | 16 | 已完成或已解決 |
-
-| 類型 | 數量 |
-|------|------|
-| enhancement | 13 |
-| bug | 6 |
-| discussion | 7 |
-| privacy | 1 |
-| blocker | 1 |
-| research | 1 |
-| branding | 1 |
+| 🔴 Open | 14 | 進行中或未處理 |
+| 🟢 Closed | 25 | 已完成或已解決 |
 
 ---
 
-## 🔴 Open Issues (10)
+## 🔴 Open Issues (12)
 
-### #47 - feat: 留言區權限控制 — 僅登入用戶可留言（高優先權）
+### 📌 4/14 新增
+
+#### #60 - feat: 許願樹認領機制重設計 — 多人認領 / 卡片留言 / 工具箱關聯
 - **標籤**: enhancement
-- **指派**: 未指派
-- **創建**: 2026-04-13
-- **狀態**: 🔴 Open
+- **狀態**: 🔴 Open（複雜，需跨模組串接）
 
-**需求摘要**：`POST /api/messages` 需加上 `requireAuth`，未登入用戶仍可瀏覽留言，但無法發表新留言。前端表單在未登入狀態應顯示登入提示。
-
-**影響範圍**：`functions/api/messages/index.ts`、討論區前端元件
-
----
-
-### #46 - 🎉 塞老師慶功宴：要請 benben（或/和...）吃什麼？ :8crythumbsup:
-- **標籤**: discussion
-- **指派**: 未指派
-- **創建**: 2026-04-13
-- **狀態**: 🔴 Open
-
-**主題**：塞老師的慶功宴，到底要請 benben（還有其他人？）吃什麼！
-
-**候選美食**：燒肉 / 火鍋 / 吃到飽 / 高級餐廳 / 路邊攤小吃 / 其他（請留言）
-
----
-
-### #44 - feat: 每個成員有自己的資訊發佈空間（盤點 AI 服務 / 痛點回饋）
-- **標籤**: enhancement, discussion
-- **指派**: 未指派
-- **創建**: 2026-04-13
-- **狀態**: 🔴 Open
-
-**需求摘要**：提供個人發佈空間，讓成員能沉澱 AI 服務盤點、使用痛點與工作流程回饋，避免有價值經驗散落在 Discord 中。
-
-**待討論**：
-- 公開範圍（全公開 / 登入可見 / 可選）
-- 是否需要積分/成就機制鼓勵分享
-- 內容格式（自由文字 / 結構化表單）
-- 與現有「討論區 Messages」的差異定位
-
----
-
-### #2530 - 🌈Rain [生活黑客], 期待許願樹長成千年神木 :13:
-- **標籤**: enhancement
-- **指派**: 未指派
-- **創建**: 2026-04-13
-- **狀態**: 🔴 Open
-
-**備註**：來自生活黑客社群成員 🌈Rain 的許願樹功能反饋。
-
----
-
-### #30 - feat: 儀表板功能補齊 + 知識庫 / AI 工具箱 / 許願樹增強
-- **標籤**: enhancement
-- **指派**: @tboydar (Dar)
-- **創建**: 2026-04-11
-- **狀態**: 🔄 PR #35 已提交，等待 review
-
-**需求摘要**：
-| 急迫度 | 項目 | 狀態 |
-|--------|------|------|
-| **高** | AI 工具箱權限修正（陪跑員不應刪除他人投稿） | 🔄 PR #35 |
-| 中 | 儀表板知識貢獻積分 | 🔄 PR #35 |
-| 中 | 週檢核點 (W1/W2/W3 checkbox) | 🔄 PR #35 |
-| 中 | 積分榜全員顯示 | 🔄 PR #35 |
-| 中 | 知識庫成員篩選 | 🔄 PR #35 |
-| 中 | 標籤共用 | 🔄 PR #35 |
-| 中 | 工具箱投稿者顯示 | 🔄 PR #35 |
-| 中 | 許願樹歷程追蹤 | 🔄 PR #35 |
-| 低 | 愛心收藏機制 | 🔄 PR #35 |
-
-**PR**: #35 (branch: `feat/30_dashboard-enhancements`)
-**Code Review**: ✅ 已完成，發現權限驗證等問題需修復
-
----
-
-### #29 - bug: 導覽列在桌面版螢幕寬度文字被擠壓
+#### #59 - bug: 知識庫投稿內容超出卡片格子 + 需要展開/收納功能 🔴高優先
 - **標籤**: bug
-- **指派**: @tboydar (Dar)
-- **創建**: 2026-04-11
-- **狀態**: 🔄 PR #34 已提交，等待 review
-
-**問題描述**：桌面版螢幕（13吋筆電、27吋外接螢幕）導覽列文字被壓縮、重疊
-- 手機尺寸正常
-- 問題在中間寬度區段（1280px-1440px）
-
-**PR**: #34 (branch: `fix/29_navbar-desktop-squeeze`)
-**Code Review**: ✅ 已完成，建議考慮 2xl 斷點優化
+- **狀態**: 🔴 Open（影響所有使用者閱讀體驗）
 
 ---
 
-### #23 - feat: Google Analytics 顯示與分析後台 + AI 建議功能
-- **標籤**: enhancement
-- **指派**: 未指派
-- **創建**: 2026-04-11
-- **狀態**: 🔄 PR #26 DRAFT
+### 📌 4/13 會後需求（meeting:20260413）
 
-**需求**：
-1. GA4 數據顯示後台（DAU、MAU、跳出率、停留時間、流量來源）
-2. Gemini AI 分析建議
-3. 用量檢查機制（quota 滿時顯示提示）
+#### #54 - docs: 新手引導 — Git 版控 / Claude Code / SDD 流程
+- **標籤**: documentation
+- **狀態**: 🔄 進行中（wiki/Claude-Code-101.md 已建立，cyclone-tw 已確認先做 Wiki）
 
-**備註**：不急，等核心功能穩定後再處理
-
-**PR**: #26 (branch: `feat/23_gemini-ai-suggestions`)
-**Code Review**: ✅ 已完成，發現 API Key 傳遞方式等安全問題
-
----
-
-### #22 - fix: OAuth 登入產生重複帳號 + 隊長 Email UNIQUE 衝突
-- **標籤**: bug, enhancement
-- **指派**: 未指派
-- **創建**: 2026-04-10
-- **狀態**: 🔄 主問題已修復，延伸需求待評估
-
-**已修復**：
-- ✅ 重複帳號問題（使用 substring name matching）
-- ✅ 隊長 email 更新
-
-**延伸需求**（來自 @cyclone-tw）：
-- [ ] 新用戶預設為「訪客/待審核」而非直接給陪跑員身份
-- [ ] 後台加入刪除成員功能
-- [ ] 後台修改成員顯示名稱（email 除外）
-
----
-
-### #15 - feat: 支援深色 / 淺色雙主題切換 (dark / light mode)
+#### #53 - feat: 共學示範 / 教學許願子系統
 - **標籤**: enhancement, discussion
-- **指派**: 未指派
-- **創建**: 2026-04-09
-- **狀態**: 💬 討論中，子 issue #16 已關閉
+- **狀態**: 🔴 Open（cyclone-tw 確認先 MVP：category 欄位 + filter）
 
-**待決定事項**：
-1. 預設模式：dark / light / 跟隨系統？
-2. 切換 UX：按鈕位置、是否有「跟隨系統」選項
-3. 持久化：localStorage / cookie / 不記憶
-4. 品牌一致性：light mode 是否保留霓虹元素？
-5. 實作範圍：全站一次到位或先做首頁？
+#### #52 - fix: Bug 回報表單稽核 + 後端串接 + 圖片上傳
+- **標籤**: bug, enhancement
+- **狀態**: 🔴 Open（cyclone-tw 確認先做 Phase 0 稽核，圖片上傳不做）
 
-**相關**: #16（首頁 demo 已完成）
+#### #51 - feat: 討論區管理增強 — 留言刪除 / 管理員 / 成果分類 / Markdown
+- **標籤**: enhancement
+- **狀態**: 🔄 PR #58 DRAFT（E1+E2+E4 完成，cyclone-tw 已確認）
+
+#### #50 - feat: 後台動態化 — 標籤管理 + 團隊成員頁 [Mega]
+- **標籤**: enhancement
+- **狀態**: 🔴 Open（涵蓋已關閉的 #61 需求）
+
+#### #49 - feat: 個人儀表板 + 積分系統全面實作 [Mega]
+- **標籤**: enhancement
+- **狀態**: 🔴 Open（cyclone-tw 已確認 Phase 分期 + 積分規則）
 
 ---
 
-### #5 - 🔒 隱私與成員資料公開：同意機制與資料安全盤點
+### 📌 功能需求
+
+#### #44 - feat: 每個成員有自己的資訊發佈空間（盤點 AI 服務 / 痛點回饋）
+- **標籤**: enhancement
+- **創建**: 2026-04-13
+- **狀態**: 🔴 Open
+
+#### #23 - feat: Google Analytics 顯示與分析後台 + AI 建議功能
+- **標籤**: enhancement
+- **創建**: 2026-04-11
+- **狀態**: 🔄 PR #26 DRAFT（有 API Key 安全問題待修）
+
+#### #15 - feat: 支援深色 / 淺色雙主題切換 (dark / light mode)
+- **標籤**: enhancement, discussion
+- **創建**: 2026-04-09
+- **狀態**: 🔄 PR #39 DRAFT
+
+---
+
+### 📌 社群反饋
+
+#### #43 - 🌈Rain #2530 [生活黑客], 期待許願樹長成千年神木 :13:
+- **創建**: 2026-04-13
+- **狀態**: 🔴 Open
+
+#### #46 - 🎉 塞老師慶功宴：要請 Dar 大吃什麼？ 🤔
+- **創建**: 2026-04-13
+- **狀態**: 🔴 Open
+
+---
+
+### 📌 隱私 / 安全
+
+#### #5 - 🔒 隱私與成員資料公開：同意機制與資料安全盤點
 - **標籤**: discussion, privacy, blocker
 - **指派**: @cyclone-tw
 - **創建**: 2026-04-08
-- **狀態**: 💬 大部分已確認，待確認 AI 管家隔離機制
-
-**已確認**：
-- ✅ 表單已加入公開同意確認
-- ✅ Discord 編號已移除，只保留暱稱
-- ✅ Repo 已設為 public，成員詳細資料僅後台可見
-- ✅ 資料最小化原則同意
-
-**待確認**：
-- [ ] AI 管家對話隔離機制（技術確認中）
-- [ ] Letta 資料保留政策
+- **狀態**: 🔄 PR #40 DRAFT，大部分已確認
 
 ---
 
-## 🟢 Closed Issues (16)
+## 🟢 Closed Issues (25)
 
-| # | 標題 | 標籤 | 關閉時間 |
-|---|------|------|----------|
-| #28 | feat: 管理後台增強 — 角色確認、成員管理、顯示名稱修改 | enhancement | 2026-04-11 |
-| #27 | bug: 多項功能異常回報（時間顯示、討論區、Issues 頁面） | bug | 2026-04-11 |
-| #21 | [Fontend] 導行列 RWD 問題 | bug | 2026-04-11 |
-| #20 | [Bug] Google 登入問題 | bug | 2026-04-11 |
-| #18 | feat: 4/9 討論會後需求整理 — cyclone.tw 網站全面改版規劃 | enhancement | 2026-04-10 |
-| #17 | Cyclone 需求清單（討論記錄） | | 2026-04-10 |
-| #16 | feat(theme): 首頁 dark/light 切換 demo | enhancement | 2026-04-11 |
-| #14 | feat: AI Agent 工具知識卡片頁面 (CRUD) | | 2026-04-10 |
-| #12 | [同步] 讓 main branch 自動跟 Cloudflare Pages 同步 | | 2026-04-11 |
-| #10 | feat: ChatBox agent reply markdown rendering support | enhancement | 2026-04-08 |
-| #9 | 🌍 全球 AI 共學專案研究：參考靈感與社群模式 | research | 2026-04-10 |
-| #8 | 🏘️ 生活黑客社群關係釐清：品牌定位與用詞確認 | discussion, branding | 2026-04-10 |
-| #7 | 📊 進度追蹤、時間管理與習慣養成機制設計 | enhancement, discussion | 2026-04-10 |
-| #6 | 📝 CMS 與 Notion 整合評估：讓非技術成員也能更新內容 | enhancement, discussion | 2026-04-11 |
-| #4 | ❓ 內容更新前需確認：缺少資料清單 | | 2026-04-11 |
-| #3 | docs: 全面更新專案用詞與網站內容 | | 2026-04-10 |
-| #1 | feat: Tauri 桌面版應用程式 (macOS/Windows/Linux) | | 2026-04-08 |
+| # | 標題 | 標籤 | PR | 關閉時間 |
+|---|------|------|-----|----------|
+| #61 | feat: 後台成員管理 — 刪除/停用/改名/審核機制 | enhancement | (涵蓋於 #50) | 2026-04-14 |
+| #55 | docs: 共學團啟動會議記錄 + 需求追蹤 | documentation | #56 | 2026-04-13 |
+| #47 | feat: 留言區權限控制 — 僅登入用戶可留言 | | #48 | 2026-04-14 |
+| #41 | feat: 最新公告系統 — 後台管理 + 前台顯示 | enhancement | #42, #45 | 2026-04-13 |
+| #36 | docs: 導入 AGENTS.md 架構 | documentation | #37 | 2026-04-12 |
+| #30 | feat: 儀表板功能補齊 + 知識庫/AI工具/許願樹 | enhancement | #35 | 2026-04-12 |
+| #29 | bug: 導覽列桌面版文字擠壓 | bug | #34 | 2026-04-12 |
+| #28 | feat: 管理後台增強 — 角色/成員/顯示名稱 | enhancement | #32 | 2026-04-11 |
+| #27 | bug: 多項功能異常（時間/討論區/Issues） | bug | #33 | 2026-04-11 |
+| #22 | fix: OAuth 重複帳號 + Email UNIQUE | bug | #57 | 2026-04-13 |
+| #21 | [Frontend] 導列 RWD 問題 | bug | #24 | 2026-04-11 |
+| #20 | [Bug] Google 登入問題 | bug | | 2026-04-11 |
+| #18 | feat: 4/9 會後需求 — 全面改版規劃 | enhancement | #19 | 2026-04-10 |
+| #17 | Cyclone 需求清單（討論記錄） | | | 2026-04-10 |
+| #16 | feat(theme): 首頁 dark/light demo | enhancement | | 2026-04-11 |
+| #14 | feat: AI Agent 工具知識卡片 CRUD | | | 2026-04-10 |
+| #12 | [同步] main 自動跟 Cloudflare Pages 同步 | | #13 | 2026-04-11 |
+| #10 | feat: ChatBox markdown rendering | enhancement | #11 | 2026-04-08 |
+| #9 | 全球 AI 共學專案研究 | research | | 2026-04-09 |
+| #8 | 生活黑客社群關係釐清 | discussion, branding | | 2026-04-09 |
+| #7 | 進度追蹤/時間管理/習慣養成 | enhancement, discussion | | 2026-04-09 |
+| #6 | CMS 與 Notion 整合評估 | enhancement, discussion | | 2026-04-11 |
+| #4 | 內容更新前缺少資料清單 | | | 2026-04-11 |
+| #3 | docs: 全面更新專案用詞與內容 | | | 2026-04-10 |
+| #1 | feat: Tauri 桌面版應用程式 | | | 2026-04-08 |
 
 ---
 
-## 🔗 相關 PR 狀態
+## 🔗 PR 狀態
 
-| PR | 標題 | Branch | 狀態 | 關聯 Issue |
-|---|------|--------|------|-----------|
-| #35 | 儀表板/知識庫/AI工具/願望清單功能增強 | `feat/30_dashboard-enhancements` | DRAFT | #30 |
-| #34 | 修復 Navbar 桌面版文字擠壓問題 | `fix/29_navbar-desktop-squeeze` | DRAFT | #29 |
-| #31 | 多項功能異常修復（時間顯示、討論區、Issues 頁面） | `copilot/fix-wishlist-time-display` | DRAFT | - |
-| #26 | Gemini AI 分析建議功能 (#23) | `feat/23_gemini-ai-suggestions` | DRAFT | #23 |
+### Open Draft PRs
+
+| PR | 標題 | Branch | 關聯 Issue |
+|---|------|--------|-----------|
+| #58 | 討論區管理增強 — 刪除/Markdown/author_id | `feat/51_discussion-management` | #51 |
+| #40 | 隱私同意機制與資料安全盤點 | `feat/5_privacy-consent` | #5 |
+| #39 | 深色/淺色主題切換 | `feat/15_dark-light-theme` | #15 |
+| #38 | OAuth 重複帳號長期修復 | `fix/22_oauth-duplicate-accounts` | #22 |
+| #26 | Gemini AI 分析建議功能 | `feat/23_gemini-ai-suggestions` | #23 |
+
+### Recently Merged
+
+| PR | 標題 | 關聯 Issue |
+|---|------|-----------|
+| #57 | fix(#22): OAuth 登入重複帳號 + Email UNIQUE 衝突 | #22 |
+| #56 | docs(#55): 共學團啟動會議記錄 + 需求追蹤 | #55 |
+| #48 | feat(#47): 留言區權限控制 — 僅登入用戶可留言 | #47 |
+| #45 | test(#41): 公告系統 unit/integration/E2E 測試 | #41 |
+| #42 | feat(#41): 最新公告系統 — 後台管理 + 前台顯示 | #41 |
+| #35 | feat(#30): 儀表板/知識庫/AI工具/願望清單功能增強 | #30 |
+| #34 | fix(#29): 修復 Navbar 桌面版文字擠壓問題 | #29 |
 
 ---
 
 ## 📋 優先處理建議
 
-### 高優先級（影響安全或核心功能）
-1. **Issue #47** - 留言區改為僅登入可留言
-2. **PR #35** - 修復 AI 工具 API 權限驗證問題
-3. **PR #26** - 修復 API Key 傳遞方式安全問題
+### 高優先級
+1. **Issue #59** - 知識庫卡片溢出 bug + 展開/收納功能 🔴
+2. **PR #58** - 討論區管理增強 review + merge
+3. **Issue #54** - 新手引導 wiki（進行中 → MiniMax）
+4. **Issue #52** - Bug 回報表單稽核 Phase 0
+5. **PR #26** - 修復 API Key 安全問題
 
-### 中優先級（使用者體驗）
-3. **PR #34** - Navbar RWD 修復
-4. **PR #31** - 時間顯示等 bug 修復
+### 中優先級
+6. **Issue #49** - 個人儀表板 + 積分系統 [Mega]
+7. **Issue #50** - 後台動態化 [Mega]（涵蓋 #61）
+8. **Issue #60** - 許願樹認領機制重設計（複雜）
+9. **PR #39** - 深色/淺色主題 review
+10. **PR #40** - 隱私同意機制 review
 
 ### 待討論
-5. **Issue #46** - 塞老師慶功宴吃什麼（最優先 🍖）
-6. **Issue #44** - 成員個人資訊發佈空間設計
-7. **Issue #22** - 確認延伸需求 scope
-8. **Issue #15** - 深色/淺色主題設計決策
-9. **Issue #5** - AI 管家隱私機制確認
+9. **Issue #53** - 共學示範 / 教學許願子系統
+10. **Issue #44** - 成員個人資訊發佈空間
+11. **Issue #5** - AI 管家隱私機制確認
+12. **Issue #46** - 塞老師慶功宴吃什麼 🍖
 
 ---
 
-*此文件由 Claude Code 自動生成，如需更新請重新執行 `/code-review`*
+*此文件由 Claude Code 自動同步，資料來源：GitHub Issues API*

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { MEMBERS } from '@/lib/constants';
@@ -317,6 +317,17 @@ function DeleteConfirm({ tool, onConfirm, onCancel }: { tool: Tool; onConfirm: (
 function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite }: { tool: Tool; canEdit: boolean; loggedIn: boolean; onEdit: () => void; onDelete: () => void; onToggleFavorite: () => void }) {
   const cfg = CATEGORY_CONFIG[tool.category] || CATEGORY_CONFIG.other;
   const [favBusy, setFavBusy] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    if (contentRef.current) {
+      setIsOverflowing(contentRef.current.scrollHeight > contentRef.current.clientHeight);
+    }
+  }, []);
+
+  useEffect(() => { checkOverflow(); }, [tool.description, checkOverflow]);
 
   async function handleFavorite() {
     setFavBusy(true);
@@ -330,7 +341,7 @@ function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite 
         border: '1px solid #2A2A4A', borderRadius: '0.875rem',
         padding: '1.25rem', display: 'flex', flexDirection: 'column', gap: '0.75rem',
         transition: 'transform 0.2s, box-shadow 0.2s',
-        cursor: 'default',
+        cursor: 'default', overflow: 'hidden',
       }}
       onMouseEnter={e => {
         e.currentTarget.style.transform = 'translateY(-2px)';
@@ -402,9 +413,39 @@ function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite 
       </h3>
 
       {/* Description */}
-      <p style={{ color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0, flex: 1 }}>
-        {tool.description}
-      </p>
+      <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
+        <p
+          ref={contentRef}
+          style={{
+            color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0,
+            overflowWrap: 'anywhere', wordBreak: 'break-word',
+            ...(expanded ? {} : { maxHeight: '4.8em', overflow: 'hidden' }),
+          }}
+        >
+          {tool.description}
+        </p>
+        {(!expanded && isOverflowing) && (
+          <div
+            style={{
+              position: 'absolute', bottom: 0, left: 0, right: 0, height: '1.6em',
+              background: 'linear-gradient(transparent, rgba(18,18,42,0.9))',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+      </div>
+      {(isOverflowing || expanded) && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          style={{
+            fontSize: '0.75rem', color: cfg.color, background: 'transparent',
+            border: 'none', cursor: 'pointer', padding: '0.2rem 0',
+            alignSelf: 'flex-start',
+          }}
+        >
+          {expanded ? '收納 ↑' : '展開更多 ↓'}
+        </button>
+      )}
 
       {/* URL link */}
       {(() => {

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -416,6 +416,7 @@ function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite 
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
         <p
           ref={contentRef}
+          id={`tool-content-${tool.id}`}
           style={{
             color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0,
             overflowWrap: 'anywhere', wordBreak: 'break-word',
@@ -437,6 +438,8 @@ function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite 
       {(isOverflowing || expanded) && (
         <button
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-controls={`tool-content-${tool.id}`}
           style={{
             fontSize: '0.75rem', color: cfg.color, background: 'transparent',
             border: 'none', cursor: 'pointer', padding: '0.2rem 0',

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -487,6 +487,7 @@ function EntryCard({
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
         <p
           ref={contentRef}
+          id={`knowledge-content-${entry.id}`}
           style={{
             color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0,
             overflowWrap: 'anywhere', wordBreak: 'break-word',
@@ -508,6 +509,8 @@ function EntryCard({
       {(isOverflowing || expanded) && (
         <button
           onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          aria-controls={`knowledge-content-${entry.id}`}
           style={{
             fontSize: '0.75rem', color: cfg.color, background: 'transparent',
             border: 'none', cursor: 'pointer', padding: '0.2rem 0',

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { MEMBERS } from '@/lib/constants';
@@ -380,6 +380,17 @@ function EntryCard({
 }) {
   const cfg = CATEGORY_CONFIG[entry.category] || CATEGORY_CONFIG.other;
   const [favBusy, setFavBusy] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    if (contentRef.current) {
+      setIsOverflowing(contentRef.current.scrollHeight > contentRef.current.clientHeight);
+    }
+  }, []);
+
+  useEffect(() => { checkOverflow(); }, [entry.content, checkOverflow]);
 
   async function handleFavorite() {
     setFavBusy(true);
@@ -394,7 +405,7 @@ function EntryCard({
         borderRadius: '0.875rem',
         padding: '1.25rem', display: 'flex', flexDirection: 'column', gap: '0.75rem',
         transition: 'transform 0.2s, box-shadow 0.2s',
-        cursor: 'default',
+        cursor: 'default', overflow: 'hidden',
       }}
       onMouseEnter={(e) => {
         e.currentTarget.style.transform = 'translateY(-2px)';
@@ -473,9 +484,39 @@ function EntryCard({
       </h3>
 
       {/* Content */}
-      <p style={{ color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0, flex: 1 }}>
-        {entry.content}
-      </p>
+      <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
+        <p
+          ref={contentRef}
+          style={{
+            color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0,
+            overflowWrap: 'anywhere', wordBreak: 'break-word',
+            ...(expanded ? {} : { maxHeight: '4.8em', overflow: 'hidden' }),
+          }}
+        >
+          {entry.content}
+        </p>
+        {(!expanded && isOverflowing) && (
+          <div
+            style={{
+              position: 'absolute', bottom: 0, left: 0, right: 0, height: '1.6em',
+              background: 'linear-gradient(transparent, rgba(18,18,42,0.9))',
+              pointerEvents: 'none',
+            }}
+          />
+        )}
+      </div>
+      {(isOverflowing || expanded) && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          style={{
+            fontSize: '0.75rem', color: cfg.color, background: 'transparent',
+            border: 'none', cursor: 'pointer', padding: '0.2rem 0',
+            alignSelf: 'flex-start',
+          }}
+        >
+          {expanded ? '收納 ↑' : '展開更多 ↓'}
+        </button>
+      )}
 
       {/* Tags */}
       {entry.tags.length > 0 && (

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-14 21:30',
+    changes: [
+      'fix(#59): 知識庫 + AI 工具箱卡片內容溢出修正 — overflowWrap/break-word + 展開/收納功能',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-14 01:05',
     changes: [
       'fix(#22): OAuth callback 隊長帳號仍排除於 name matching（安全），但 email exact match 可正確配對',


### PR DESCRIPTION
## Summary

- 修正知識庫和 AI 工具箱長文字內容超出卡片邊界的排版 bug
- 新增展開/收納功能：預設顯示 3 行摘要，點擊「展開更多 ↓」查看全文
- 收納狀態加漸層遮罩，視覺提示還有更多內容
- 卡片容器加 `overflow: hidden` 防止任何殘留溢出

## 影響範圍

- `src/components/knowledge/KnowledgeBoard.tsx` — EntryCard 元件
- `src/components/ai-tools/ToolCardBoard.tsx` — ToolCard 元件
- 兩者使用完全相同的展開/收納模式

## 測試方式

1. 到 `/knowledge` 或 `/ai-tools` 頁面
2. 找一則內容較長的投稿（超過 3 行）
3. 確認：卡片只顯示 3 行 + 底部漸層遮罩 + 「展開更多 ↓」按鈕
4. 點擊按鈕 → 完整內容展開 → 按鈕變成「收納 ↑」
5. 確認長 URL / 連續英文字不會撐破卡片

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)