### PR TITLE
feat(#44): 團隊頁成員個人檔案頁面

### DIFF
--- a/functions/api/members/[id].ts
+++ b/functions/api/members/[id].ts
@@ -1,0 +1,61 @@
+import { createClient } from '@libsql/client/web';
+import { ROLE_LEVEL, getEffectiveRole } from '../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// GET /api/members/:id — single member
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const id = context.params.id as string;
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `SELECT u.id, u.name, u.discord_id, u.avatar_url, u.color,
+              u.display_name, u.emoji, u.bio,
+              GROUP_CONCAT(ur.role) AS roles
+            FROM users u
+            LEFT JOIN user_roles ur ON ur.user_id = u.id
+            WHERE u.id = ? AND u.status = 'active' AND u.archived_at IS NULL
+            GROUP BY u.id`,
+      args: [id],
+    });
+
+    if (!result.rows.length) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到該成員' }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const row = result.rows[0];
+    const roles = String(row.roles ?? '').split(',').filter(Boolean);
+    const effectiveRole = roles.length > 0 ? getEffectiveRole(roles) : 'companion';
+
+    const member = {
+      id: String(row.id),
+      name: String(row.name),
+      tag: String(row.discord_id ?? ''),
+      role: effectiveRole,
+      avatar: String(row.emoji ?? row.avatar_url ?? '👤'),
+      color: String(row.color ?? '#9090B0'),
+      groupRole: effectiveRole,
+      display_name: String(row.display_name ?? ''),
+      bio: String(row.bio ?? ''),
+    };
+
+    return new Response(JSON.stringify({ ok: true, member }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/components/team/MemberProfile.tsx
+++ b/src/components/team/MemberProfile.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect } from 'react';
+
+interface Member {
+  id: string;
+  name: string;
+  display_name: string;
+  bio: string;
+  avatar: string;
+  color: string;
+  role: string;
+  groupRole: string;
+}
+
+interface AiTool {
+  id: number;
+  name: string;
+  description: string;
+  url: string;
+  category: string;
+  upvotes: number;
+  created_at: string;
+}
+
+interface KnowledgeEntry {
+  id: string;
+  title: string;
+  content: string;
+  category: string;
+  icon: string;
+  upvotes: number;
+  url: string;
+  created_at: string;
+}
+
+const ROLE_LABELS: Record<string, string> = {
+  captain: '隊長',
+  tech: '技術維護',
+  admin: '行政協作',
+  member: '正式隊員',
+  companion: '陪跑員',
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  agent: 'Agent',
+  llm: 'LLM',
+  productivity: '生產力',
+  dev: '開發',
+  other: '其他',
+  template: '工作流模板',
+  'best-practice': '最佳實踐',
+  qa: '問答精華',
+};
+
+function formatTimeAgo(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diff = Math.floor((now.getTime() - date.getTime()) / 1000);
+  if (diff < 60) return '剛剛';
+  if (diff < 3600) return `${Math.floor(diff / 60)} 分鐘前`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} 小時前`;
+  if (diff < 2592000) return `${Math.floor(diff / 86400)} 天前`;
+  return `${Math.floor(diff / 2592000)} 個月前`;
+}
+
+const SAFE_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
+function safeColor(c: string | undefined): string {
+  if (!c || !SAFE_COLOR_RE.test(c)) return '#6B7280';
+  return c;
+}
+
+export default function MemberProfile({ memberId }: { memberId: string }) {
+  const [member, setMember] = useState<Member | null>(null);
+  const [aiTools, setAiTools] = useState<AiTool[]>([]);
+  const [knowledge, setKnowledge] = useState<KnowledgeEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [memberRes, toolsRes, knowledgeRes] = await Promise.all([
+          fetch(`/api/members/${encodeURIComponent(memberId)}`),
+          fetch(`/api/ai-tools?contributor_id=${encodeURIComponent(memberId)}`),
+          fetch(`/api/knowledge?contributor_id=${encodeURIComponent(memberId)}`),
+        ]);
+
+        const memberData = await memberRes.json();
+        const toolsData = await toolsRes.json();
+        const knowledgeData = await knowledgeRes.json();
+
+        if (memberData.ok && memberData.member) {
+          setMember(memberData.member);
+        }
+        if (toolsData.ok) setAiTools(toolsData.tools || []);
+        if (knowledgeData.ok) setKnowledge(knowledgeData.entries || []);
+      } catch {
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [memberId]);
+
+  if (loading) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center">
+          <div className="w-24 h-24 rounded-full animate-pulse bg-[var(--color-bg-surface)] mx-auto mb-4" />
+          <div className="h-8 w-48 animate-pulse bg-[var(--color-bg-surface)] mx-auto rounded" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !member) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
+        <p className="text-[var(--color-text-muted)]">找不到該成員或載入失敗</p>
+        <a href="/team" className="text-[var(--color-primary)] hover:underline mt-4 inline-block">← 返回團隊頁</a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      {/* Back link */}
+      <a href="/team" className="text-sm text-[var(--color-text-muted)] hover:text-[var(--color-primary)] transition-colors mb-6 inline-block">
+        ← 返回團隊頁
+      </a>
+
+      {/* Member Info Card */}
+      <div
+        className="glass rounded-2xl p-6 sm:p-8 mb-10"
+        style={{ borderLeft: `4px solid ${safeColor(member.color)}` }}
+      >
+        <div className="flex flex-col sm:flex-row items-center sm:items-start gap-6">
+          <div
+            className="w-24 h-24 rounded-full flex items-center justify-center text-5xl border-2"
+            style={{ borderColor: safeColor(member.color), background: `${safeColor(member.color)}1A` }}
+          >
+            {member.avatar || '👤'}
+          </div>
+          <div className="text-center sm:text-left flex-1">
+            <h1 className="text-2xl sm:text-3xl font-bold text-[var(--color-text-primary)] mb-1">
+              {member.display_name || member.name}
+              {member.groupRole !== 'companion' && (
+                <span className="text-sm font-normal ml-2" style={{ color: safeColor(member.color) }}>
+                  {ROLE_LABELS[member.groupRole] || member.role}
+                </span>
+              )}
+            </h1>
+            {member.groupRole === 'companion' && (
+              <span
+                className="inline-block px-2.5 py-0.5 rounded-full text-[10px] font-semibold tracking-wide border mb-2"
+                style={{ color: safeColor(member.color), borderColor: `${safeColor(member.color)}44`, background: `${safeColor(member.color)}18` }}
+              >
+                {ROLE_LABELS[member.groupRole] || member.role}
+              </span>
+            )}
+            <p className="text-[var(--color-text-secondary)] mt-2 max-w-xl leading-relaxed">
+              {member.bio || '這位成員還沒有填寫自我介紹。'}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* AI Tools Section */}
+      <section className="mb-10">
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-2xl">🤖</span>
+          <h2 className="text-xl font-bold text-[var(--color-text-primary)]">AI 工具投稿</h2>
+          <span className="text-sm text-[var(--color-text-muted)]">({aiTools.length})</span>
+        </div>
+        {aiTools.length === 0 ? (
+          <div className="glass rounded-xl p-6 text-center text-[var(--color-text-muted)]">
+            尚無 AI 工具投稿
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {aiTools.map((tool) => (
+              <a
+                key={tool.id}
+                href={tool.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="glass rounded-xl p-4 hover:border-[var(--color-primary)] transition-colors block"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="font-semibold text-[var(--color-text-primary)] truncate">{tool.name}</h3>
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-surface)] text-[var(--color-text-muted)]">
+                    {CATEGORY_LABELS[tool.category] || tool.category}
+                  </span>
+                </div>
+                <p className="text-sm text-[var(--color-text-muted)] line-clamp-2 mb-3">{tool.description}</p>
+                <div className="flex items-center justify-between text-xs text-[var(--color-text-muted)]">
+                  <span>👍 {tool.upvotes || 0}</span>
+                  <span>{formatTimeAgo(tool.created_at)}</span>
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Knowledge Section */}
+      <section>
+        <div className="flex items-center gap-3 mb-5">
+          <span className="text-2xl">📚</span>
+          <h2 className="text-xl font-bold text-[var(--color-text-primary)]">知識庫貢獻</h2>
+          <span className="text-sm text-[var(--color-text-muted)]">({knowledge.length})</span>
+        </div>
+        {knowledge.length === 0 ? (
+          <div className="glass rounded-xl p-6 text-center text-[var(--color-text-muted)]">
+            尚無知識庫貢獻
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2">
+            {knowledge.map((entry) => (
+              <a
+                key={entry.id}
+                href={`/knowledge`}
+                className="glass rounded-xl p-4 hover:border-[var(--color-primary)] transition-colors block"
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <span className="text-2xl">{entry.icon || '📘'}</span>
+                  <h3 className="font-semibold text-[var(--color-text-primary)] truncate flex-1">{entry.title}</h3>
+                </div>
+                <p className="text-sm text-[var(--color-text-muted)] line-clamp-2 mb-3">{entry.content}</p>
+                <div className="flex items-center justify-between text-xs text-[var(--color-text-muted)]">
+                  <span className="text-[10px] px-2 py-0.5 rounded-full bg-[var(--color-bg-surface)]">
+                    {CATEGORY_LABELS[entry.category] || entry.category}
+                  </span>
+                  <span>{formatTimeAgo(entry.created_at)}</span>
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/team/MemberProfile.tsx
+++ b/src/components/team/MemberProfile.tsx
@@ -62,6 +62,7 @@ function formatTimeAgo(dateStr: string): string {
   return `${Math.floor(diff / 2592000)} 個月前`;
 }
 
+<<<<<<< HEAD
 const SAFE_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
 function safeColor(c: string | undefined): string {
   if (!c || !SAFE_COLOR_RE.test(c)) return '#6B7280';

--- a/src/components/team/TeamBoard.tsx
+++ b/src/components/team/TeamBoard.tsx
@@ -158,6 +158,19 @@ export default function TeamBoard() {
                     {member.bio}
                   </p>
                 )}
+
+                {/* View Profile Button */}
+                <a
+                  href={`/team/${member.id}`}
+                  className="mt-3 px-3 py-1.5 rounded-lg text-xs font-medium transition-all hover:opacity-80"
+                  style={{
+                    background: `${member.color}15`,
+                    color: member.color,
+                    border: `1px solid ${member.color}30`,
+                  }}
+                >
+                  查看空間 →
+                </a>
               </div>
             ))}
           </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,14 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-15 18:45',
+    changes: [
+      'feat(#50): 成員個人空間 — /team/:id 顯示成員資訊、AI 工具投稿、知識庫貢獻',
+      'feat(#50): 團隊頁新增「查看空間」按鈕，連結至成員個人頁面',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-16',
     changes: [
       'feat(#51-E5): Admin Panel 討論區管理 — 顯示所有留言含已刪除，管理員可軟刪除/復原/切換置頂',

--- a/src/pages/team/[id].astro
+++ b/src/pages/team/[id].astro
@@ -1,0 +1,12 @@
+---
+import Layout from '@/layouts/Layout.astro';
+import MemberProfile from '@/components/team/MemberProfile';
+
+export const prerender = false;
+
+const { id } = Astro.params;
+---
+
+<Layout title="成員空間" description="共學團成員的個人空間">
+  <MemberProfile client:load memberId={id!} />
+</Layout>


### PR DESCRIPTION
## Summary
- TeamBoard 成員卡片新增連結到個人頁
- 新增 MemberProfile.tsx 元件顯示成員詳細資訊
- 新增 /team/[id] 動態路由頁面（每位成員一頁）
- 更新 changelog

## Test plan
- [ ] `bun run build` 通過（47 pages）
- [ ] 團隊頁成員卡片可點擊進入個人頁
- [ ] 個人頁正確顯示成員資訊

🤖 Generated with [Claude Code](https://claude.com/claude-code)