### PR TITLE
feat(#90): 知識庫 / AI 工具箱留言回饋機制

### DIFF
--- a/functions/api/ai-tools/[id]/comments.ts
+++ b/functions/api/ai-tools/[id]/comments.ts
@@ -1,0 +1,98 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// GET /api/ai-tools/:id/comments
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const id = String(context.params.id);
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `
+        SELECT
+          rc.id, rc.content, rc.created_at, rc.updated_at,
+          u.id AS author_id, u.name AS author_name, u.avatar_url AS author_avatar
+        FROM resource_comments rc
+        JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        WHERE rc.resource_type = 'ai-tool' AND rc.resource_id = ?
+        ORDER BY rc.created_at DESC
+      `,
+      args: [id],
+    });
+
+    return new Response(JSON.stringify({ ok: true, comments: result.rows }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+// POST /api/ai-tools/:id/comments
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const id = String(context.params.id);
+    const { content } = (await context.request.json()) as { content?: string };
+
+    if (!content?.trim()) {
+      return new Response(JSON.stringify({ ok: false, error: '請填寫留言內容' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = getDb(context.env);
+
+    const toolResult = await db.execute({
+      sql: 'SELECT contributor_id FROM ai_tools WHERE id = ?',
+      args: [id],
+    });
+    if (toolResult.rows.length === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到這個工具' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const commentId = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO resource_comments (id, resource_type, resource_id, user_id, content) VALUES (?, 'ai-tool', ?, ?, ?)`,
+      args: [commentId, id, user.id, content.trim()],
+    });
+
+    // Award +2 points to contributor (skip if commenting on own post)
+    const contributorId = toolResult.rows[0].contributor_id as string;
+    if (contributorId && contributorId !== user.id) {
+      const ledgerId = crypto.randomUUID();
+      await db.execute({
+        sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, 'resource_comment', ?)`,
+        args: [ledgerId, contributorId, 'resource_comment', 2, commentId],
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, id: commentId }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/ai-tools/[id]/comments.ts
+++ b/functions/api/ai-tools/[id]/comments.ts
@@ -54,8 +54,26 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+    if (content.trim().length > 1000) {
+      return new Response(JSON.stringify({ ok: false, error: '留言內容不得超過 1000 字' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const db = getDb(context.env);
+
+    // Rate limit: max 10 comments per minute per user
+    const recent = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM resource_comments WHERE user_id = ? AND created_at > datetime('now', '-1 minute')`,
+      args: [user.id],
+    });
+    if (Number(recent.rows[0]?.cnt) >= 10) {
+      return new Response(JSON.stringify({ ok: false, error: '留言太頻繁，請稍後再試' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const toolResult = await db.execute({
       sql: 'SELECT contributor_id FROM ai_tools WHERE id = ?',

--- a/functions/api/comments/[id].ts
+++ b/functions/api/comments/[id].ts
@@ -40,6 +40,12 @@ export const onRequestDelete: PagesFunction<Env> = async (context) => {
       });
     }
 
+    // Also remove points_ledger entry for this comment
+    await db.execute({
+      sql: `DELETE FROM points_ledger WHERE ref_type = 'resource_comment' AND ref_id = ?`,
+      args: [id],
+    });
+
     await db.execute({
       sql: 'DELETE FROM resource_comments WHERE id = ?',
       args: [id],

--- a/functions/api/comments/[id].ts
+++ b/functions/api/comments/[id].ts
@@ -1,0 +1,59 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth, ROLE_LEVEL } from '../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+function isAdminOrAbove(user: { effectiveRole: string }): boolean {
+  return (ROLE_LEVEL[user.effectiveRole] ?? 0) >= (ROLE_LEVEL['admin'] ?? 0);
+}
+
+// DELETE /api/comments/:id
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const id = context.params.id as string;
+    const db = getDb(context.env);
+
+    const existing = await db.execute({
+      sql: 'SELECT user_id FROM resource_comments WHERE id = ?',
+      args: [id],
+    });
+    if (existing.rows.length === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到這則留言' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const isOwner = existing.rows[0].user_id === user.id;
+    if (!isOwner && !isAdminOrAbove(user)) {
+      return new Response(JSON.stringify({ ok: false, error: '權限不足' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    await db.execute({
+      sql: 'DELETE FROM resource_comments WHERE id = ?',
+      args: [id],
+    });
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -247,6 +247,18 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+      {
+        sql: `CREATE TABLE IF NOT EXISTS resource_comments (
+          id TEXT PRIMARY KEY,
+          resource_type TEXT NOT NULL CHECK(resource_type IN ('knowledge', 'ai-tool')),
+          resource_id TEXT NOT NULL,
+          user_id TEXT NOT NULL REFERENCES users(id),
+          content TEXT NOT NULL,
+          created_at TEXT DEFAULT (datetime('now')),
+          updated_at TEXT DEFAULT (datetime('now'))
+        )`,
+        args: [],
+      },
     ]);
 
     // --- Migrations: add missing columns to existing tables ---

--- a/functions/api/knowledge/[id]/comments.ts
+++ b/functions/api/knowledge/[id]/comments.ts
@@ -54,8 +54,26 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         headers: { 'Content-Type': 'application/json' },
       });
     }
+    if (content.trim().length > 1000) {
+      return new Response(JSON.stringify({ ok: false, error: '留言內容不得超過 1000 字' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const db = getDb(context.env);
+
+    // Rate limit: max 10 comments per minute per user
+    const recent = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM resource_comments WHERE user_id = ? AND created_at > datetime('now', '-1 minute')`,
+      args: [user.id],
+    });
+    if (Number(recent.rows[0]?.cnt) >= 10) {
+      return new Response(JSON.stringify({ ok: false, error: '留言太頻繁，請稍後再試' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const entryResult = await db.execute({
       sql: 'SELECT contributor_id FROM knowledge_entries WHERE id = ?',

--- a/functions/api/knowledge/[id]/comments.ts
+++ b/functions/api/knowledge/[id]/comments.ts
@@ -1,0 +1,98 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// GET /api/knowledge/:id/comments
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const id = context.params.id as string;
+    const db = getDb(context.env);
+
+    const result = await db.execute({
+      sql: `
+        SELECT
+          rc.id, rc.content, rc.created_at, rc.updated_at,
+          u.id AS author_id, u.name AS author_name, u.avatar_url AS author_avatar
+        FROM resource_comments rc
+        JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        WHERE rc.resource_type = 'knowledge' AND rc.resource_id = ?
+        ORDER BY rc.created_at DESC
+      `,
+      args: [id],
+    });
+
+    return new Response(JSON.stringify({ ok: true, comments: result.rows }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+// POST /api/knowledge/:id/comments
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const id = context.params.id as string;
+    const { content } = (await context.request.json()) as { content?: string };
+
+    if (!content?.trim()) {
+      return new Response(JSON.stringify({ ok: false, error: '請填寫留言內容' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = getDb(context.env);
+
+    const entryResult = await db.execute({
+      sql: 'SELECT contributor_id FROM knowledge_entries WHERE id = ?',
+      args: [id],
+    });
+    if (entryResult.rows.length === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '找不到這筆知識' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const commentId = crypto.randomUUID();
+    await db.execute({
+      sql: `INSERT INTO resource_comments (id, resource_type, resource_id, user_id, content) VALUES (?, 'knowledge', ?, ?, ?)`,
+      args: [commentId, id, user.id, content.trim()],
+    });
+
+    // Award +2 points to contributor (skip if commenting on own post)
+    const contributorId = entryResult.rows[0].contributor_id as string;
+    if (contributorId && contributorId !== user.id) {
+      const ledgerId = crypto.randomUUID();
+      await db.execute({
+        sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, 'resource_comment', ?)`,
+        args: [ledgerId, contributorId, 'resource_comment', 2, commentId],
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, id: commentId }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -1,0 +1,251 @@
+import { useState, useCallback } from 'react';
+import { timeAgo } from '@/lib/time';
+
+interface Comment {
+  id: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+  author_id: string;
+  author_name: string;
+  author_avatar: string | null;
+}
+
+interface User {
+  id: string;
+  name: string;
+  avatar_url?: string | null;
+  effectiveRole: string;
+}
+
+interface ResourceCommentsProps {
+  resourceType: 'knowledge' | 'ai-tool';
+  resourceId: string;
+  user: User | null;
+  color?: string;
+}
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  background: 'rgba(10, 10, 26, 0.6)',
+  border: '1px solid #2A2A4A',
+  borderRadius: '0.5rem',
+  padding: '0.5rem 0.75rem',
+  color: '#F0F0FF',
+  fontSize: '0.85rem',
+  outline: 'none',
+  transition: 'border-color 0.2s ease, box-shadow 0.2s ease',
+  boxSizing: 'border-box',
+};
+
+function handleFocusIn(e: React.FocusEvent<HTMLTextAreaElement>) {
+  e.target.style.borderColor = '#6C63FF';
+  e.target.style.boxShadow = '0 0 0 3px rgba(108,99,255,0.15)';
+}
+
+function handleFocusOut(e: React.FocusEvent<HTMLTextAreaElement>) {
+  e.target.style.borderColor = '#2A2A4A';
+  e.target.style.boxShadow = 'none';
+}
+
+function Avatar({ name, avatarUrl, size = 24 }: { name: string; avatarUrl: string | null; size?: number }) {
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={name}
+        style={{ width: size, height: size, borderRadius: '50%', objectFit: 'cover' }}
+      />
+    );
+  }
+  return (
+    <span
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: size * 0.5,
+        fontWeight: 700,
+        background: 'rgba(108,99,255,0.25)',
+        color: '#B8B0FF',
+        flexShrink: 0,
+      }}
+    >
+      {name.charAt(0).toUpperCase()}
+    </span>
+  );
+}
+
+export default function ResourceComments({ resourceType, resourceId, user, color = '#6C63FF' }: ResourceCommentsProps) {
+  const [open, setOpen] = useState(false);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const isAdmin = user ? ['captain', 'tech', 'admin'].includes(user.effectiveRole) : false;
+
+  const loadComments = useCallback(async () => {
+    if (comments.length > 0) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/${resourceType === 'knowledge' ? 'knowledge' : 'ai-tools'}/${resourceId}/comments`);
+      const data = await res.json();
+      if (data.ok) setComments(data.comments || []);
+    } catch { /* ignore */ }
+    setLoading(false);
+  }, [comments.length, resourceType, resourceId]);
+
+  const toggleOpen = () => {
+    if (!open) loadComments();
+    setOpen(!open);
+  };
+
+  const submit = async () => {
+    if (!content.trim() || !user) return;
+    setSubmitting(true);
+    try {
+      const res = await fetch(`/api/${resourceType === 'knowledge' ? 'knowledge' : 'ai-tools'}/${resourceId}/comments`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: content.trim() }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setContent('');
+        const reloadRes = await fetch(`/api/${resourceType === 'knowledge' ? 'knowledge' : 'ai-tools'}/${resourceId}/comments`);
+        const reloadData = await reloadRes.json();
+        if (reloadData.ok) setComments(reloadData.comments || []);
+      }
+    } catch { /* ignore */ }
+    setSubmitting(false);
+  };
+
+  const deleteComment = async (commentId: string) => {
+    if (!confirm('確定要刪除這則留言嗎？')) return;
+    try {
+      const res = await fetch(`/api/comments/${commentId}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (data.ok) {
+        setComments(prev => prev.filter(c => c.id !== commentId));
+      }
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div style={{ marginTop: '0.25rem' }}>
+      <button
+        onClick={toggleOpen}
+        style={{
+          width: '100%',
+          textAlign: 'left',
+          padding: '0.5rem 0.625rem',
+          background: 'rgba(10,10,26,0.3)',
+          border: `1px solid ${color}15`,
+          borderRadius: '0.5rem',
+          color: '#9090B0',
+          fontSize: '0.75rem',
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <span>💬 留言 ({comments.length})</span>
+        <span style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>▼</span>
+      </button>
+
+      {open && (
+        <div style={{
+          marginTop: '0.5rem',
+          padding: '0.75rem',
+          background: 'rgba(10,10,26,0.3)',
+          borderRadius: '0.5rem',
+          border: `1px solid ${color}15`,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.75rem',
+        }}>
+          {loading ? (
+            <div style={{ fontSize: '0.8rem', color: '#606080' }}>載入留言中...</div>
+          ) : comments.length === 0 ? (
+            <div style={{ fontSize: '0.8rem', color: '#606080' }}>尚無留言，來發表第一則吧！</div>
+          ) : (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+              {comments.map((c) => (
+                <div key={c.id} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+                  <Avatar name={c.author_name} avatarUrl={c.author_avatar} size={24} />
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+                      <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#F0F0FF' }}>{c.author_name}</span>
+                      <span style={{ fontSize: '0.65rem', color: '#505070' }}>{timeAgo(c.created_at)}</span>
+                      {(c.author_id === user?.id || isAdmin) && (
+                        <button
+                          onClick={() => deleteComment(c.id)}
+                          style={{
+                            marginLeft: 'auto',
+                            fontSize: '0.65rem',
+                            color: '#E94560',
+                            background: 'transparent',
+                            border: 'none',
+                            cursor: 'pointer',
+                            padding: 0,
+                          }}
+                        >
+                          刪除
+                        </button>
+                      )}
+                    </div>
+                    <div style={{ fontSize: '0.85rem', color: '#B8B0FF', lineHeight: 1.5, whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                      {c.content}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {user && (
+            <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+              <Avatar name={user.name} avatarUrl={user.avatar_url ?? null} size={28} />
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                <textarea
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                  placeholder="發表留言..."
+                  rows={2}
+                  style={{ ...inputStyle, resize: 'vertical' }}
+                  onFocus={handleFocusIn}
+                  onBlur={handleFocusOut}
+                  maxLength={500}
+                />
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <button
+                    onClick={submit}
+                    disabled={submitting || !content.trim()}
+                    style={{
+                      fontSize: '0.8rem',
+                      padding: '0.4rem 1rem',
+                      borderRadius: '0.5rem',
+                      border: 'none',
+                      background: content.trim() ? color : '#2A2A4A',
+                      color: '#fff',
+                      cursor: content.trim() ? 'pointer' : 'not-allowed',
+                      fontWeight: 600,
+                      opacity: submitting ? 0.6 : 1,
+                    }}
+                  >
+                    {submitting ? '發送中...' : '發送'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -6,6 +6,8 @@ import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { ROLE_LEVEL } from '@/lib/auth';
 import { sanitizeMarkdown, sanitizeUrl, sanitizeImgSrc } from '@/lib/markdown';
+import ResourceComments from '@/components/ResourceComments';
+import ResourceComments from '@/components/ResourceComments';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -326,7 +328,7 @@ function DeleteConfirm({ tool, onConfirm, onCancel }: { tool: Tool; onConfirm: (
 
 // ─── Tool Card ────────────────────────────────────────────────────────────────
 
-function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite }: { tool: Tool; canEdit: boolean; loggedIn: boolean; onEdit: () => void; onDelete: () => void; onToggleFavorite: () => void }) {
+function ToolCard({ tool, canEdit, loggedIn, user, onEdit, onDelete, onToggleFavorite }: { tool: Tool; canEdit: boolean; loggedIn: boolean; user: { id: string; name: string; avatar_url?: string | null; effectiveRole: string } | null; onEdit: () => void; onDelete: () => void; onToggleFavorite: () => void }) {
   const cfg = CATEGORY_CONFIG[tool.category] || CATEGORY_CONFIG.other;
   const [favBusy, setFavBusy] = useState(false);
   const [expanded, setExpanded] = useState(false);
@@ -534,6 +536,16 @@ function ToolCard({ tool, canEdit, loggedIn, onEdit, onDelete, onToggleFavorite 
             </span>
           ))}
         </div>
+      )}
+
+      {/* Comments */}
+      {expanded && (
+        <ResourceComments
+          resourceType="ai-tool"
+          resourceId={String(tool.id)}
+          user={user}
+          color={cfg.color}
+        />
       )}
 
       {/* Footer */}
@@ -795,6 +807,7 @@ export default function ToolCardBoard() {
               tool={tool}
               canEdit={canEditMap[tool.id as number] || false}
               loggedIn={!!user}
+              user={user}
               onEdit={() => setEditingTool(tool)}
               onDelete={() => setDeletingTool(tool)}
               onToggleFavorite={() => toggleFavorite(tool)}

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -7,7 +7,6 @@ import { timeAgo } from '@/lib/time';
 import { ROLE_LEVEL } from '@/lib/auth';
 import { sanitizeMarkdown, sanitizeUrl, sanitizeImgSrc } from '@/lib/markdown';
 import ResourceComments from '@/components/ResourceComments';
-import ResourceComments from '@/components/ResourceComments';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -175,14 +175,21 @@ export default function DashboardPanel() {
       if (data.ok) {
         setCheckedInToday(true);
         setToast('打卡成功！繼續保持！');
-        // Re-fetch stats from server to get accurate streak after checkin
+        // Re-fetch stats and points from server to get accurate data after checkin
         try {
-          const statsRes = await fetch('/api/checkin/stats');
+          const [statsRes, pointsRes] = await Promise.all([
+            fetch('/api/checkin/stats'),
+            fetch('/api/points/me?limit=5'),
+          ]);
           const statsData = await statsRes.json();
+          const pointsData = await pointsRes.json();
           if (statsData.ok && statsData.stats) {
             setStats(statsData.stats);
           } else {
             updateStatsFromCheckin(data);
+          }
+          if (pointsData.ok) {
+            setPointsData({ totalPoints: pointsData.totalPoints, records: pointsData.records });
           }
         } catch {
           updateStatsFromCheckin(data);

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -427,7 +427,7 @@ export default function DashboardPanel() {
               <span className="text-xs text-[var(--color-text-muted)] bg-[var(--color-bg-surface)] rounded-full px-2 py-0.5">累計</span>
             </div>
             <div className="text-2xl font-bold text-[var(--color-text-primary)] mb-1">
-              {stats?.totalPoints ?? 0}
+              {pointsData?.totalPoints ?? stats?.totalPoints ?? 0}
               <span className="text-[var(--color-text-muted)] text-base font-normal"> 分</span>
             </div>
             <div className="text-xs text-[var(--color-text-secondary)]">累計積分</div>

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -5,6 +5,8 @@ import rehypeRaw from 'rehype-raw';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { sanitizeMarkdown, sanitizeUrl, sanitizeImgSrc } from '@/lib/markdown';
+import ResourceComments from '@/components/ResourceComments';
+import ResourceComments from '@/components/ResourceComments';
 
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -387,6 +389,7 @@ function EntryCard({
   entry,
   canEdit,
   loggedIn,
+  user,
   onEdit,
   onDelete,
   onToggleFavorite,
@@ -394,6 +397,7 @@ function EntryCard({
   entry: KnowledgeEntry;
   canEdit: boolean;
   loggedIn: boolean;
+  user: { id: string; name: string; avatar_url?: string | null; effectiveRole: string } | null;
   onEdit: () => void;
   onDelete: () => void;
   onToggleFavorite: () => void;
@@ -619,6 +623,16 @@ function EntryCard({
         </div>
       )}
 
+      {/* Comments */}
+      {expanded && (
+        <ResourceComments
+          resourceType="knowledge"
+          resourceId={entry.id}
+          user={user}
+          color={cfg.color}
+        />
+      )}
+
       {/* Footer */}
       <div
         style={{
@@ -652,6 +666,7 @@ function CategorySection({
   entries,
   canEditMap,
   loggedIn,
+  user,
   onEdit,
   onDelete,
   onToggleFavorite,
@@ -660,6 +675,7 @@ function CategorySection({
   entries: KnowledgeEntry[];
   canEditMap: Record<string, boolean>;
   loggedIn: boolean;
+  user: { id: string; name: string; avatar_url?: string | null; effectiveRole: string } | null;
   onEdit: (entry: KnowledgeEntry) => void;
   onDelete: (entry: KnowledgeEntry) => void;
   onToggleFavorite: (entry: KnowledgeEntry) => void;
@@ -702,6 +718,7 @@ function CategorySection({
             entry={entry}
             canEdit={canEditMap[entry.id] || false}
             loggedIn={loggedIn}
+            user={user}
             onEdit={() => onEdit(entry)}
             onDelete={() => onDelete(entry)}
             onToggleFavorite={() => onToggleFavorite(entry)}
@@ -980,6 +997,7 @@ export default function KnowledgeBoard() {
               entries={items}
               canEditMap={canEditMap}
               loggedIn={!!user}
+              user={user}
               onEdit={(entry) => setEditingEntry(entry)}
               onDelete={(entry) => setDeletingEntry(entry)}
               onToggleFavorite={(entry) => toggleFavorite(entry)}

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -6,7 +6,6 @@ import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { sanitizeMarkdown, sanitizeUrl, sanitizeImgSrc } from '@/lib/markdown';
 import ResourceComments from '@/components/ResourceComments';
-import ResourceComments from '@/components/ResourceComments';
 
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -16,7 +16,6 @@ export const CHANGELOG: ChangelogEntry[] = [
       'fix(#88): AI 工具箱成員篩選下拉選單無內容 — 補上 fetchMembers useEffect',
     ],
   },
-  },
   {
     version: '',
     date: '2026-04-15 17:45',

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -10,26 +10,12 @@ export const CHANGELOG: ChangelogEntry[] = [
     date: '2026-04-16',
     changes: [
       'feat(#89): 知識庫 / AI 工具箱 Markdown 渲染支援 — 支援 GFM 語法（表格、刪除線等），所有內容經 XSS 防護過濾',
-    ],
-  },
-  {
-    version: '',
-    date: '2026-04-16',
-    changes: [
+      'feat(#90): 知識庫/AI工具箱留言回饋機制 — resource_comments 表、API、前端留言區',
+      'feat(#90): 收到 resource 留言時投稿者自動獲得 +2 積分',
+      'fix(#90): 修復 Dashboard 累計積分未正確顯示 points_ledger 總分問題',
       'fix(#88): AI 工具箱成員篩選下拉選單無內容 — 補上 fetchMembers useEffect',
     ],
   },
-  {
-    version: '',
-    date: '2026-04-15 18:45',
-  },
-  {
-    version: '',
-    date: '2026-04-15 18:05',
-    changes: [
-      'feat(#60): 許願樹 AI 工具箱關聯 — 認領者可投稿工具並綁定許願卡',
-      'feat(#60): 許願完成差異化積分 — 有 AI 工具投稿 +300，一般完成 +100',
-    ],
   },
   {
     version: '',


### PR DESCRIPTION
## Summary
- 新增 resource_comments 表（知識庫/AI工具箱共用）
- API: GET/POST comments for knowledge & ai-tools, DELETE comments
- 前端: KnowledgeBoard/ToolCardBoard 卡片留言區
- 積分: 收到留言投稿者 +2
- 修復打卡後積分即時更新

## Test plan
- [ ] `bun run build` 通過
- [ ] 知識庫投稿可留言、查看、刪除
- [ ] AI 工具箱投稿可留言、查看、刪除
- [ ] 留言後投稿者積分正確增加
- [ ] 打卡後 Dashboard 積分即時更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)