### PR TITLE
fix: build 修正 — 回復靜態生成、清除 conflict markers

### DIFF
--- a/src/components/team/MemberProfile.tsx
+++ b/src/components/team/MemberProfile.tsx
@@ -62,7 +62,6 @@ function formatTimeAgo(dateStr: string): string {
   return `${Math.floor(diff / 2592000)} 個月前`;
 }
 
-<<<<<<< HEAD
 const SAFE_COLOR_RE = /^#[0-9a-fA-F]{3,8}$/;
 function safeColor(c: string | undefined): string {
   if (!c || !SAFE_COLOR_RE.test(c)) return '#6B7280';

--- a/src/pages/team/[id].astro
+++ b/src/pages/team/[id].astro
@@ -1,8 +1,13 @@
 ---
 import Layout from '@/layouts/Layout.astro';
 import MemberProfile from '@/components/team/MemberProfile';
+import { MEMBERS } from '@/lib/constants';
 
-export const prerender = false;
+export async function getStaticPaths() {
+  return MEMBERS.map((member) => ({
+    params: { id: member.id },
+  }));
+}
 
 const { id } = Astro.params;
 ---


### PR DESCRIPTION
## Summary
- `[id].astro` 回復 `getStaticPaths` 靜態生成（Astro v5 static 模式不支援 SSR）
- `MemberProfile.tsx` 清除殘留 conflict markers（導致 build 失敗）

## Context
PR #86 的 `prerender = false` 在 Astro v5 `output: 'static'` 模式下無法運作，造成 Cloudflare Pages build 卡住。

🤖 Generated with [Claude Code](https://claude.com/claude-code)