### PR TITLE
feat(#49): 積分系統 Phase 1 — points_ledger + API + 打卡計分 + 儀表板

### DIFF
--- a/functions/api/checkin/index.ts
+++ b/functions/api/checkin/index.ts
@@ -99,6 +99,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     });
 
     const alreadyCheckedIn = result.rowsAffected === 0;
+
+    // 寫入積分明細（僅首次打卡）
+    if (!alreadyCheckedIn) {
+      await db.execute({
+        sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, ?, ?)`,
+        args: [crypto.randomUUID(), user.id, 'checkin', 10, 'checkin', id],
+      });
+    }
+
     const streak = await calculateStreak(db, user.id);
 
     return new Response(

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -198,6 +198,18 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+      {
+        sql: `CREATE TABLE IF NOT EXISTS points_ledger (
+          id TEXT PRIMARY KEY,
+          user_id TEXT NOT NULL REFERENCES users(id),
+          action TEXT NOT NULL,
+          points INTEGER NOT NULL,
+          ref_type TEXT,
+          ref_id TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
+        )`,
+        args: [],
+      },
     ]);
 
     // --- Migrations: add missing columns to existing tables ---

--- a/functions/api/points/leaderboard.ts
+++ b/functions/api/points/leaderboard.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@libsql/client/web';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/points/leaderboard — 積分排行榜（公開，不需登入）
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const db = createClient({
+      url: context.env.TURSO_DATABASE_URL,
+      authToken: context.env.TURSO_AUTH_TOKEN,
+    });
+
+    const url = new URL(context.request.url);
+    const limitParam = url.searchParams.get('limit');
+    const limit = Math.min(Math.max(Number(limitParam || 20), 1), 100);
+
+    const result = await db.execute({
+      sql: `
+        SELECT
+          p.user_id,
+          u.name AS user_name,
+          u.avatar_url,
+          COALESCE(SUM(p.points), 0) AS total_points,
+          COUNT(p.id) AS total_records
+        FROM points_ledger p
+        JOIN users u ON u.id = p.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        GROUP BY p.user_id
+        ORDER BY total_points DESC
+        LIMIT ?
+      `,
+      args: [limit],
+    });
+
+    const leaderboard = result.rows.map((r) => ({
+      user_id: r.user_id as string,
+      user_name: (r.user_name as string) ?? '',
+      avatar_url: r.avatar_url as string | null,
+      total_points: Number(r.total_points),
+      total_records: Number(r.total_records),
+    }));
+
+    return new Response(
+      JSON.stringify({ ok: true, leaderboard }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/functions/api/points/me.ts
+++ b/functions/api/points/me.ts
@@ -1,0 +1,61 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/points/me — 查詢自己的積分記錄與總分
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const db = createClient({
+      url: context.env.TURSO_DATABASE_URL,
+      authToken: context.env.TURSO_AUTH_TOKEN,
+    });
+
+    const url = new URL(context.request.url);
+    const limitParam = url.searchParams.get('limit');
+    const limit = Math.min(Math.max(Number(limitParam || 20), 1), 100);
+
+    const [recordsResult, totalResult] = await Promise.all([
+      db.execute({
+        sql: `SELECT id, action, points, ref_type, ref_id, created_at FROM points_ledger WHERE user_id = ? ORDER BY created_at DESC LIMIT ?`,
+        args: [user.id, limit],
+      }),
+      db.execute({
+        sql: `SELECT COALESCE(SUM(points), 0) AS totalPoints FROM points_ledger WHERE user_id = ?`,
+        args: [user.id],
+      }),
+    ]);
+
+    const totalPoints = Number(totalResult.rows[0]?.totalPoints ?? 0);
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        totalPoints,
+        records: recordsResult.rows.map((r) => ({
+          id: r.id,
+          action: r.action,
+          points: r.points,
+          refType: r.ref_type,
+          refId: r.ref_id,
+          createdAt: r.created_at,
+        })),
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const message = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(
+      JSON.stringify({ ok: false, error: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+};

--- a/issues/49-points-system/findings.md
+++ b/issues/49-points-system/findings.md
@@ -1,0 +1,16 @@
+# Issue #49 — 研究發現與決策記錄
+
+## 決策記錄
+
+1. **points_ledger 作為單一積分來源**
+   - 既有 `checkins.points` 欄位保留不動，未來 leaderboard 可逐步遷移到 `points_ledger`，但 Phase 1 不強制遷移，避免影響現有排行榜邏輯。
+
+2. **ref_type / ref_id 設計**
+   - `ref_type` 用來標記積分來源類型（如 `checkin`、`knowledge`、`wish`），`ref_id` 則指向該來源的具體記錄 ID，方便除錯與未來撤銷積分。
+
+3. **DashboardPanel 積分顯示策略**
+   - 不改動既有 stats grid，而是在下方新增「最近積分」獨立區塊，減少對原有 UI 的衝擊，也讓用戶能看到積分明細。
+
+## 問題 / 假設
+
+- 暫無。

--- a/issues/49-points-system/progress.md
+++ b/issues/49-points-system/progress.md
@@ -1,0 +1,18 @@
+# Issue #49 — 進度日誌
+
+## 2026-04-14
+
+### 已完成
+
+- 建立 `points_ledger` 資料表並更新 `functions/api/db/init.ts`
+- 建立 `functions/api/points/me.ts`（支援 `?limit=`）
+- 建立 `functions/api/points/leaderboard.ts`（公開排行榜，支援 `?limit=`）
+- 修改 `functions/api/checkin/index.ts`，打卡成功後自動插入 `action='checkin', points=10`
+- 修改 `src/components/dashboard/DashboardPanel.tsx`，新增「最近積分」區塊（顯示最近 5 筆）
+- 更新 `src/lib/changelog.ts`
+
+### 交棒筆記
+
+- 當前 branch: `feat-49-points-system`（worktree 路徑已切換至此）
+- 待驗證: `bun run build` 與 `bun run test:e2e`
+- 待完成: 建立 PR draft 並附 E2E 錄影/截圖

--- a/issues/49-points-system/task_plan.md
+++ b/issues/49-points-system/task_plan.md
@@ -1,0 +1,39 @@
+# Issue #49 — 積分系統核心（Phase 1）
+
+## 背景
+
+目前打卡、知識投稿、AI 工具投稿、許願樹等行為都已上線，但缺少統一的積分追蹤機制。Phase 1 要建立核心資料表與 API，並在打卡時自動發放積分。
+
+## 目標
+
+1. 建立 `points_ledger` 資料表，作為統一積分流水帳。
+2. 提供 `GET /api/points/me`（個人積分與明細）與 `GET /api/points/leaderboard`（積分排行榜）。
+3. 打卡成功時自動寫入 `+10` 分到 `points_ledger`。
+4. 在 Dashboard 顯示最近積分記錄。
+5. 維護 `src/lib/changelog.ts`。
+
+## 積分規則（Phase 1）
+
+| 行為 | 積分 |
+|------|------|
+| 每日打卡 | +10 |
+| 知識投稿 | +20 |
+| AI 工具投稿 | +20 |
+| 許願 | +5 |
+| 認領 | +10 |
+| 完成 | +30 |
+
+> 本 PR 僅實作打卡自動發放，其餘行為在後續 Phase 接入。
+
+## Checklist
+
+- [x] 建立 `points_ledger` 資料表（schema 已定義）
+- [x] 在 `/api/db/init.ts` 加入 `CREATE TABLE`
+- [x] 建立 `/api/points/me` API
+- [x] 建立 `/api/points/leaderboard` API
+- [x] 在 `/api/checkin` POST 中打卡成功後寫入 `+10` 分
+- [x] `DashboardPanel.tsx` 加入「最近積分」顯示區塊
+- [x] 更新 `src/lib/changelog.ts`
+- [x] `bun run build` 通過
+- [x] `bun run test:e2e` — 3 failed / 1 flaky 均為既有問題（homepage title 不含 Cyclone、messages-auth 登入按鈕 strict violation、issue-27 GitHub API flaky），非本次修改造成
+- [ ] PR draft 建立並附 E2E 錄影/截圖

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -12,6 +12,20 @@ interface CheckinStats {
   knowledgeCount: number;
 }
 
+interface PointRecord {
+  id: string;
+  action: string;
+  points: number;
+  refType: string | null;
+  refId: string | null;
+  createdAt: string;
+}
+
+interface PointsData {
+  totalPoints: number;
+  records: PointRecord[];
+}
+
 const ROLE_BADGE_COLORS: Record<GroupRole, string> = {
   captain: '#6C63FF',
   tech: '#00D9FF',
@@ -42,6 +56,8 @@ export default function DashboardPanel() {
   const { user, loading: authLoading, login } = useAuth();
   const [stats, setStats] = useState<CheckinStats | null>(null);
   const [statsLoading, setStatsLoading] = useState(true);
+  const [pointsData, setPointsData] = useState<PointsData | null>(null);
+  const [pointsLoading, setPointsLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
   const [checkedInToday, setCheckedInToday] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -50,10 +66,13 @@ export default function DashboardPanel() {
   useEffect(() => {
     if (!user) {
       setStatsLoading(false);
+      setPointsLoading(false);
       return;
     }
     let cancelled = false;
     setStatsLoading(true);
+    setPointsLoading(true);
+
     fetch('/api/checkin/stats')
       .then((r) => r.json())
       .then((data) => {
@@ -67,6 +86,20 @@ export default function DashboardPanel() {
       .finally(() => {
         if (!cancelled) setStatsLoading(false);
       });
+
+    fetch('/api/points/me?limit=5')
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data.ok) {
+          setPointsData({ totalPoints: data.totalPoints, records: data.records });
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setPointsLoading(false);
+      });
+
     return () => { cancelled = true; };
   }, [user]);
 
@@ -333,6 +366,48 @@ export default function DashboardPanel() {
           </div>
         </div>
       )}
+
+      {/* Recent Points */}
+      <div className="glass rounded-2xl border border-[var(--color-border)] p-5">
+        <h2 className="text-base font-bold text-[var(--color-text-primary)] mb-4 flex items-center gap-2">
+          <span className="text-lg">⭐</span> 最近積分
+        </h2>
+        {pointsLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-10 animate-pulse rounded bg-[var(--color-overlay-neutral-strong)]" />
+            ))}
+          </div>
+        ) : pointsData && pointsData.records.length > 0 ? (
+          <div className="space-y-2">
+            {pointsData.records.map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center justify-between rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-surface)]/40 px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-lg">
+                    {r.action === 'checkin' ? '🔥' : r.action === 'knowledge' ? '📚' : r.action === 'ai-tool' ? '🛠️' : r.action === 'wish' ? '✨' : r.action === 'claim' ? '🎯' : r.action === 'complete' ? '🏆' : '⭐'}
+                  </span>
+                  <div>
+                    <div className="text-sm font-medium text-[var(--color-text-primary)]">
+                      {r.action === 'checkin' ? '每日打卡' : r.action === 'knowledge' ? '知識投稿' : r.action === 'ai-tool' ? 'AI 工具投稿' : r.action === 'wish' ? '許願' : r.action === 'claim' ? '認領任務' : r.action === 'complete' ? '完成任務' : r.action}
+                    </div>
+                    <div className="text-xs text-[var(--color-text-muted)]">
+                      {new Date(r.createdAt).toLocaleString('zh-TW')}
+                    </div>
+                  </div>
+                </div>
+                <span className="text-sm font-bold text-[var(--color-neon-green)]">+{r.points}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-sm text-[var(--color-text-secondary)]">
+            還沒有積分記錄，趕快打卡或投稿來賺取積分吧！
+          </div>
+        )}
+      </div>
 
       {/* Weekly Checkpoints */}
       {WEEKS.length > 0 && (

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,15 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260414.1135',
+    date: '2026-04-14 22:45',
+    changes: [
+      'feat(#49): Phase 1 — 積分系統核心（points_ledger 資料表 + /api/points/me + /api/points/leaderboard）',
+      'feat(#49): 打卡成功自動寫入 +10 積分到 points_ledger',
+      'feat(#49): DashboardPanel 新增「最近積分」區塊，顯示最近 5 筆積分記錄',
+    ],
+  },
+  {
     version: '',
     date: '2026-04-14 22:20',
     changes: [


### PR DESCRIPTION
## Summary

Issue #49 Phase 1 — 積分系統核心實作：

- 建立 `points_ledger` 資料表（`functions/api/db/init.ts`）
- 新增 `/api/points/me`（個人積分與明細）與 `/api/points/leaderboard`（公開排行榜）
- 打卡成功後自動寫入 `+10` 積分到 `points_ledger`（`functions/api/checkin/index.ts`）
- `DashboardPanel.tsx` 新增「最近積分」區塊，顯示最近 5 筆積分記錄
- 更新 `src/lib/changelog.ts` 與 `issues/49-points-system/` 文件

## Test plan

- [ ] 本地 `bun run build` 無 TypeScript 錯誤
- [ ] 部署後打卡成功，檢查 `points_ledger` 有 +10 記錄
- [ ] 儀表板「最近積分」正確顯示明細
- [ ] `/api/points/leaderboard` 公開排行榜正常運作

Closes #49