### PR TITLE
feat(#60): 許願樹認領重設計 — 後端 API

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -211,6 +211,27 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+      {
+        sql: `CREATE TABLE IF NOT EXISTS wish_claimers (
+          id TEXT PRIMARY KEY,
+          wish_id TEXT NOT NULL REFERENCES wishes(id),
+          user_id TEXT NOT NULL REFERENCES users(id),
+          status TEXT DEFAULT 'claimed' CHECK(status IN ('claimed','completed')),
+          created_at TEXT DEFAULT (datetime('now')),
+          UNIQUE(wish_id, user_id)
+        )`,
+        args: [],
+      },
+      {
+        sql: `CREATE TABLE IF NOT EXISTS wish_comments (
+          id TEXT PRIMARY KEY,
+          wish_id TEXT NOT NULL REFERENCES wishes(id),
+          author_id TEXT NOT NULL REFERENCES users(id),
+          content TEXT NOT NULL,
+          created_at TEXT DEFAULT (datetime('now'))
+        )`,
+        args: [],
+      },
     ]);
 
     // --- Migrations: add missing columns to existing tables ---
@@ -226,6 +247,16 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE messages ADD COLUMN author_id TEXT REFERENCES users(id)`, note: 'messages.author_id' },
       { sql: `ALTER TABLE tags ADD COLUMN sort_order INTEGER DEFAULT 0`, note: 'tags.sort_order' },
     ];
+
+    // --- Migrate legacy wish.claimer_id → wish_claimers ---
+    try {
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO wish_claimers (id, wish_id, user_id, status)
+              SELECT lower(hex(randomblob(16))), id, claimer_id, 'claimed'
+              FROM wishes WHERE claimer_id IS NOT NULL AND claimer_id != ''`,
+        args: [],
+      });
+    } catch { /* no legacy claimers to migrate */ }
 
     // --- Migrate wish categories: site → feature ---
     try {

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -80,6 +80,31 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     }
 
     const r = result.rows[0];
+
+    // Fetch claimers
+    const claimersResult = await db.execute({
+      sql: `
+        SELECT wc.status, u.id, u.name, u.avatar_url
+        FROM wish_claimers wc
+        JOIN users u ON u.id = wc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        WHERE wc.wish_id = ?
+      `,
+      args: [id],
+    });
+    const claimers = claimersResult.rows.map((c) => ({
+      id: c.id as string,
+      name: c.name as string,
+      avatarUrl: c.avatar_url as string | null,
+      status: c.status as string,
+    }));
+
+    // Fetch comments count
+    const commentsCountResult = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM wish_comments WHERE wish_id = ?`,
+      args: [id],
+    });
+    const comments_count = Number(commentsCountResult.rows[0]?.cnt ?? 0);
+
     const wish = {
       id: r.id,
       title: r.title,
@@ -95,9 +120,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         name: r.wisher_name,
         avatarUrl: r.wisher_avatar,
       },
-      claimer: r.claimer_id
-        ? { id: r.claimer_id, name: r.claimer_name, avatarUrl: r.claimer_avatar }
-        : null,
+      claimers,
+      comments_count,
     };
 
     return new Response(JSON.stringify({ ok: true, wish }), {
@@ -154,19 +178,79 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
           headers: { 'Content-Type': 'application/json' },
         });
       }
-      if (wish.status !== 'pending') {
-        return new Response(JSON.stringify({ ok: false, error: '此願望無法被認領' }), {
+      if (wish.status !== 'pending' && wish.status !== 'claimed') {
+        return new Response(JSON.stringify({ ok: false, error: '此願望目前無法被認領' }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' },
         });
       }
 
+      // Insert into wish_claimers (idempotent — UNIQUE prevents duplicates)
+      const claimId = crypto.randomUUID();
       await db.execute({
-        sql: `UPDATE wishes SET claimer_id = ?, status = 'claimed', updated_at = datetime('now') WHERE id = ?`,
-        args: [user.id, id],
+        sql: `INSERT OR IGNORE INTO wish_claimers (id, wish_id, user_id, status) VALUES (?, ?, ?, 'claimed')`,
+        args: [claimId, id, user.id],
+      });
+
+      // Update wish status to claimed if it was pending
+      if (wish.status === 'pending') {
+        await db.execute({
+          sql: `UPDATE wishes SET status = 'claimed', updated_at = datetime('now') WHERE id = ?`,
+          args: [id],
+        });
+        await ensureWishHistoryMigration(db);
+        await recordStatusChange(db, id, 'pending', 'claimed', user.id);
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // ── Complete action ──────────────────────────────────────────────────
+    if (body.action === 'complete') {
+      const wishRow = wish;
+      // Only wisher or admin+ can mark as completed
+      const canComplete = wishRow.wisher_id === user.id || isAdminOrAbove(user);
+      if (!canComplete) {
+        return new Response(JSON.stringify({ ok: false, error: '權限不足，只有許願者或管理員可確認完成' }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (wishRow.status === 'completed') {
+        return new Response(JSON.stringify({ ok: false, error: '此願望已經完成' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Mark all claimers as completed
+      await db.execute({
+        sql: `UPDATE wish_claimers SET status = 'completed' WHERE wish_id = ? AND status = 'claimed'`,
+        args: [id],
+      });
+
+      // Update wish status
+      await db.execute({
+        sql: `UPDATE wishes SET status = 'completed', updated_at = datetime('now') WHERE id = ?`,
+        args: [id],
       });
       await ensureWishHistoryMigration(db);
-      await recordStatusChange(db, id, 'pending', 'claimed', user.id);
+      await recordStatusChange(db, id, wishRow.status as string, 'completed', user.id);
+
+      // Award points to all claimers (+100 each)
+      const claimersResult = await db.execute({
+        sql: `SELECT user_id FROM wish_claimers WHERE wish_id = ? AND status = 'completed'`,
+        args: [id],
+      });
+      for (const row of claimersResult.rows) {
+        const ledgerId = crypto.randomUUID();
+        await db.execute({
+          sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, 'wish_completed', 100, 'wish', ?)`,
+          args: [ledgerId, row.user_id as string, id],
+        });
+      }
 
       return new Response(JSON.stringify({ ok: true }), {
         headers: { 'Content-Type': 'application/json' },

--- a/functions/api/wishes/[id]/comments.ts
+++ b/functions/api/wishes/[id]/comments.ts
@@ -1,0 +1,95 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// GET /api/wishes/:id/comments
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const wishId = context.params.id as string;
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `
+        SELECT wc.id, wc.content, wc.created_at,
+               u.id AS author_id, u.name AS author_name, u.avatar_url AS author_avatar
+        FROM wish_comments wc
+        JOIN users u ON u.id = wc.author_id AND u.archived_at IS NULL AND u.status = 'active'
+        WHERE wc.wish_id = ?
+        ORDER BY wc.created_at ASC
+      `,
+      args: [wishId],
+    });
+
+    const comments = result.rows.map((r) => ({
+      id: r.id,
+      content: r.content,
+      created_at: r.created_at,
+      author: {
+        id: r.author_id,
+        name: r.author_name,
+        avatarUrl: r.author_avatar,
+      },
+    }));
+
+    return new Response(JSON.stringify({ ok: true, comments }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+// POST /api/wishes/:id/comments
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const wishId = context.params.id as string;
+    const db = getDb(context.env);
+
+    // Verify wish exists
+    const wishResult = await db.execute({
+      sql: 'SELECT id FROM wishes WHERE id = ?',
+      args: [wishId],
+    });
+    if (!wishResult.rows.length) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到此願望' }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const body = (await context.request.json()) as { content?: string };
+    const content = (body.content || '').trim();
+    if (!content) {
+      return new Response(JSON.stringify({ ok: false, error: '請填寫留言內容' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const id = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO wish_comments (id, wish_id, author_id, content) VALUES (?, ?, ?, ?)`,
+      args: [id, wishId, user.id, content],
+    });
+
+    return new Response(JSON.stringify({ ok: true, id }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/wishes/index.ts
+++ b/functions/api/wishes/index.ts
@@ -58,13 +58,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           w.created_at, w.updated_at,
           wisher.id AS wisher_id,
           wisher.name AS wisher_name,
-          wisher.avatar_url AS wisher_avatar,
-          claimer.id AS claimer_id,
-          claimer.name AS claimer_name,
-          claimer.avatar_url AS claimer_avatar
+          wisher.avatar_url AS wisher_avatar
         FROM wishes w
         JOIN users wisher ON wisher.id = w.wisher_id AND wisher.archived_at IS NULL AND wisher.status = 'active'
-        LEFT JOIN users claimer ON claimer.id = w.claimer_id AND claimer.archived_at IS NULL AND claimer.status = 'active'
         ${where}
         ORDER BY w.created_at DESC
       `,
@@ -86,9 +82,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         name: r.wisher_name,
         avatarUrl: r.wisher_avatar,
       },
-      claimer: r.claimer_id
-        ? { id: r.claimer_id, name: r.claimer_name, avatarUrl: r.claimer_avatar }
-        : null,
+      claimers: [] as { id: string; name: string; avatarUrl: string | null; status: string }[],
+      comments_count: 0,
       history: [] as { from_status: string; to_status: string; changed_by: string; created_at: string }[],
     }));
 
@@ -112,6 +107,45 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
             changed_by: h.changed_by as string,
             created_at: h.created_at as string,
           });
+        }
+      }
+    }
+
+    // Fetch claimers for all wishes
+    if (wishes.length > 0) {
+      const wishIds = wishes.map((w) => w.id as string);
+      const placeholders = wishIds.map(() => '?').join(',');
+      const claimersResult = await db.execute({
+        sql: `
+          SELECT wc.wish_id, wc.status, u.id, u.name, u.avatar_url
+          FROM wish_claimers wc
+          JOIN users u ON u.id = wc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+          WHERE wc.wish_id IN (${placeholders})
+        `,
+        args: wishIds,
+      });
+      const wishMap = new Map(wishes.map((w) => [w.id as string, w]));
+      for (const c of claimersResult.rows) {
+        const wish = wishMap.get(c.wish_id as string);
+        if (wish) {
+          wish.claimers.push({
+            id: c.id as string,
+            name: c.name as string,
+            avatarUrl: c.avatar_url as string | null,
+            status: c.status as string,
+          });
+        }
+      }
+
+      // Fetch comments count
+      const commentsResult = await db.execute({
+        sql: `SELECT wish_id, COUNT(*) AS cnt FROM wish_comments WHERE wish_id IN (${placeholders}) GROUP BY wish_id`,
+        args: wishIds,
+      });
+      for (const c of commentsResult.rows) {
+        const wish = wishMap.get(c.wish_id as string);
+        if (wish) {
+          wish.comments_count = Number(c.cnt);
         }
       }
     }

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -13,6 +13,22 @@ interface WishUser {
   avatarUrl: string | null;
 }
 
+interface WishClaimer {
+  id: string;
+  name: string;
+  avatarUrl: string | null;
+  status: 'claimed' | 'completed';
+}
+
+interface WishComment {
+  id: string;
+  author_id: string;
+  author_name: string;
+  author_avatar: string | null;
+  content: string;
+  created_at: string;
+}
+
 interface WishHistoryEntry {
   from_status: string;
   to_status: string;
@@ -31,8 +47,10 @@ interface Wish {
   createdAt: string;
   updatedAt: string;
   wisher: WishUser;
-  claimer: WishUser | null;
+  claimers: WishClaimer[];
   history: WishHistoryEntry[];
+  comments?: WishComment[];
+  comments_count?: number;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -349,22 +367,64 @@ function DeleteConfirmModal({ wish, onClose, onDeleted }: { wish: Wish; onClose:
   );
 }
 
+// ─── ClaimerBadge ──────────────────────────────────────────────────────────────
+
+function ClaimerBadge({ status }: { status: 'claimed' | 'completed' }) {
+  if (status === 'completed') {
+    return (
+      <span style={{
+        fontSize: '0.6rem',
+        fontWeight: 700,
+        padding: '0.05rem 0.35rem',
+        borderRadius: '9999px',
+        background: 'rgba(255,193,7,0.2)',
+        color: '#FFC107',
+        border: '1px solid rgba(255,193,7,0.4)',
+        whiteSpace: 'nowrap',
+      }}>
+        已完成
+      </span>
+    );
+  }
+  return (
+    <span style={{
+      fontSize: '0.6rem',
+      fontWeight: 700,
+      padding: '0.05rem 0.35rem',
+      borderRadius: '9999px',
+      background: 'rgba(0,245,160,0.15)',
+      color: '#00F5A0',
+      border: '1px solid rgba(0,245,160,0.3)',
+      whiteSpace: 'nowrap',
+    }}>
+      認領中
+    </span>
+  );
+}
+
 // ─── WishCard ──────────────────────────────────────────────────────────────────
 
 function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: ReturnType<typeof useAuth>['user']; onRefresh: () => void; onDelete: (wish: Wish) => void }) {
   const [actionLoading, setActionLoading] = useState(false);
+  const [commentsOpen, setCommentsOpen] = useState(false);
+  const [comments, setComments] = useState<WishComment[]>(wish.comments || []);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentContent, setCommentContent] = useState('');
+  const [commentSubmitting, setCommentSubmitting] = useState(false);
+
   const cfg = STATUS_CONFIG[wish.status];
   const isCompleted = wish.status === 'completed';
   const isWisher = user?.id === wish.wisher.id;
-  const isClaimer = user?.id === wish.claimer?.id;
   const isAdminUser = user && ['captain', 'tech', 'admin'].includes(user.effectiveRole);
+  const isClaimer = wish.claimers.some(c => c.id === user?.id);
+  const hasClaimers = wish.claimers.length > 0;
+  const activeClaimers = wish.claimers.filter(c => c.status === 'claimed');
 
-  const handleAction = async (action: string) => {
+  const handleAction = async (action: string, claimerId?: string) => {
     setActionLoading(true);
     try {
-      const body: Record<string, string> = {};
-      if (action === 'claim') body.action = 'claim';
-      else if (action === 'in-progress' || action === 'completed') body.status = action;
+      const body: Record<string, string> = { action };
+      if (claimerId) body.claimer_id = claimerId;
 
       const res = await fetch(`/api/wishes/${wish.id}`, {
         method: 'PATCH',
@@ -376,6 +436,49 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
     } catch { /* ignore */ }
     setActionLoading(false);
   };
+
+  const loadComments = async () => {
+    if (comments.length > 0) return;
+    setCommentsLoading(true);
+    try {
+      const res = await fetch(`/api/wishes/${wish.id}/comments`);
+      const data = await res.json();
+      if (data.ok) setComments(data.comments || []);
+    } catch { /* ignore */ }
+    setCommentsLoading(false);
+  };
+
+  const toggleComments = () => {
+    if (!commentsOpen) loadComments();
+    setCommentsOpen(!commentsOpen);
+  };
+
+  const submitComment = async () => {
+    if (!commentContent.trim() || !user) return;
+    setCommentSubmitting(true);
+    try {
+      const res = await fetch(`/api/wishes/${wish.id}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: commentContent.trim() }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setCommentContent('');
+        if (data.comment) {
+          setComments(prev => [data.comment, ...prev]);
+        } else {
+          const reloadRes = await fetch(`/api/wishes/${wish.id}/comments`);
+          const reloadData = await reloadRes.json();
+          if (reloadData.ok) setComments(reloadData.comments || []);
+        }
+      }
+    } catch { /* ignore */ }
+    setCommentSubmitting(false);
+  };
+
+  const visibleClaimers = wish.claimers.slice(0, 3);
+  const hiddenClaimerCount = wish.claimers.length - 3;
 
   return (
     <div
@@ -451,27 +554,64 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
         {wish.description}
       </p>
 
-      {/* Footer */}
+      {/* Footer: Wisher */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: '0.5rem', borderTop: '1px solid rgba(108,99,255,0.1)' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.8rem', color: '#9090B0' }}>
           <Avatar name={wish.wisher.name} avatarUrl={wish.wisher.avatarUrl} size={22} />
           <span>{wish.wisher.name}</span>
         </div>
-        {wish.claimer && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: '0.8rem' }}>
-            <span style={{ color: cfg.color, fontWeight: 500 }}>
-              {isCompleted ? '由' : '認領者'}
-            </span>
-            <Avatar name={wish.claimer.name} avatarUrl={wish.claimer.avatarUrl} size={22} />
-            <span style={{ color: cfg.color, fontWeight: 500 }}>{wish.claimer.name}</span>
-          </div>
-        )}
       </div>
+
+      {/* Claimers Section */}
+      {hasClaimers && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '0.5rem', background: 'rgba(10,10,26,0.4)', borderRadius: '0.5rem', border: '1px solid rgba(108,99,255,0.1)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <div style={{ fontSize: '0.7rem', color: '#606080', fontWeight: 600 }}>認領者</div>
+            <a
+              href="/ai-tools"
+              style={{
+                fontSize: '0.7rem',
+                color: '#00D9FF',
+                textDecoration: 'none',
+                fontWeight: 600,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 2,
+              }}
+            >
+              🛠️ 投稿到工具箱
+            </a>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {wish.claimers.map((claimer) => (
+              <div key={claimer.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <Avatar name={claimer.name} avatarUrl={claimer.avatarUrl} size={24} />
+                <span style={{ fontSize: '0.8rem', color: '#F0F0FF', fontWeight: 500 }}>{claimer.name}</span>
+                <ClaimerBadge status={claimer.status} />
+              </div>
+            ))}
+          </div>
+          {visibleClaimers.length < wish.claimers.length && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                {visibleClaimers.map((c, i) => (
+                  <div key={c.id} style={{ marginLeft: i > 0 ? -8 : 0, border: '2px solid rgba(10,10,26,0.6)', borderRadius: '50%' }}>
+                    <Avatar name={c.name} avatarUrl={c.avatarUrl} size={22} />
+                  </div>
+                ))}
+              </div>
+              {hiddenClaimerCount > 0 && (
+                <span style={{ fontSize: '0.7rem', color: '#9090B0', fontWeight: 500 }}>+{hiddenClaimerCount}</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {/* Action buttons */}
       {user && !isCompleted && (
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {wish.status === 'pending' && !isWisher && (
+          {wish.status === 'pending' && !isWisher && !isClaimer && (
             <button
               onClick={() => handleAction('claim')}
               disabled={actionLoading}
@@ -504,9 +644,9 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
               {actionLoading ? '處理中...' : '🔨 開始實作'}
             </button>
           )}
-          {(wish.status === 'in-progress') && (isClaimer || isAdminUser) && (
+          {(wish.status === 'in-progress' || wish.status === 'claimed') && activeClaimers.length > 0 && (isWisher || isAdminUser) && (
             <button
-              onClick={() => handleAction('completed')}
+              onClick={() => handleAction('complete')}
               disabled={actionLoading}
               style={{
                 ...neonBtnStyle,
@@ -515,7 +655,7 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
                 opacity: actionLoading ? 0.6 : 1,
               }}
             >
-              {actionLoading ? '處理中...' : '✅ 完成'}
+              {actionLoading ? '處理中...' : '✅ 完成確認'}
             </button>
           )}
         </div>
@@ -550,6 +690,103 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
           })}
         </div>
       )}
+
+      {/* Comments Section */}
+      <div style={{ marginTop: '0.25rem' }}>
+        <button
+          onClick={toggleComments}
+          style={{
+            width: '100%',
+            textAlign: 'left',
+            padding: '0.5rem 0.625rem',
+            background: 'rgba(10,10,26,0.3)',
+            border: '1px solid rgba(108,99,255,0.1)',
+            borderRadius: '0.5rem',
+            color: '#9090B0',
+            fontSize: '0.75rem',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span>💬 留言 {typeof wish.comments_count === 'number' ? `(${wish.comments_count})` : `(${comments.length})`}</span>
+          <span style={{ transform: commentsOpen ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>▼</span>
+        </button>
+
+        {commentsOpen && (
+          <div style={{
+            marginTop: '0.5rem',
+            padding: '0.75rem',
+            background: 'rgba(10,10,26,0.3)',
+            borderRadius: '0.5rem',
+            border: '1px solid rgba(108,99,255,0.1)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.75rem',
+          }}>
+            {commentsLoading ? (
+              <div style={{ fontSize: '0.8rem', color: '#606080' }}>載入留言中...</div>
+            ) : comments.length === 0 ? (
+              <div style={{ fontSize: '0.8rem', color: '#606080' }}>尚無留言，來發表第一則吧！</div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+                {comments.map((c) => (
+                  <div key={c.id} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                    <Avatar name={c.author_name} avatarUrl={c.author_avatar} size={24} />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+                        <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#F0F0FF' }}>{c.author_name}</span>
+                        <span style={{ fontSize: '0.65rem', color: '#505070' }}>{timeAgo(c.created_at)}</span>
+                      </div>
+                      <div style={{ fontSize: '0.85rem', color: '#B8B0FF', lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {c.content}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {user && (
+              <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                <Avatar name={user.name} avatarUrl={user.avatar_url} size={28} />
+                <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  <textarea
+                    value={commentContent}
+                    onChange={(e) => setCommentContent(e.target.value)}
+                    placeholder="發表留言..."
+                    rows={2}
+                    style={{ ...inputStyle, resize: 'vertical', fontSize: '0.85rem', padding: '0.5rem 0.75rem' }}
+                    onFocus={handleFocusIn}
+                    onBlur={handleFocusOut}
+                    maxLength={500}
+                  />
+                  <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <button
+                      onClick={submitComment}
+                      disabled={commentSubmitting || !commentContent.trim()}
+                      style={{
+                        fontSize: '0.8rem',
+                        padding: '0.4rem 1rem',
+                        borderRadius: '0.5rem',
+                        border: 'none',
+                        background: commentContent.trim() ? '#6C63FF' : '#2A2A4A',
+                        color: '#fff',
+                        cursor: commentContent.trim() ? 'pointer' : 'not-allowed',
+                        fontWeight: 600,
+                        opacity: commentSubmitting ? 0.6 : 1,
+                      }}
+                    >
+                      {commentSubmitting ? '發送中...' : '發送'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -677,7 +914,7 @@ export default function WishBoard() {
           <p style={{ color: '#9090B0' }}>目前還沒有願望，成為第一個許願的人吧！</p>
         </div>
       ) : (
-        <div style={{ display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}>
+        <div style={{ display: 'grid', gap: 16, gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}>
           {wishes.map((wish) => (
             <WishCard key={wish.id} wish={wish} user={user} onRefresh={fetchWishes} onDelete={(w) => setDeleteTarget(w)} />
           ))}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,16 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260414.1145',
+    date: '2026-04-14 23:45',
+    changes: [
+      'feat(#60): 許願樹認領重設計 — wish_claimers 表（多人認領）+ wish_comments 表（留言）+ 完整 CRUD API',
+      'feat(#60): PATCH /api/wishes/:id 新增 "claim"（多人認領）+ "complete"（完成確認 + 獎勵 +100 積分）',
+      'feat(#60): GET /api/wishes 及 GET /api/wishes/:id 回傳 claimers[] + comments_count',
+      'feat(#60): 遷移 legacy wishes.claimer_id → wish_claimers（INSERT OR IGNORE 防重複）',
+    ],
+  },
+  {
     version: 'v20260414.1135',
     date: '2026-04-14 22:45',
     changes: [

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,15 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260414.1451',
+    date: '2026-04-14 23:55',
+    changes: [
+      'feat(#60): WishBoard 前端重設計 — 多人認領頭像列表、認領者 claimed/completed badge、完成確認按鈕',
+      'feat(#60): 許願卡片新增留言區塊（展開/收納 + 輸入框 + 即時提交）',
+      'feat(#60): 認領者區塊新增「投稿到工具箱」連結按鈕',
+    ],
+  },
+  {
     version: 'v20260414.1145',
     date: '2026-04-14 23:45',
     changes: [
@@ -32,6 +41,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     ],
   },
   {
+    version: '',
     date: '2026-04-14 22:20',
     changes: [
       'fix(#52): Bug 回報表單串接後端 — 提交到 /api/issues + 成功後顯示追蹤連結',


### PR DESCRIPTION
## Summary
- 新增 `wish_claimers` 表（多人認領）+ `wish_comments` 表（留言）
- PATCH `/api/wishes/:id` 新增 `claim`（多人認領）+ `complete`（完成確認 + 獎勵 +100 積分）
- GET `/api/wishes` 及 GET `/api/wishes/:id` 回傳 `claimers[]` + `comments_count`
- 遷移 legacy `wishes.claimer_id` → `wish_claimers`（INSERT OR IGNORE 防重複）

## Test plan
- [ ] 測試多人認領同一願望（claim action）
- [ ] 測試完成確認（complete action）— 確認者獲 +100 積分
- [ ] 測試留言新增與取得（GET/POST comments）
- [ ] 確認 GET /api/wishes 回傳正確 claimers 陣列
- [ ] 確認 GET /api/wishes/:id 回傳正確 claimers + comments_count
- [ ] 確認 legacy claimer_id 遷移正常

🤖 Generated with [Claude Code](https://claude.ai/code)