### PR TITLE
feat(#51-E5): 後台 Admin Panel 討論區留言管理

### DIFF
--- a/functions/api/admin/messages/[id].ts
+++ b/functions/api/admin/messages/[id].ts
@@ -1,0 +1,76 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// PATCH /api/admin/messages/:id — restore deleted message or toggle pinned
+// Body: { restore?: boolean, pinned?: number }
+// ---------------------------------------------------------------------------
+
+export const onRequestPatch: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireRole(context.request, context.env, 'admin');
+    const id = context.params.id as string;
+    const db = getDb(context.env);
+
+    const body = (await context.request.json()) as { restore?: boolean; delete?: boolean; pinned?: number };
+    const { restore, delete: doDelete, pinned } = body;
+
+    const existing = await db.execute({ sql: 'SELECT id FROM messages WHERE id = ?', args: [id] });
+    if (!existing.rows.length) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到此留言' }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const updates: string[] = [];
+    const args: (string | number)[] = [];
+
+    if (restore) {
+      updates.push('deleted_at = NULL', 'deleted_by = NULL');
+    } else if (doDelete) {
+      updates.push("deleted_at = datetime('now')", 'deleted_by = ?');
+      args.push(user.id);
+    }
+
+    if (pinned !== undefined) {
+      if (pinned !== 0 && pinned !== 1) {
+        return new Response(JSON.stringify({ ok: false, error: 'pinned 只能是 0 或 1' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      updates.push('pinned = ?');
+      args.push(pinned);
+    }
+
+    if (updates.length === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '請提供 delete / restore / pinned' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    args.push(id);
+    await db.execute({
+      sql: `UPDATE messages SET ${updates.join(', ')} WHERE id = ?`,
+      args,
+    });
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/messages/index.ts
+++ b/functions/api/admin/messages/index.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/admin/messages — list ALL messages including soft-deleted
+// ---------------------------------------------------------------------------
+
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+
+    const offset = parseInt(context.request.headers.get('x-offset') || '0', 10);
+    const limit = 50;
+
+    const result = await db.execute({
+      sql: `
+        SELECT m.*,
+               COALESCE(lc.like_count, 0) AS like_count,
+               u.name AS author_name
+        FROM messages m
+        LEFT JOIN (
+          SELECT message_id, COUNT(*) AS like_count
+          FROM discussion_likes
+          GROUP BY message_id
+        ) lc ON lc.message_id = m.id
+        LEFT JOIN users u ON u.id = m.author_id AND u.archived_at IS NULL AND u.status = 'active'
+        ORDER BY m.pinned DESC, m.created_at DESC
+        LIMIT ? OFFSET ?
+      `,
+      args: [limit, offset],
+    });
+
+    const countResult = await db.execute({ sql: 'SELECT COUNT(*) AS total FROM messages', args: [] });
+    const total = Number(countResult.rows[0]?.total ?? 0);
+
+    return new Response(JSON.stringify({ ok: true, messages: result.rows, total }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -57,6 +57,22 @@ interface Announcement {
   updated_at: string;
 }
 
+interface AdminMessage {
+  id: number;
+  author: string;
+  author_id: string | null;
+  author_name: string | null;
+  content: string;
+  category: string;
+  tag: string;
+  pinned: number;
+  like_count: number;
+  created_at: string;
+  edited_at: string | null;
+  deleted_at: string | null;
+  deleted_by: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -168,6 +184,13 @@ export default function AdminPanel() {
   const [deletingAnnouncement, setDeletingAnnouncement] = useState<{ id: string; title: string; loading: boolean } | null>(null);
   const [showAnnouncementModal, setShowAnnouncementModal] = useState(false);
 
+  // Admin Messages
+  const [adminMessages, setAdminMessages] = useState<AdminMessage[]>([]);
+  const [messagesLoading, setMessagesLoading] = useState(false);
+  const [messagesOffset, setMessagesOffset] = useState(0);
+  const [messagesTotal, setMessagesTotal] = useState(0);
+  const [messageAction, setMessageAction] = useState<{ id: number; loading: boolean } | null>(null);
+
   const isAdmin = isRole('admin');
 
   const fetchData = useCallback(async () => {
@@ -193,12 +216,24 @@ export default function AdminPanel() {
       setUsers(usersData.users);
       if (analyticsData.ok) setAnalytics(analyticsData.analytics);
       if (announcementsData.ok) setAnnouncements(announcementsData.announcements || []);
+
+      // Fetch messages with current offset
+      const messagesRes = await fetch('/api/admin/messages', {
+        headers: { 'x-offset': String(messagesOffset) },
+      });
+      const messagesData = await messagesRes.json();
+      if (messagesData.ok) {
+        setAdminMessages((prev) =>
+          messagesOffset === 0 ? messagesData.messages : [...prev, ...messagesData.messages],
+        );
+        setMessagesTotal(messagesData.total);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : '載入失敗');
     } finally {
       setDataLoading(false);
     }
-  }, [includeArchived]);
+  }, [includeArchived, messagesOffset]);
 
   useEffect(() => {
     if (isAdmin) fetchData();
@@ -302,6 +337,89 @@ export default function AdminPanel() {
       setError(err instanceof Error ? err.message : '核可失敗');
     } finally {
       setUpdating(null);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Message mutations
+  // ---------------------------------------------------------------------------
+
+  async function handleDeleteMessage(id: number) {
+    setMessageAction({ id, loading: true });
+    try {
+      const res = await fetch(`/api/admin/messages/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ delete: true }),
+      });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '刪除失敗');
+      // Refresh messages from offset 0
+      setMessagesOffset(0);
+      const messagesRes = await fetch('/api/admin/messages', {
+        headers: { 'x-offset': '0' },
+      });
+      const messagesData = await messagesRes.json();
+      if (messagesData.ok) {
+        setAdminMessages(messagesData.messages);
+        setMessagesTotal(messagesData.total);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '刪除失敗');
+    } finally {
+      setMessageAction(null);
+    }
+  }
+
+  async function handleRestore(id: number) {
+    setMessageAction({ id, loading: true });
+    try {
+      const res = await fetch(`/api/admin/messages/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ restore: true }),
+      });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '復原失敗');
+      setMessagesOffset(0);
+      const messagesRes = await fetch('/api/admin/messages', {
+        headers: { 'x-offset': '0' },
+      });
+      const messagesData = await messagesRes.json();
+      if (messagesData.ok) {
+        setAdminMessages(messagesData.messages);
+        setMessagesTotal(messagesData.total);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '復原失敗');
+    } finally {
+      setMessageAction(null);
+    }
+  }
+
+  async function handleTogglePinned(id: number, pinned: number) {
+    setMessageAction({ id, loading: true });
+    try {
+      const res = await fetch(`/api/admin/messages/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pinned }),
+      });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '操作失敗');
+      setMessagesOffset(0);
+      const messagesRes = await fetch('/api/admin/messages', {
+        headers: { 'x-offset': '0' },
+      });
+      const messagesData = await messagesRes.json();
+      if (messagesData.ok) {
+        setAdminMessages(messagesData.messages);
+        setMessagesTotal(messagesData.total);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '操作失敗');
+    } finally {
+      setMessageAction(null);
     }
   }
 
@@ -889,6 +1007,135 @@ export default function AdminPanel() {
         <p className="text-xs mt-2" style={{ color: 'var(--color-text-muted)' }}>
           左側為較高等級。高等級角色自動擁有低等級的所有權限。
         </p>
+      </section>
+
+      {/* 討論區管理 */}
+      <section
+        className="rounded-xl p-5"
+        style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+            討論區管理
+          </h3>
+          <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+            {adminMessages.length} / {messagesTotal} 則留言
+          </span>
+        </div>
+
+        {adminMessages.length === 0 && !messagesLoading ? (
+          <p className="text-sm text-center py-4" style={{ color: 'var(--color-text-muted)' }}>
+            尚無留言
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left" style={{ color: 'var(--color-text-muted)', borderBottom: '1px solid var(--color-border)' }}>
+                  <th className="pb-2 pr-3 font-medium">作者</th>
+                  <th className="pb-2 pr-3 font-medium">內容摘要</th>
+                  <th className="pb-2 pr-3 font-medium">分類</th>
+                  <th className="pb-2 pr-3 font-medium">時間</th>
+                  <th className="pb-2 pr-3 font-medium">狀態</th>
+                  <th className="pb-2 font-medium">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {adminMessages.map((msg) => {
+                  const isDeleted = !!msg.deleted_at;
+                  const isPinned = msg.pinned === 1;
+                  const isActing = messageAction?.id === msg.id;
+                  return (
+                    <tr
+                      key={msg.id}
+                      className="border-b"
+                      style={{ borderColor: 'var(--color-border)', opacity: isDeleted ? 0.6 : 1 }}
+                    >
+                      <td className="py-2 pr-3">
+                        <span className="text-xs">{msg.author_name || msg.author || '未知'}</span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs truncate max-w-[200px] block">{msg.content}</span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs">{msg.category || '-'}</span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs whitespace-nowrap">
+                          {new Date(msg.created_at).toLocaleString('zh-TW', { hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <div className="flex flex-wrap gap-1">
+                          {isPinned && (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/20 text-yellow-500">
+                              置頂
+                            </span>
+                          )}
+                          {isDeleted ? (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-500">
+                              已刪除
+                            </span>
+                          ) : (
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-green-500/20 text-green-500">
+                              正常
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="py-2">
+                        <div className="flex gap-1">
+                          {isDeleted ? (
+                            <button
+                              onClick={() => handleRestore(msg.id)}
+                              disabled={isActing}
+                              className="text-[10px] px-2 py-1 rounded text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 transition-colors"
+                            >
+                              {isActing ? '復原中...' : '復原'}
+                            </button>
+                          ) : (
+                            <button
+                              onClick={() => handleDeleteMessage(msg.id)}
+                              disabled={isActing}
+                              className="text-[10px] px-2 py-1 rounded text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 transition-colors"
+                            >
+                              {isActing ? '刪除中...' : '刪除'}
+                            </button>
+                          )}
+                          <button
+                            onClick={() => handleTogglePinned(msg.id, isPinned ? 0 : 1)}
+                            disabled={isActing}
+                            className="text-[10px] px-2 py-1 rounded text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                          >
+                            {isActing ? '...' : isPinned ? '取消置頂' : '置頂'}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {messagesLoading && (
+          <p className="text-sm text-center py-3" style={{ color: 'var(--color-text-muted)' }}>
+            載入中...
+          </p>
+        )}
+
+        {adminMessages.length < messagesTotal && !messagesLoading && (
+          <div className="text-center mt-3">
+            <button
+              onClick={() => setMessagesOffset((o) => o + 50)}
+              className="text-xs px-4 py-1.5 rounded-full border transition-colors hover:bg-[var(--color-bg-hover)]"
+              style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-secondary)' }}
+            >
+              載入更多 ({adminMessages.length} / {messagesTotal})
+            </button>
+          </div>
+        )}
       </section>
 
       {/* Add Member Modal */}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-16',
+    changes: [
+      'feat(#51-E5): Admin Panel 討論區管理 — 顯示所有留言含已刪除，管理員可軟刪除/復原/切換置頂',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-15 18:30',
     changes: [
       'feat(#44): 成員聲音 — 新增 /member-voices 頁面，支援 AI 服務盤點與痛點回饋',


### PR DESCRIPTION
## Summary
- AdminPanel 新增「討論區留言管理」區塊（table 顯示所有留言）
- 新增 GET /api/admin/messages 取得所有留言（含已刪除）
- 新增 PATCH /api/admin/messages/:id 支援 restore（deleted_at 設回 NULL）
- 已刪除留言顯示「已刪除」標記，管理員可恢復
- 更新 changelog

## Test plan
- [ ] `bun run build` 通過（18 pages）
- [ ] Admin Panel 留言管理 table 正確顯示
- [ ] 管理員可軟刪除 / 恢復留言
- [ ] 已刪除留言顯示「已刪除」標記

🤖 Generated with [Claude Code](https://claude.com/claude-code)