### PR TITLE
fix(#69): 公告系統前台修正 — 移除 X 按鈕 + 多則顯示 + 換行 + 字體放大

### DIFF
--- a/src/components/announcements/AnnouncementBanner.tsx
+++ b/src/components/announcements/AnnouncementBanner.tsx
@@ -9,93 +9,73 @@ interface Announcement {
   created_at: string;
 }
 
-interface Props {
-  dismissKey?: string;
-}
+const MAX_VISIBLE = 3;
 
-export default function AnnouncementBanner({ dismissKey = 'announcement-dismissed' }: Props) {
+export default function AnnouncementBanner() {
   const [announcements, setAnnouncements] = useState<Announcement[]>([]);
-  const [dismissed, setDismissed] = useState<string[]>([]);
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(dismissKey);
-    if (stored) {
-      try {
-        setDismissed(JSON.parse(stored));
-      } catch {
-        setDismissed([]);
-      }
-    }
     fetch('/api/announcements')
       .then((r) => r.json())
       .then((data) => {
         if (data.ok && data.announcements?.length > 0) {
-          setAnnouncements(data.announcements);
+          setAnnouncements(data.announcements.slice(0, MAX_VISIBLE));
           setVisible(true);
         }
       })
       .catch(() => {});
-  }, [dismissKey]);
+  }, []);
 
-  const active = announcements.filter((a) => !dismissed.includes(a.id));
-
-  if (!visible || active.length === 0) return null;
-
-  const banner = active[0];
-
-  const dismiss = () => {
-    const next = [...dismissed, banner.id];
-    setDismissed(next);
-    localStorage.setItem(dismissKey, JSON.stringify(next));
-    const remaining = announcements.filter((a) => !next.includes(a.id));
-    if (remaining.length > 0) {
-      setAnnouncements(remaining);
-    } else {
-      setVisible(false);
-    }
-  };
+  if (!visible || announcements.length === 0) return null;
 
   return (
-    <div
-      className="relative overflow-hidden rounded-xl px-4 py-3 mb-6"
-      style={{
-        background: 'linear-gradient(135deg, #6C63FF20 0%, #00D9FF10 100%)',
-        border: '1px solid #6C63FF40',
-      }}
-    >
-      <div className="flex items-start gap-3">
-        <div className="shrink-0 text-xl">📢</div>
-        <div className="flex-1 min-w-0">
-          {banner.pinned && (
-            <span
-              className="text-[10px] font-semibold px-2 py-0.5 rounded-full mr-2"
-              style={{ background: '#6C63FF', color: '#fff' }}
-            >
-              📌 置頂
-            </span>
-          )}
-          <span className="font-medium text-sm" style={{ color: 'var(--color-text-primary)' }}>
-            {banner.title}
-          </span>
-          <div className="text-xs mt-1 line-clamp-2" style={{ color: 'var(--color-text-secondary)' }}>
-            {banner.content}
-          </div>
-          {banner.author_name && (
-            <div className="text-[10px] mt-1" style={{ color: 'var(--color-text-muted)' }}>
-              {banner.author_name} · {new Date(banner.created_at).toLocaleString('zh-TW')}
-            </div>
-          )}
-        </div>
-        <button
-          onClick={dismiss}
-          className="shrink-0 p-1 rounded-lg text-xs transition-opacity hover:opacity-70"
-          style={{ color: 'var(--color-text-muted)', background: 'transparent' }}
-          aria-label="關閉公告"
+    <div className="mb-6 space-y-2">
+      {announcements.map((a) => (
+        <div
+          key={a.id}
+          className="relative overflow-hidden rounded-xl px-4 py-3"
+          style={{
+            background: 'linear-gradient(135deg, #6C63FF20 0%, #00D9FF10 100%)',
+            border: '1px solid #6C63FF40',
+          }}
         >
-          ✕
-        </button>
-      </div>
+          <div className="flex items-start gap-3">
+            <div className="shrink-0 text-xl">📢</div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 flex-wrap">
+                {a.pinned && (
+                  <span
+                    className="text-[10px] font-semibold px-2 py-0.5 rounded-full"
+                    style={{ background: '#6C63FF', color: '#fff' }}
+                  >
+                    📌 置頂
+                  </span>
+                )}
+                <span className="font-medium" style={{ color: 'var(--color-text-primary)', fontSize: '0.95rem' }}>
+                  {a.title}
+                </span>
+              </div>
+              <div
+                className="mt-1"
+                style={{
+                  color: 'var(--color-text-secondary)',
+                  fontSize: '0.85rem',
+                  whiteSpace: 'pre-line',
+                  lineHeight: 1.5,
+                }}
+              >
+                {a.content}
+              </div>
+              {a.author_name && (
+                <div className="text-[10px] mt-1" style={{ color: 'var(--color-text-muted)' }}>
+                  {a.author_name} · {new Date(a.created_at).toLocaleString('zh-TW')}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,13 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: '',
+    date: '2026-04-15 00:15',
+    changes: [
+      'fix(#69): 公告系統前台修正 — 移除 X 按鈕、顯示 3 則公告、支援換行、字體放大',
+    ],
+  },
+  {
     version: 'v20260414.1451',
     date: '2026-04-14 23:55',
     changes: [


### PR DESCRIPTION
## Summary
- 移除前台公告 X 關閉按鈕 + localStorage dismiss 機制（公告管理交後台）
- 改為顯示最近 3 則公告（列表形式，原本只顯示 1 則）
- 內容支援換行（white-space: pre-line）
- 標題字體 0.95rem、內文 0.85rem

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)