### PR TITLE
feat(#53): 許願樹分類重設計 — personal/feature/teaching + filter

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -153,7 +153,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           id TEXT PRIMARY KEY,
           title TEXT NOT NULL,
           description TEXT NOT NULL,
-          category TEXT DEFAULT 'personal' CHECK(category IN ('personal', 'site')),
+          category TEXT DEFAULT 'personal' CHECK(category IN ('personal', 'feature', 'teaching')),
           status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'claimed', 'in-progress', 'completed')),
           wisher_id TEXT NOT NULL REFERENCES users(id),
           claimer_id TEXT REFERENCES users(id),
@@ -212,6 +212,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE users ADD COLUMN archived_at TEXT`, note: 'users.archived_at' },
       { sql: `ALTER TABLE messages ADD COLUMN author_id TEXT REFERENCES users(id)`, note: 'messages.author_id' },
     ];
+
+    // --- Migrate wish categories: site → feature ---
+    try {
+      await db.execute({ sql: `UPDATE wishes SET category = 'feature' WHERE category = 'site'`, args: [] });
+    } catch { /* no rows or already migrated */ }
+
     for (const m of migrations) {
       try { await db.execute({ sql: m.sql, args: [] }); } catch { /* column already exists */ }
     }

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -218,7 +218,7 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
 
     if (body.title !== undefined) { updates.push('title = ?'); args.push(body.title.trim()); }
     if (body.description !== undefined) { updates.push('description = ?'); args.push(body.description.trim()); }
-    if (body.category !== undefined && ['personal', 'site'].includes(body.category)) {
+    if (body.category !== undefined && ['personal', 'feature', 'teaching'].includes(body.category)) {
       updates.push('category = ?'); args.push(body.category);
     }
     if (body.icon !== undefined) { updates.push('icon = ?'); args.push(body.icon.trim()); }

--- a/functions/api/wishes/index.ts
+++ b/functions/api/wishes/index.ts
@@ -40,7 +40,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const conditions: string[] = [];
     const args: string[] = [];
 
-    if (category && ['personal', 'site'].includes(category)) {
+    if (category && ['personal', 'feature', 'teaching'].includes(category)) {
       conditions.push('w.category = ?');
       args.push(category);
     }
@@ -147,7 +147,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     const title = (body.title || '').trim();
     const description = (body.description || '').trim();
-    const category = body.category === 'site' ? 'site' : 'personal';
+    const category = ['personal', 'feature', 'teaching'].includes(body.category || '') ? body.category as string : 'personal';
     const icon = (body.icon || '✨').trim();
 
     if (!title) {

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -4,7 +4,7 @@ import { timeAgo } from '@/lib/time';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-type WishCategory = 'personal' | 'site';
+type WishCategory = 'personal' | 'feature' | 'teaching';
 type WishStatus = 'pending' | 'claimed' | 'in-progress' | 'completed';
 
 interface WishUser {
@@ -44,9 +44,10 @@ const STATUS_CONFIG: Record<WishStatus, { label: string; color: string; borderCo
   completed:   { label: '已完成',   color: '#00F5A0', borderColor: 'rgba(0,245,160,0.25)', badgeBg: 'rgba(0,245,160,0.15)', badgeText: '#00F5A0' },
 };
 
-const CATEGORY_CONFIG: Record<WishCategory, { label: string }> = {
-  personal: { label: '個人需求' },
-  site:     { label: '網站功能' },
+const CATEGORY_CONFIG: Record<WishCategory, { label: string; color: string }> = {
+  personal: { label: '個人需求', color: '#00F5A0' },
+  feature:  { label: '功能建議', color: '#6C63FF' },
+  teaching: { label: '教學許願', color: '#00D9FF' },
 };
 
 const ICON_OPTIONS = ['✨', '🔨', '📚', '💡', '🎯', '🚀', '🎨', '🔧', '📝', '🌟', '💬', '⚡', '🐛', '🔒', '📊', '🎮'];
@@ -54,7 +55,8 @@ const ICON_OPTIONS = ['✨', '🔨', '📚', '💡', '🎯', '🚀', '🎨', '�
 const FILTER_CATEGORIES = [
   { value: '', label: '全部' },
   { value: 'personal', label: '個人需求' },
-  { value: 'site', label: '網站功能' },
+  { value: 'feature', label: '功能建議' },
+  { value: 'teaching', label: '教學許願' },
 ];
 
 const FILTER_STATUSES = [
@@ -235,7 +237,7 @@ function CreateWishModal({ onClose, onCreated }: { onClose: () => void; onCreate
         <div style={{ marginBottom: '1rem' }}>
           <label style={labelStyle}>類別</label>
           <div style={{ display: 'flex', gap: 8 }}>
-            {(['personal', 'site'] as WishCategory[]).map((cat) => (
+            {(['personal', 'feature', 'teaching'] as WishCategory[]).map((cat) => (
               <button
                 key={cat}
                 onClick={() => setCategory(cat)}
@@ -420,8 +422,8 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
               fontSize: '0.7rem',
               padding: '0.1rem 0.4rem',
               borderRadius: '9999px',
-              background: wish.category === 'site' ? 'rgba(0,217,255,0.15)' : 'rgba(108,99,255,0.15)',
-              color: wish.category === 'site' ? '#00D9FF' : '#9B93FF',
+              background: `${(CATEGORY_CONFIG[wish.category] || CATEGORY_CONFIG.personal).color}15`,
+              color: (CATEGORY_CONFIG[wish.category] || CATEGORY_CONFIG.personal).color,
               whiteSpace: 'nowrap',
             }}
           >

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-14 22:15',
+    changes: [
+      'feat(#53): 許願樹分類重設計 — 個人需求/功能建議/教學許願 + 前端 filter + site→feature 遷移',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-14 20:40',
     changes: [
       'feat(#51): 討論區管理增強 — 留言刪除功能（作者/管理員）、Markdown 渲染、author_id schema 遷移',


### PR DESCRIPTION
## Summary
- 許願樹 category 從 `personal | site` 改為 `personal | feature | teaching`
- 前端 filter 同步更新，CATEGORY_CONFIG 加入 color
- DB schema CHECK 約束更新 + 舊 `site` 資料自動 migration → `feature`
- API GET/POST/PATCH 驗證規則全部同步

## cyclone-tw 確認
- MVP：加 category 欄位 + filter
- 其餘（mentor tag、排定時間、錄影連結）暫緩

## Test plan
- [ ] 建立新願望可選三種分類
- [ ] 分類 filter 正常篩選
- [ ] 舊 site 類別願望顯示為「功能建議」
- [ ] Edit 願望可切換分類

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)