### PR TITLE
fix(#78): DB migration 補全 + members SQL 修正

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -144,6 +144,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
           icon TEXT DEFAULT '📘',
           contributor_id TEXT NOT NULL REFERENCES users(id),
           upvotes INTEGER DEFAULT 0,
+          url TEXT DEFAULT '',
           created_at TEXT DEFAULT (datetime('now')),
           updated_at TEXT DEFAULT (datetime('now'))
         )`,
@@ -253,6 +254,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE users ADD COLUMN emoji TEXT DEFAULT ''`, note: 'users.emoji' },
       { sql: `ALTER TABLE users ADD COLUMN color TEXT DEFAULT '#6C63FF'`, note: 'users.color' },
       { sql: `ALTER TABLE users ADD COLUMN bio TEXT DEFAULT ''`, note: 'users.bio' },
+      { sql: `ALTER TABLE knowledge_entries ADD COLUMN url TEXT DEFAULT ''`, note: 'knowledge_entries.url' },
     ];
 
     // --- Migrate legacy wish.claimer_id → wish_claimers ---

--- a/functions/api/members/index.ts
+++ b/functions/api/members/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { ROLE_LEVEL, getEffectiveRole } from '../../../src/lib/auth.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -13,24 +14,39 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
     const db = getDb(context.env);
 
+    // Fetch users + their roles via LEFT JOIN
     const result = await db.execute({
-      sql: `SELECT id, name, tag, role, avatar_url, color, effective_role, display_name, emoji, bio
-            FROM users
-            WHERE status = 'active' AND archived_at IS NULL
-            ORDER BY effective_role DESC, name ASC`,
+      sql: `SELECT u.id, u.name, u.discord_id, u.avatar_url, u.color,
+              u.display_name, u.emoji, u.bio,
+              GROUP_CONCAT(ur.role) AS roles
+            FROM users u
+            LEFT JOIN user_roles ur ON ur.user_id = u.id
+            WHERE u.status = 'active' AND u.archived_at IS NULL
+            GROUP BY u.id`,
+      args: [],
     });
 
-    const members = result.rows.map((row) => ({
-      id: String(row.id),
-      name: String(row.name),
-      tag: String(row.tag ?? ''),
-      role: String(row.role ?? ''),
-      avatar: String(row.emoji ?? row.avatar_url ?? '👤'),
-      color: String(row.color ?? '#9090B0'),
-      groupRole: String(row.effective_role ?? 'member'),
-      display_name: String(row.display_name ?? ''),
-      bio: String(row.bio ?? ''),
-    }));
+    const members = result.rows.map((row) => {
+      const roles = (String(row.roles ?? '').split(',').filter(Boolean));
+      const effectiveRole = roles.length > 0 ? getEffectiveRole(roles) : 'companion';
+      return {
+        id: String(row.id),
+        name: String(row.name),
+        tag: String(row.discord_id ?? ''),
+        role: effectiveRole,
+        avatar: String(row.emoji ?? row.avatar_url ?? '👤'),
+        color: String(row.color ?? '#9090B0'),
+        groupRole: effectiveRole,
+        display_name: String(row.display_name ?? ''),
+        bio: String(row.bio ?? ''),
+      };
+    });
+
+    // Sort by role hierarchy (highest first), then name
+    members.sort((a, b) => {
+      const levelDiff = (ROLE_LEVEL[b.groupRole] ?? 0) - (ROLE_LEVEL[a.groupRole] ?? 0);
+      return levelDiff !== 0 ? levelDiff : a.name.localeCompare(b.name);
+    });
 
     return new Response(JSON.stringify({ ok: true, members }), {
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- 新增 `knowledge_entries.url` 欄位到 CREATE TABLE + ALTER TABLE migration
- 修正 `/api/members` SQL — `tag` 改用 `discord_id`、`role/effective_role` 改從 `user_roles` JOIN 取得

## 修復的 API 端點
| Endpoint | 問題 | 修正 |
|----------|------|------|
| `/api/knowledge` | `no such column: ke.url` | 加入 migration |
| `/api/members` | `no such column: tag` | SQL 改用 `discord_id` |
| `/api/members` | `no such column: effective_role` | SQL JOIN `user_roles` |

## Test plan
- [ ] Merge 後跑 `POST /api/db/init` 新增 knowledge_entries.url
- [ ] 驗證 `GET /api/members` 回傳正常 JSON
- [ ] 驗證 `GET /api/knowledge` 回傳正常 JSON
- [ ] 驗證團隊頁面 https://cyclone.tw/team 正常顯示成員

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)