### PR TITLE
security(#51-E4): 討論區 Markdown XSS 防護強化

### DIFF
--- a/src/components/discuss/MessageBoard.tsx
+++ b/src/components/discuss/MessageBoard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import DOMPurify from 'dompurify';
+import { sanitizeUrl, sanitizeImgSrc } from '../../lib/markdown';
 import { useAuth } from '@/components/auth/useAuth';
 import { ROLE_LEVEL } from '@/lib/auth';
 import { timeAgo } from '@/lib/time';
@@ -252,7 +252,8 @@ function MessageCard({
                 },
                 a({ href, children, ...props }) {
                   if (!href) return <span {...props}>{children}</span>;
-                  const safe = DOMPurify.sanitize(href, { RETURN_TRUSTED_TYPE: false }) as string;
+                  const safe = sanitizeUrl(href);
+                  if (!safe) return <span {...props}>{children}</span>;
                   return (
                     <a
                       href={safe}
@@ -260,11 +261,15 @@ function MessageCard({
                       rel="noopener noreferrer"
                       className="underline hover:opacity-80"
                       style={{ color: 'var(--color-neon-blue)' }}
-                      {...props}
                     >
                       {children}
                     </a>
                   );
+                },
+                img({ src, alt, ...props }) {
+                  const safeSrc = sanitizeImgSrc(src);
+                  if (!safeSrc) return null;
+                  return <img src={safeSrc} alt={alt || ''} loading="lazy" style={{ maxWidth: '100%' }} />;
                 },
               }}
             >

--- a/src/components/discuss/MessageBoard.tsx
+++ b/src/components/discuss/MessageBoard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
-import { sanitizeUrl, sanitizeImgSrc } from '../../lib/markdown';
+import { sanitizeUrl, sanitizeImgSrc, sanitizeMarkdown } from '../../lib/markdown';
 import { useAuth } from '@/components/auth/useAuth';
 import { ROLE_LEVEL } from '@/lib/auth';
 import { timeAgo } from '@/lib/time';
@@ -273,7 +273,7 @@ function MessageCard({
                 },
               }}
             >
-              {msg.content}
+              {sanitizeMarkdown(msg.content)}
             </ReactMarkdown>
           </div>
           <div className="flex items-center justify-end mt-2 gap-2">

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-15 17:45',
     changes: [
+      'security(#51-E4): 討論區 Markdown XSS 防護 — URL 白名單、標籤/屬性白名單、img src 限制 https',
       'feat(#51): 討論區留言編輯功能 — 作者/管理員可編輯、顯示已編輯標記、PATCH /api/messages/:id',
       'feat(#51): 討論區留言分類重設計 — 閒聊/成果分享/問題/建議',
       'feat(#51): 討論區置頂留言 — 管理員可置頂/取消置頂，置頂留言顯示於最上方',

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -12,11 +12,18 @@ const ALLOWED_TAGS = [
 ];
 
 const ALLOWED_ATTR = [
-  'href', 'src', 'alt', 'title', 'class', 'target', 'rel',
+  'href', 'alt', 'title', 'class', 'target', 'rel',
   'checked', 'disabled', 'type', 'colspan', 'rowspan', 'align',
 ];
 
 const FORBID_TAGS = ['script', 'iframe', 'style', 'form', 'textarea', 'button'];
+
+// Block all on* event handler attributes globally
+DOMPurify.addHook('uponSanitizeAttribute', (_node, data) => {
+  if (data.attrName?.startsWith('on')) {
+    data.forceKeepAttr = false;
+  }
+});
 
 // ─── URL Sanitization ───────────────────────────────────────────────────────
 
@@ -37,7 +44,6 @@ export function sanitizeImgSrc(src: string | undefined): string {
   if (!src) return '';
   try {
     const parsed = new URL(src, window.location.origin);
-    // Only allow https images (no http, data:, blob:, etc.)
     if (parsed.protocol !== 'https:') return '';
     return parsed.href;
   } catch {
@@ -52,9 +58,6 @@ export function sanitizeMarkdown(html: string): string {
     ALLOWED_TAGS,
     ALLOWED_ATTR,
     FORBID_TAGS,
-    FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover'],
-    // Ban all on* event handler attributes
     ALLOW_DATA_ATTR: false,
-    ADD_TAGS: [],
   });
 }

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1,0 +1,60 @@
+import DOMPurify from 'dompurify';
+
+// ─── Tag & Attribute Whitelist ──────────────────────────────────────────────
+
+const ALLOWED_TAGS = [
+  'p', 'br', 'strong', 'em', 'a', 'code', 'pre',
+  'ul', 'ol', 'li', 'blockquote', 'img',
+  'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'table', 'thead', 'tbody', 'th', 'td', 'tr',
+  'hr', 'del', 'input',
+  'span', 'div',
+];
+
+const ALLOWED_ATTR = [
+  'href', 'src', 'alt', 'title', 'class', 'target', 'rel',
+  'checked', 'disabled', 'type', 'colspan', 'rowspan', 'align',
+];
+
+const FORBID_TAGS = ['script', 'iframe', 'style', 'form', 'textarea', 'button'];
+
+// ─── URL Sanitization ───────────────────────────────────────────────────────
+
+const SAFE_PROTOCOLS = ['http:', 'https:'];
+
+export function sanitizeUrl(url: string | undefined): string {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url, window.location.origin);
+    if (!SAFE_PROTOCOLS.includes(parsed.protocol)) return '';
+    return parsed.href;
+  } catch {
+    return '';
+  }
+}
+
+export function sanitizeImgSrc(src: string | undefined): string {
+  if (!src) return '';
+  try {
+    const parsed = new URL(src, window.location.origin);
+    // Only allow https images (no http, data:, blob:, etc.)
+    if (parsed.protocol !== 'https:') return '';
+    return parsed.href;
+  } catch {
+    return '';
+  }
+}
+
+// ─── Full Markdown Content Sanitization ─────────────────────────────────────
+
+export function sanitizeMarkdown(html: string): string {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS,
+    ALLOWED_ATTR,
+    FORBID_TAGS,
+    FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover'],
+    // Ban all on* event handler attributes
+    ALLOW_DATA_ATTR: false,
+    ADD_TAGS: [],
+  });
+}


### PR DESCRIPTION
## Summary
- 新增 `src/lib/markdown.ts`：`sanitizeUrl()` / `sanitizeImgSrc()` / `sanitizeMarkdown()`
- 標籤白名單：禁止 script/iframe/style/form/textarea/button
- 屬性白名單 + 禁止所有 on* event handler
- `img src` 只允許 `https://` 協議
- `a href` 只允許 `http/https` 協議（阻止 `javascript:` 等注入）
- MessageBoard.tsx 改用 sanitize helpers 取代內聯 DOMPurify

## Test plan
- [ ] 正常 Markdown 渲染不受影響（連結、粗體、列表、表格）
- [ ] `<script>alert(1)</script>` 被過濾
- [ ] `<img src=x onerror=alert(1)>` 被過濾
- [ ] `<a href="javascript:alert(1)">` 被過濾或替換為 about:blank
- [ ] `http://` 圖片被阻擋（僅允許 https）
- [ ] build 綠燈

🤖 Generated with [Claude Code](https://claude.com/claude-code)