### PR TITLE
test(#91): e2e demo tour spec — LambdaTest 導覽影片 + 報告

### DIFF
--- a/e2e/demo-tour.spec.ts
+++ b/e2e/demo-tour.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from './lambdatest-setup';
+import fs from 'fs';
+
+/**
+ * 老闆 Demo Tour — 單一 test session（= 一支完整影片），內部用 test.step() 分段。
+ * 每個 step 結束時累計時間，test 最後產生 ContactLoop 風格的 markdown 報告。
+ */
+
+test.describe.configure({ retries: 0 });
+test.use({ viewport: { width: 1280, height: 720 } });
+
+const dwell = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const ACT = { timeout: 3000 };
+
+type StepResult = { name: string; durationMs: number; status: 'passed' | 'failed' };
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+}
+
+test.describe('Cyclone Demo Tour', () => {
+  test('walkthrough with interactions', async ({ page }) => {
+    test.setTimeout(360_000);
+
+    const results: StepResult[] = [];
+    const section = async (name: string, fn: () => Promise<void>) => {
+      await test.step(name, async () => {
+        const start = Date.now();
+        try {
+          await fn();
+          results.push({ name, durationMs: Date.now() - start, status: 'passed' });
+        } catch (e) {
+          results.push({ name, durationMs: Date.now() - start, status: 'failed' });
+          throw e;
+        }
+      });
+    };
+
+    await section('首頁 + 導覽列互動', async () => {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await dwell(2000);
+
+      const nav = page.locator('nav').first();
+      await nav.getByText('討論區').first().hover(ACT).catch(() => {});
+      await dwell(600);
+      await nav.getByText('團隊').first().hover(ACT).catch(() => {});
+      await dwell(600);
+
+      const moreBtn = page.locator('#more-menu-btn');
+      if (await moreBtn.isVisible().catch(() => false)) {
+        await moreBtn.click(ACT).catch(() => {});
+        await dwell(1800);
+        await page.keyboard.press('Escape').catch(() => {});
+        await dwell(500);
+      }
+
+      await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight / 2 }));
+      await dwell(1200);
+      await page.evaluate(() => window.scrollTo({ top: 0 }));
+      await dwell(700);
+    });
+
+    const stops = [
+      { path: '/discuss/', label: '討論區' },
+      { path: '/team/', label: '團隊' },
+      { path: '/knowledge/', label: '知識庫' },
+      { path: '/wishlist/', label: '許願樹' },
+      { path: '/changelog/', label: 'Changelog' },
+      { path: '/leaderboard/', label: '積分榜' },
+    ];
+
+    for (const { path, label } of stops) {
+      await section(label, async () => {
+        const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+        expect(res?.status(), `${label} status`).toBeLessThan(400);
+        await dwell(1500);
+
+        await page.locator('main a, main article, main li').first().hover(ACT).catch(() => {});
+        await dwell(600);
+
+        await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight / 2 }));
+        await dwell(1200);
+        await page.evaluate(() => window.scrollTo({ top: 0 }));
+        await dwell(600);
+      });
+    }
+
+    await section('手機 RWD（375×667 + 漢堡選單）', async () => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await dwell(1500);
+
+      const burger = page.locator('#mobile-menu-btn');
+      if (await burger.isVisible().catch(() => false)) {
+        await burger.click(ACT).catch(() => {});
+        await dwell(2000);
+        await burger.click(ACT).catch(() => {});
+        await dwell(500);
+      }
+      await page.evaluate(() => window.scrollTo({ top: 400 }));
+      await dwell(1000);
+    });
+
+    // 產生 ContactLoop 風格的 markdown 報告
+    const passed = results.filter((r) => r.status === 'passed').length;
+    const failed = results.length - passed;
+    const header =
+      failed === 0
+        ? `ALL PASSED — 共 ${results.length} 項：✅ ${passed} passed, ❌ 0 failed, ⚠️ 0 error`
+        : `共 ${results.length} 項：✅ ${passed} passed, ❌ ${failed} failed`;
+    const lines = [
+      `# Cyclone Tour — prod 測試報告`,
+      ``,
+      `日期：${new Date().toLocaleString('zh-TW', { timeZone: 'Asia/Taipei' })}`,
+      `Base URL：${process.env.E2E_BASE_URL || 'https://cyclone.tw'}`,
+      `Viewport：1280×720 → 375×667（末段手機 RWD）`,
+      `Browser：Chrome latest @ Windows 10（LambdaTest 雲端）`,
+      ``,
+      header,
+      ``,
+      ...results.map((r) => {
+        const icon = r.status === 'passed' ? '✅' : '❌';
+        const status = r.status === 'passed' ? 'Passed' : 'Failed';
+        return `${icon} ${r.name} — ${status} (${formatDuration(r.durationMs)})`;
+      }),
+      ``,
+    ];
+    fs.mkdirSync('test-results', { recursive: true });
+    fs.writeFileSync('test-results/demo-report.md', lines.join('\n'));
+    console.log('\n' + lines.join('\n'));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:e2e": "playwright test",
     "test:e2e:local": "E2E_BASE_URL=http://localhost:4321 playwright test",
     "test:e2e:lt": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:demo": "RUN_DEMO_TOUR=1 playwright test e2e/demo-tour.spec.ts"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260413.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,9 @@ const useLambdaTest = !!process.env.LT_USERNAME;
 
 export default defineConfig({
   testDir: './e2e',
+  // demo-tour 是給 stakeholder 看的導覽影片，不屬於 regression 套件 —
+  // 只有明確設 RUN_DEMO_TOUR=1（或 `bun run test:e2e:demo`）才納入。
+  testIgnore: process.env.RUN_DEMO_TOUR ? [] : ['**/demo-tour.spec.ts'],
   timeout: 60_000,
   retries: 1,
   reporter: [['list'], ['html', { open: 'never' }]],


### PR DESCRIPTION
Closes #91

## Summary

- 新增 `e2e/demo-tour.spec.ts`：單一 test 對應 LambdaTest 一支完整導覽影片（~1.3 min）
- 內部以 `test.step()` 分 8 段 → HTML 報告可展開逐項檢視時間
- 測試結束自動產出 ContactLoop 風格 markdown 報告到 `test-results/demo-report.md`
- 所有 hover / click 設 3 秒 timeout + `.catch()`，避免 LambdaTest session idle timeout 強制關閉
- **隔離**：`playwright.config.ts` 預設 `testIgnore` 掉這支 spec，只有 `RUN_DEMO_TOUR=1` 才納入；一般 `bun run test:e2e` / CI 不會跑到

## Covered steps

| # | 頁面 | 互動 |
|---|---|---|
| 1 | `/` | hover 導覽列、打開「更多」下拉、Esc 關閉、捲動 |
| 2 | `/discuss/` | hover 第一則訊息、捲動 |
| 3 | `/team/` | hover 第一位成員、捲動 |
| 4 | `/knowledge/` | hover 第一張卡、捲動 |
| 5 | `/wishlist/` | hover 第一項、捲動 |
| 6 | `/changelog/` | hover 第一則、捲動 |
| 7 | `/leaderboard/` | hover 第一名、捲動 |
| 8 | `/` @ 375×667 | 打開漢堡選單、捲動（手機 RWD） |

## Run

LambdaTest 雲端（走專屬 npm script）：

```bash
LT_USERNAME=... LT_ACCESS_KEY=... E2E_BASE_URL=https://cyclone.tw \
  bun run test:e2e:demo -- --project=chrome-latest-win10@lambdatest
```

本機：省略 LT 認證會 fallback 成本機 Playwright（無 `--project`）。

**為什麼要隔離：** demo tour 是給 stakeholder 看的 1.3-min 導覽，不屬於 regression。predicate 是 `RUN_DEMO_TOUR=1`，驗證：
- `bunx playwright test --list` → 63 tests in 7 files（不含 demo）
- `RUN_DEMO_TOUR=1 bunx playwright test --list` → 1 test in 1 file（只有 demo）

## Test plan

- [x] LambdaTest 雲端 8 個 step 全 pass
- [x] `test-results/demo-report.md` 正確產出
- [x] LambdaTest 公開影片 URL 可匿名存取
- [x] `bun run test:e2e` 預設不會跑到 demo（testIgnore 生效）

🎬 **prod E2E 影片：** https://automation.lambdatest.com/public/video?testID=DA-WIN-2102426-1776324363957243472EZQ&auth=a87758165f3ee269963408a9550eacc7

📋 **測試報告：**

```
ALL PASSED — 共 8 項：✅ 8 passed, ❌ 0 failed, ⚠️ 0 error
✅ 首頁 + 導覽列互動 — Passed (00:00:17)
✅ 討論區 — Passed (00:00:06)
✅ 團隊 — Passed (00:00:08)
✅ 知識庫 — Passed (00:00:05)
✅ 許願樹 — Passed (00:00:06)
✅ Changelog — Passed (00:00:05)
✅ 積分榜 — Passed (00:00:08)
✅ 手機 RWD（375×667 + 漢堡選單） — Passed (00:00:07)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)