### PR TITLE
feat(#60): 許願樹認領機制重設計 — 多人認領/工具箱關聯/完成確認

### DIFF
--- a/functions/api/ai-tools/index.ts
+++ b/functions/api/ai-tools/index.ts
@@ -22,7 +22,8 @@ const INIT_SQL = `CREATE TABLE IF NOT EXISTS ai_tools (
   upvotes INTEGER DEFAULT 0,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-  github_url TEXT DEFAULT ''
+  github_url TEXT DEFAULT '',
+  wish_id TEXT DEFAULT ''
 )`;
 
 async function ensureMigration(db: ReturnType<typeof createClient>) {
@@ -31,6 +32,9 @@ async function ensureMigration(db: ReturnType<typeof createClient>) {
   } catch { /* column already exists */ }
   try {
     await db.execute({ sql: `ALTER TABLE ai_tools ADD COLUMN github_url TEXT DEFAULT ''`, args: [] });
+  } catch { /* column already exists */ }
+  try {
+    await db.execute({ sql: `ALTER TABLE ai_tools ADD COLUMN wish_id TEXT DEFAULT ''`, args: [] });
   } catch { /* column already exists */ }
 }
 
@@ -129,7 +133,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const user = await requireAuth(context.request, context.env);
-    const { name, description, url, category, author, author_tag } = await context.request.json() as Record<string, string>;
+    const { name, description, url, category, author, author_tag, wish_id } = await context.request.json() as Record<string, string>;
 
     if (!name?.trim() || !description?.trim() || !url?.trim()) {
       return new Response(JSON.stringify({ error: '請填寫工具名稱、簡介和連結' }), {
@@ -142,8 +146,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     await ensureMigration(db);
 
     const result = await db.execute({
-      sql: `INSERT INTO ai_tools (name, description, url, category, author, author_tag, contributor_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+      sql: `INSERT INTO ai_tools (name, description, url, category, author, author_tag, contributor_id, wish_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
       args: [
         name.trim(),
         description.trim(),
@@ -152,6 +156,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         (author || user.name).trim(),
         author_tag?.trim() || '',
         user.id,
+        wish_id?.trim() || '',
       ],
     });
 

--- a/functions/api/ai-tools/index.ts
+++ b/functions/api/ai-tools/index.ts
@@ -141,9 +141,30 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       });
     }
 
+    // Validate URL format
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
+      return new Response(JSON.stringify({ error: '連結必須以 http:// 或 https:// 開頭' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     const db = getDb(context.env);
     await db.execute({ sql: INIT_SQL, args: [] });
     await ensureMigration(db);
+
+    // Validate wish_id: submitter must be a claimer of that wish
+    if (wish_id?.trim()) {
+      const claimCheck = await db.execute({
+        sql: `SELECT 1 FROM wish_claimers WHERE wish_id = ? AND user_id = ? AND status = 'claimed'`,
+        args: [wish_id.trim(), user.id],
+      });
+      if (claimCheck.rows.length === 0) {
+        return new Response(JSON.stringify({ error: '無效的許願卡或非認領者' }), {
+          status: 403, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
 
     const result = await db.execute({
       sql: `INSERT INTO ai_tools (name, description, url, category, author, author_tag, contributor_id, wish_id)
@@ -151,7 +172,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       args: [
         name.trim(),
         description.trim(),
-        url.trim(),
+        trimmedUrl,
         category || 'other',
         (author || user.name).trim(),
         author_tag?.trim() || '',

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -259,6 +259,13 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       });
       for (const row of claimersResult.rows) {
         const claimerId = row.user_id as string;
+        // Idempotent: skip if points already awarded for this wish+claimer
+        const existingPoints = await db.execute({
+          sql: `SELECT id FROM points_ledger WHERE user_id = ? AND ref_type = 'wish' AND ref_id = ?`,
+          args: [claimerId, id],
+        });
+        if (existingPoints.rows.length > 0) continue;
+
         const toolCheck = await db.execute({
           sql: `SELECT id FROM ai_tools WHERE wish_id = ? AND contributor_id = ? LIMIT 1`,
           args: [id, claimerId],

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -105,6 +105,18 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     });
     const comments_count = Number(commentsCountResult.rows[0]?.cnt ?? 0);
 
+    // Fetch linked AI tools
+    const toolsResult = await db.execute({
+      sql: `SELECT id, name, url, contributor_id FROM ai_tools WHERE wish_id = ?`,
+      args: [id],
+    });
+    const linked_tools = toolsResult.rows.map((t) => ({
+      id: Number(t.id),
+      name: t.name as string,
+      url: t.url as string,
+      contributor_id: t.contributor_id as string,
+    }));
+
     const wish = {
       id: r.id,
       title: r.title,
@@ -122,6 +134,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       },
       claimers,
       comments_count,
+      linked_tools,
     };
 
     return new Response(JSON.stringify({ ok: true, wish }), {
@@ -239,16 +252,22 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       await ensureWishHistoryMigration(db);
       await recordStatusChange(db, id, wishRow.status as string, 'completed', user.id);
 
-      // Award points to all claimers (+100 each)
+      // Award points to claimers based on linked AI tool submissions
       const claimersResult = await db.execute({
         sql: `SELECT user_id FROM wish_claimers WHERE wish_id = ? AND status = 'completed'`,
         args: [id],
       });
       for (const row of claimersResult.rows) {
+        const claimerId = row.user_id as string;
+        const toolCheck = await db.execute({
+          sql: `SELECT id FROM ai_tools WHERE wish_id = ? AND contributor_id = ? LIMIT 1`,
+          args: [id, claimerId],
+        });
+        const hasTool = toolCheck.rows.length > 0;
         const ledgerId = crypto.randomUUID();
         await db.execute({
-          sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, 'wish_completed', 100, 'wish', ?)`,
-          args: [ledgerId, row.user_id as string, id],
+          sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, 'wish', ?)`,
+          args: [ledgerId, claimerId, hasTool ? 'wish_completed_ai_tool' : 'wish_completed', hasTool ? 300 : 100, id],
         });
       }
 

--- a/functions/api/wishes/index.ts
+++ b/functions/api/wishes/index.ts
@@ -85,6 +85,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       claimers: [] as { id: string; name: string; avatarUrl: string | null; status: string }[],
       comments_count: 0,
       history: [] as { from_status: string; to_status: string; changed_by: string; created_at: string }[],
+      linked_tools: [] as { id: number; name: string; url: string; contributor_id: string }[],
     }));
 
     // Fetch history for all wishes
@@ -146,6 +147,23 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         const wish = wishMap.get(c.wish_id as string);
         if (wish) {
           wish.comments_count = Number(c.cnt);
+        }
+      }
+
+      // Fetch linked AI tools
+      const toolsResult = await db.execute({
+        sql: `SELECT id, name, url, contributor_id, wish_id FROM ai_tools WHERE wish_id IN (${placeholders})`,
+        args: wishIds,
+      });
+      for (const t of toolsResult.rows) {
+        const wish = wishMap.get(t.wish_id as string);
+        if (wish) {
+          wish.linked_tools.push({
+            id: Number(t.id),
+            name: t.name as string,
+            url: t.url as string,
+            contributor_id: t.contributor_id as string,
+          });
         }
       }
     }

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -773,7 +773,7 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
                 {wish.linked_tools.map((tool) => (
                   <a
                     key={tool.id}
-                    href={tool.url}
+                    href={tool.url?.startsWith('http') ? tool.url : '#'}
                     target="_blank"
                     rel="noopener noreferrer"
                     style={{

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -36,6 +36,13 @@ interface WishHistoryEntry {
   created_at: string;
 }
 
+interface LinkedTool {
+  id: number;
+  name: string;
+  url: string;
+  contributor_id: string;
+}
+
 interface Wish {
   id: string;
   title: string;
@@ -51,6 +58,7 @@ interface Wish {
   history: WishHistoryEntry[];
   comments?: WishComment[];
   comments_count?: number;
+  linked_tools?: LinkedTool[];
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -367,6 +375,150 @@ function DeleteConfirmModal({ wish, onClose, onDeleted }: { wish: Wish; onClose:
   );
 }
 
+// ─── SubmitToolModal ───────────────────────────────────────────────────────────
+
+function SubmitToolModal({ wishId, onClose, onSubmitted }: { wishId: string; onClose: () => void; onSubmitted: () => void }) {
+  const { user } = useAuth();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [url, setUrl] = useState('');
+  const [category, setCategory] = useState<'agent' | 'llm' | 'productivity' | 'dev' | 'other'>('other');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async () => {
+    if (!name.trim() || !description.trim() || !url.trim()) {
+      setError('請填寫工具名稱、簡介和連結');
+      return;
+    }
+    setSubmitting(true);
+    setError('');
+    try {
+      const res = await fetch('/api/ai-tools', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim(),
+          url: url.trim(),
+          category,
+          wish_id: wishId,
+        }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        onSubmitted();
+        onClose();
+      } else {
+        setError(data.error || '投稿失敗');
+      }
+    } catch {
+      setError('網路錯誤，請稍後再試');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div
+        style={{
+          ...glassStyle,
+          borderRadius: '1rem',
+          padding: '1.5rem',
+          width: '100%',
+          maxWidth: 480,
+          maxHeight: '90vh',
+          overflowY: 'auto',
+        }}
+      >
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.25rem' }}>
+          <h3 style={{ fontSize: '1.125rem', fontWeight: 700, color: '#F0F0FF', margin: 0 }}>🛠️ 投稿到 AI 工具箱</h3>
+          <button onClick={onClose} style={{ background: 'none', border: 'none', color: '#9090B0', fontSize: '1.25rem', cursor: 'pointer', lineHeight: 1 }}>✕</button>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.75rem' }}>
+          <div>
+            <label style={labelStyle}>工具名稱 *</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Claude Code"
+              style={{ ...inputStyle, width: '100%' }}
+              onFocus={handleFocusIn}
+              onBlur={handleFocusOut}
+            />
+          </div>
+          <div>
+            <label style={labelStyle}>分類</label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value as typeof category)}
+              style={{ ...inputStyle, width: '100%', cursor: 'pointer' }}
+              onFocus={handleFocusIn}
+              onBlur={handleFocusOut}
+            >
+              <option value="agent">🤖 Agent</option>
+              <option value="llm">🧠 LLM</option>
+              <option value="productivity">⚡ 生產力</option>
+              <option value="dev">💻 開發</option>
+              <option value="other">📦 其他</option>
+            </select>
+          </div>
+        </div>
+
+        <div style={{ marginBottom: '0.75rem' }}>
+          <label style={labelStyle}>連結 *</label>
+          <input
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://..."
+            style={{ ...inputStyle, width: '100%' }}
+            onFocus={handleFocusIn}
+            onBlur={handleFocusOut}
+          />
+        </div>
+
+        <div style={{ marginBottom: '1rem' }}>
+          <label style={labelStyle}>簡介 *</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="簡短描述這個工具的用途和特色..."
+            rows={3}
+            style={{ ...inputStyle, width: '100%', resize: 'vertical' }}
+            onFocus={handleFocusIn}
+            onBlur={handleFocusOut}
+          />
+        </div>
+
+        {error && <p style={{ color: '#FF6B6B', fontSize: '0.85rem', marginBottom: '0.75rem' }}>{error}</p>}
+
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button
+            onClick={onClose}
+            style={{ padding: '0.625rem 1rem', borderRadius: '0.75rem', border: '1px solid #2A2A4A', background: 'transparent', color: '#9090B0', cursor: 'pointer', fontSize: '0.875rem' }}
+          >
+            取消
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !user}
+            style={{ ...neonBtnStyle, opacity: submitting ? 0.6 : 1 }}
+          >
+            {submitting ? '投稿中...' : '確認投稿'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── ClaimerBadge ──────────────────────────────────────────────────────────────
 
 function ClaimerBadge({ status }: { status: 'claimed' | 'completed' }) {
@@ -411,6 +563,7 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
   const [commentsLoading, setCommentsLoading] = useState(false);
   const [commentContent, setCommentContent] = useState('');
   const [commentSubmitting, setCommentSubmitting] = useState(false);
+  const [showSubmitTool, setShowSubmitTool] = useState(false);
 
   const cfg = STATUS_CONFIG[wish.status];
   const isCompleted = wish.status === 'completed';
@@ -567,30 +720,77 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '0.5rem', background: 'rgba(10,10,26,0.4)', borderRadius: '0.5rem', border: '1px solid rgba(108,99,255,0.1)' }}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ fontSize: '0.7rem', color: '#606080', fontWeight: 600 }}>認領者</div>
-            <a
-              href="/ai-tools"
-              style={{
-                fontSize: '0.7rem',
-                color: '#00D9FF',
-                textDecoration: 'none',
-                fontWeight: 600,
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 2,
-              }}
-            >
-              🛠️ 投稿到工具箱
-            </a>
+            {isClaimer && !isCompleted && (
+              <button
+                onClick={() => setShowSubmitTool(true)}
+                style={{
+                  fontSize: '0.7rem',
+                  color: '#00D9FF',
+                  background: 'transparent',
+                  border: 'none',
+                  fontWeight: 600,
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 2,
+                  cursor: 'pointer',
+                  padding: 0,
+                }}
+              >
+                🛠️ 投稿到工具箱
+              </button>
+            )}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-            {wish.claimers.map((claimer) => (
-              <div key={claimer.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <Avatar name={claimer.name} avatarUrl={claimer.avatarUrl} size={24} />
-                <span style={{ fontSize: '0.8rem', color: '#F0F0FF', fontWeight: 500 }}>{claimer.name}</span>
-                <ClaimerBadge status={claimer.status} />
-              </div>
-            ))}
+            {wish.claimers.map((claimer) => {
+              const hasTool = wish.linked_tools?.some(t => t.contributor_id === claimer.id);
+              return (
+                <div key={claimer.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <Avatar name={claimer.name} avatarUrl={claimer.avatarUrl} size={24} />
+                  <span style={{ fontSize: '0.8rem', color: '#F0F0FF', fontWeight: 500 }}>{claimer.name}</span>
+                  <ClaimerBadge status={claimer.status} />
+                  {hasTool && (
+                    <span style={{
+                      fontSize: '0.6rem',
+                      fontWeight: 700,
+                      padding: '0.05rem 0.35rem',
+                      borderRadius: '9999px',
+                      background: 'rgba(0,217,255,0.15)',
+                      color: '#00D9FF',
+                      border: '1px solid rgba(0,217,255,0.3)',
+                      whiteSpace: 'nowrap',
+                    }}>
+                      已投稿
+                    </span>
+                  )}
+                </div>
+              );
+            })}
           </div>
+          {wish.linked_tools && wish.linked_tools.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 4 }}>
+              <div style={{ fontSize: '0.7rem', color: '#606080', fontWeight: 600 }}>關聯工具</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {wish.linked_tools.map((tool) => (
+                  <a
+                    key={tool.id}
+                    href={tool.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      fontSize: '0.75rem',
+                      color: '#00D9FF',
+                      textDecoration: 'none',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: 4,
+                    }}
+                  >
+                    🔗 {tool.name}
+                  </a>
+                ))}
+              </div>
+            </div>
+          )}
           {visibleClaimers.length < wish.claimers.length && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 2 }}>
               <div style={{ display: 'flex', alignItems: 'center' }}>
@@ -689,6 +889,14 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
             );
           })}
         </div>
+      )}
+
+      {showSubmitTool && (
+        <SubmitToolModal
+          wishId={wish.id}
+          onClose={() => setShowSubmitTool(false)}
+          onSubmitted={() => { setShowSubmitTool(false); onRefresh(); }}
+        />
       )}
 
       {/* Comments Section */}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,14 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-15 18:05',
+    changes: [
+      'feat(#60): 許願樹 AI 工具箱關聯 — 認領者可投稿工具並綁定許願卡',
+      'feat(#60): 許願完成差異化積分 — 有 AI 工具投稿 +300，一般完成 +100',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-15 17:45',
     changes: [
       'feat(#51): 討論區留言編輯功能 — 作者/管理員可編輯、顯示已編輯標記、PATCH /api/messages/:id',


### PR DESCRIPTION
## Summary
- AI 工具箱新增 `wish_id` 欄位，認領者投稿時可關聯許願卡
- 許願卡 GET 回傳 `linked_tools`（關聯的 AI 工具列表）
- 完成確認積分制：投稿 AI 工具被確認 +300、文字方案 +100
- 前端 WishBoard 新增 SubmitToolModal、認領者留言區、完成確認按鈕
- wish_claimers / wish_comments 表已存在，本次串接前後端

## Test plan
- [ ] 認領者可認領許願（多人認領）
- [ ] 認領者可在許願卡留言
- [ ] 認領者可投稿 AI 工具並關聯該許願
- [ ] 許願者按「完成」→ 認領者獲 +100（方案）或 +300（AI 工具）
- [ ] admin/captain 可代確認完成
- [ ] 關聯的 AI 工具在許願卡上顯示連結
- [ ] build 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)