### PR TITLE
feat(#51-E6): 討論區留言檢舉機制

### DIFF
--- a/functions/api/admin/reports/[id].ts
+++ b/functions/api/admin/reports/[id].ts
@@ -1,0 +1,49 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// DELETE /api/admin/reports/:id — 管理員處理/關閉檢舉
+export const onRequestDelete: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const reportId = parseInt(context.params.id ?? '', 10);
+
+    if (!reportId || isNaN(reportId)) {
+      return new Response(JSON.stringify({ ok: false, error: '無效的檢舉 ID' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = getDb(context.env);
+
+    // 將檢舉標記為 resolved（軟刪除，不影響舉報記錄）
+    const result = await db.execute({
+      sql: 'UPDATE message_reports SET status = ? WHERE id = ? AND status = ?',
+      args: ['resolved', reportId, 'pending'],
+    });
+
+    if (result.rowsAffected === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '檢舉不存在或已處理' }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/admin/reports/index.ts
+++ b/functions/api/admin/reports/index.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@libsql/client/web';
+import { requireRole } from '../../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// GET /api/admin/reports — 管理員查看所有檢舉列表
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    await requireRole(context.request, context.env, 'admin');
+    const db = getDb(context.env);
+
+    const offset = parseInt(context.request.headers.get('x-offset') || '0', 10);
+    const limit = 50;
+
+    const result = await db.execute({
+      sql: `
+        SELECT
+          mr.id,
+          mr.message_id,
+          mr.reporter_id,
+          mr.reason,
+          mr.status,
+          mr.created_at,
+          m.content AS message_content,
+          m.author AS message_author,
+          u.name AS reporter_name
+        FROM message_reports mr
+        LEFT JOIN messages m ON m.id = mr.message_id
+        LEFT JOIN users u ON u.id = mr.reporter_id
+        ORDER BY mr.created_at DESC
+        LIMIT ? OFFSET ?
+      `,
+      args: [limit, offset],
+    });
+
+    const countResult = await db.execute({
+      sql: 'SELECT COUNT(*) AS total FROM message_reports',
+      args: [],
+    });
+    const total = Number(countResult.rows[0]?.total ?? 0);
+
+    return new Response(JSON.stringify({ ok: true, reports: result.rows, total }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -247,6 +247,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+<<<<<<< HEAD
       {
         sql: `CREATE TABLE IF NOT EXISTS resource_comments (
           id TEXT PRIMARY KEY,
@@ -259,6 +260,21 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         )`,
         args: [],
       },
+||||||| parent of b8886d9 (feat(#51-E6): 討論區留言檢舉機制)
+=======
+      {
+        sql: `CREATE TABLE IF NOT EXISTS message_reports (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          message_id INTEGER NOT NULL REFERENCES messages(id),
+          reporter_id TEXT NOT NULL REFERENCES users(id),
+          reason TEXT NOT NULL,
+          status TEXT DEFAULT 'pending' CHECK(status IN ('pending', 'resolved')),
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+          UNIQUE(message_id, reporter_id)
+        )`,
+        args: [],
+      },
+>>>>>>> b8886d9 (feat(#51-E6): 討論區留言檢舉機制)
     ]);
 
     // --- Migrations: add missing columns to existing tables ---

--- a/functions/api/messages/[id]/report.ts
+++ b/functions/api/messages/[id]/report.ts
@@ -92,6 +92,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         status: 400, headers: { 'Content-Type': 'application/json' },
       });
     }
+    if (reason.trim().length > 500) {
+      return new Response(JSON.stringify({ ok: false, error: '檢舉原因不得超過 500 字' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
 
     const db = getDb(context.env);
 

--- a/functions/api/messages/[id]/report.ts
+++ b/functions/api/messages/[id]/report.ts
@@ -1,0 +1,135 @@
+import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../../../src/lib/auth.ts';
+
+interface Env {
+  TURSO_DATABASE_URL: string;
+  TURSO_AUTH_TOKEN: string;
+}
+
+function getDb(env: Env) {
+  return createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+}
+
+// HEAD /api/messages/:id/report — 檢查当前用户是否已檢舉過
+export const onRequestHead: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const messageId = parseInt(context.params.id ?? '', 10);
+    if (!messageId || isNaN(messageId)) {
+      return new Response(null, { status: 400 });
+    }
+    const db = getDb(context.env);
+    const result = await db.execute({
+      sql: 'SELECT id FROM message_reports WHERE message_id = ? AND reporter_id = ?',
+      args: [messageId, user.id],
+    });
+    if (result.rows.length > 0) {
+      return new Response(null, { status: 200 });
+    }
+    return new Response(null, { status: 404 });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    return new Response(null, { status: 500 });
+  }
+};
+
+// GET /api/messages/:id/report — 回傳單一留言的檢舉統計（供 MessageBoard GET 使用）
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const messageId = parseInt(context.params.id ?? '', 10);
+    if (!messageId || isNaN(messageId)) {
+      return new Response(JSON.stringify({ ok: false, error: '無效的留言 ID' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    const db = getDb(context.env);
+    const result = await db.execute({
+      sql: `SELECT mr.*,
+                    u.name AS reporter_name
+             FROM message_reports mr
+             LEFT JOIN users u ON u.id = mr.reporter_id
+             WHERE mr.message_id = ?
+             ORDER BY mr.created_at DESC`,
+      args: [messageId],
+    });
+    const reportedByMe = await db.execute({
+      sql: 'SELECT id FROM message_reports WHERE message_id = ? AND reporter_id = ?',
+      args: [messageId, user.id],
+    });
+    return new Response(JSON.stringify({
+      ok: true,
+      reports: result.rows,
+      reported_by_me: reportedByMe.rows.length > 0,
+    }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};
+
+// POST /api/messages/:id/report — 檢舉留言（需登入）
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  try {
+    const user = await requireAuth(context.request, context.env);
+    const messageId = parseInt(context.params.id ?? '', 10);
+
+    if (!messageId || isNaN(messageId)) {
+      return new Response(JSON.stringify({ ok: false, error: '無效的留言 ID' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { reason } = await context.request.json() as { reason?: string };
+
+    if (!reason?.trim()) {
+      return new Response(JSON.stringify({ ok: false, error: '請填寫檢舉原因' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const db = getDb(context.env);
+
+    // 檢查留言是否存在
+    const msgRow = await db.execute({
+      sql: 'SELECT id FROM messages WHERE id = ?',
+      args: [messageId],
+    });
+    if (msgRow.rows.length === 0) {
+      return new Response(JSON.stringify({ ok: false, error: '留言不存在' }), {
+        status: 404, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // 檢查是否已檢舉過
+    const existing = await db.execute({
+      sql: 'SELECT id FROM message_reports WHERE message_id = ? AND reporter_id = ?',
+      args: [messageId, user.id],
+    });
+    if (existing.rows.length > 0) {
+      return new Response(JSON.stringify({ ok: false, error: '您已經檢舉過這則留言' }), {
+        status: 409, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    await db.execute({
+      sql: 'INSERT INTO message_reports (message_id, reporter_id, reason) VALUES (?, ?, ?)',
+      args: [messageId, user.id, reason.trim()],
+    });
+
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err: unknown) {
+    if (err instanceof Response) return err;
+    const msg = err instanceof Error ? err.message : '未知錯誤';
+    return new Response(JSON.stringify({ ok: false, error: msg }), {
+      status: 500, headers: { 'Content-Type': 'application/json' },
+    });
+  }
+};

--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -18,20 +18,55 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
     const db = getDb(context.env);
 
+    // 嘗試取得當前登入使用者（optional — 不強迫登入）
+    let currentUserId: string | null = null;
+    try {
+      const { requireAuth } = await import('../../../src/lib/auth.ts');
+      const u = await requireAuth(context.request, context.env);
+      currentUserId = u.id;
+    } catch {
+      // 未登入，繼續以訪客身份
+    }
+
     const result = await db.execute({
-      sql: `SELECT m.*, COALESCE(lc.like_count, 0) as like_count
+      sql: `SELECT m.*,
+                   COALESCE(lc.like_count, 0) as like_count,
+                   COALESCE(mr.report_count, 0) AS report_count
             FROM messages m
             LEFT JOIN (
               SELECT message_id, COUNT(*) as like_count
               FROM discussion_likes
               GROUP BY message_id
             ) lc ON lc.message_id = m.id
+            LEFT JOIN (
+              SELECT message_id, COUNT(*) AS report_count
+              FROM message_reports
+              WHERE status = 'pending'
+              GROUP BY message_id
+            ) mr ON mr.message_id = m.id
             WHERE m.deleted_at IS NULL
             ORDER BY m.pinned DESC, m.created_at DESC LIMIT 100`,
       args: [],
     });
 
-    return new Response(JSON.stringify({ ok: true, messages: result.rows }), {
+    // 如果已登入，撈出該使用者的檢舉記錄
+    let reportedByMe: Set<number> = new Set();
+    if (currentUserId) {
+      const reports = await db.execute({
+        sql: 'SELECT message_id FROM message_reports WHERE reporter_id = ?',
+        args: [currentUserId],
+      });
+      for (const row of reports.rows) {
+        reportedByMe.add(row.message_id as number);
+      }
+    }
+
+    const messages = result.rows.map((row) => ({
+      ...row,
+      reported_by_me: reportedByMe.has(row.id as number),
+    }));
+
+    return new Response(JSON.stringify({ ok: true, messages }), {
       headers: {
         'Content-Type': 'application/json',
         'Access-Control-Allow-Origin': '*',

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -73,6 +73,18 @@ interface AdminMessage {
   deleted_by: string | null;
 }
 
+interface AdminReport {
+  id: number;
+  message_id: number;
+  reporter_id: string;
+  reason: string;
+  status: 'pending' | 'resolved';
+  created_at: string;
+  message_content: string | null;
+  message_author: string | null;
+  reporter_name: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -191,6 +203,13 @@ export default function AdminPanel() {
   const [messagesTotal, setMessagesTotal] = useState(0);
   const [messageAction, setMessageAction] = useState<{ id: number; loading: boolean } | null>(null);
 
+  // Admin Reports
+  const [adminReports, setAdminReports] = useState<AdminReport[]>([]);
+  const [reportsLoading, setReportsLoading] = useState(false);
+  const [reportsOffset, setReportsOffset] = useState(0);
+  const [reportsTotal, setReportsTotal] = useState(0);
+  const [reportAction, setReportAction] = useState<{ id: number; loading: boolean } | null>(null);
+
   const isAdmin = isRole('admin');
 
   const fetchData = useCallback(async () => {
@@ -227,6 +246,18 @@ export default function AdminPanel() {
           messagesOffset === 0 ? messagesData.messages : [...prev, ...messagesData.messages],
         );
         setMessagesTotal(messagesData.total);
+      }
+
+      // Fetch reports
+      const reportsRes = await fetch('/api/admin/reports', {
+        headers: { 'x-offset': String(reportsOffset) },
+      });
+      const reportsData = await reportsRes.json();
+      if (reportsData.ok) {
+        setAdminReports((prev) =>
+          reportsOffset === 0 ? reportsData.reports : [...prev, ...reportsData.reports],
+        );
+        setReportsTotal(reportsData.total);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : '載入失敗');
@@ -420,6 +451,28 @@ export default function AdminPanel() {
       setError(err instanceof Error ? err.message : '操作失敗');
     } finally {
       setMessageAction(null);
+    }
+  }
+
+  async function handleResolveReport(reportId: number) {
+    setReportAction({ id: reportId, loading: true });
+    try {
+      const res = await fetch(`/api/admin/reports/${reportId}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (!data.ok) throw new Error(data.error || '處理失敗');
+      setReportsOffset(0);
+      const reportsRes = await fetch('/api/admin/reports', {
+        headers: { 'x-offset': '0' },
+      });
+      const reportsData = await reportsRes.json();
+      if (reportsData.ok) {
+        setAdminReports(reportsData.reports);
+        setReportsTotal(reportsData.total);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '處理失敗');
+    } finally {
+      setReportAction(null);
     }
   }
 
@@ -1133,6 +1186,116 @@ export default function AdminPanel() {
               style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-secondary)' }}
             >
               載入更多 ({adminMessages.length} / {messagesTotal})
+            </button>
+          </div>
+        )}
+      </section>
+
+      {/* 檢舉管理 */}
+      <section
+        className="rounded-xl p-5"
+        style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+            🚩 檢舉管理
+          </h3>
+          <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+            {adminReports.length} / {reportsTotal} 筆檢舉
+          </span>
+        </div>
+
+        {adminReports.length === 0 && !reportsLoading ? (
+          <p className="text-sm text-center py-4" style={{ color: 'var(--color-text-muted)' }}>
+            尚無檢舉記錄
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left" style={{ color: 'var(--color-text-muted)', borderBottom: '1px solid var(--color-border)' }}>
+                  <th className="pb-2 pr-3 font-medium">留言作者</th>
+                  <th className="pb-2 pr-3 font-medium">留言摘要</th>
+                  <th className="pb-2 pr-3 font-medium">檢舉人</th>
+                  <th className="pb-2 pr-3 font-medium">原因</th>
+                  <th className="pb-2 pr-3 font-medium">時間</th>
+                  <th className="pb-2 pr-3 font-medium">狀態</th>
+                  <th className="pb-2 font-medium">操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {adminReports.map((rep) => {
+                  const isPending = rep.status === 'pending';
+                  const isActing = reportAction?.id === rep.id;
+                  return (
+                    <tr
+                      key={rep.id}
+                      className="border-b"
+                      style={{ borderColor: 'var(--color-border)', opacity: !isPending ? 0.6 : 1 }}
+                    >
+                      <td className="py-2 pr-3">
+                        <span className="text-xs">{rep.message_author || '未知'}</span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs truncate max-w-[180px] block">
+                          {rep.message_content?.slice(0, 30) || '（已刪除）'}...
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs">{rep.reporter_name || rep.reporter_id}</span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs truncate max-w-[150px] block" title={rep.reason}>
+                          {rep.reason}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span className="text-xs whitespace-nowrap">
+                          {new Date(rep.created_at).toLocaleString('zh-TW', { hour: '2-digit', minute: '2-digit' })}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3">
+                        <span
+                          className="text-[10px] px-1.5 py-0.5 rounded"
+                          style={{
+                            background: isPending ? 'rgba(233,69,96,0.1)' : 'rgba(0,245,160,0.1)',
+                            color: isPending ? '#E94560' : '#00F5A0',
+                          }}
+                        >
+                          {isPending ? '待處理' : '已處理'}
+                        </span>
+                      </td>
+                      <td className="py-2">
+                        {isPending ? (
+                          <button
+                            onClick={() => handleResolveReport(rep.id)}
+                            disabled={isActing}
+                            className="text-[10px] px-2 py-1 rounded text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 transition-colors"
+                          >
+                            {isActing ? '處理中...' : '標記已處理'}
+                          </button>
+                        ) : (
+                          <span className="text-[10px]" style={{ color: 'var(--color-text-muted)' }}>
+                            已結案
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {adminReports.length < reportsTotal && !reportsLoading && (
+          <div className="text-center mt-3">
+            <button
+              onClick={() => setReportsOffset((o) => o + 50)}
+              className="text-xs px-4 py-1.5 rounded-full border transition-colors hover:bg-[var(--color-bg-hover)]"
+              style={{ borderColor: 'var(--color-border)', color: 'var(--color-text-secondary)' }}
+            >
+              載入更多 ({adminReports.length} / {reportsTotal})
             </button>
           </div>
         )}

--- a/src/components/discuss/MessageBoard.tsx
+++ b/src/components/discuss/MessageBoard.tsx
@@ -20,6 +20,8 @@ interface Message {
   like_count: number;
   deleted_at: string | null;
   deleted_by: string | null;
+  report_count: number;
+  reported_by_me?: boolean;
 }
 
 const CATEGORIES = ['閒聊', '成果分享', '問題', '建議'];
@@ -42,6 +44,7 @@ function MessageCard({
   onDelete,
   onEdit,
   onPinToggle,
+  onReport,
 }: {
   msg: Message;
   likedIds: Set<number>;
@@ -52,6 +55,7 @@ function MessageCard({
   onDelete: (messageId: number) => void;
   onEdit: (messageId: number, newContent: string) => void;
   onPinToggle: (messageId: number, pinned: number) => void;
+  onReport: (messageId: number, reason: string) => void;
 }) {
   const color = CATEGORY_COLORS[msg.category] || 'var(--color-primary)';
   const liked = likedIds.has(msg.id);
@@ -60,6 +64,9 @@ function MessageCard({
   const [editContent, setEditContent] = useState(msg.content);
   const [editSaving, setEditSaving] = useState(false);
   const [pinLoading, setPinLoading] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
+  const [reportReason, setReportReason] = useState('');
+  const [reportSubmitting, setReportSubmitting] = useState(false);
 
   const canModify = currentUser && (
     msg.author_id === currentUser.id ||
@@ -234,6 +241,22 @@ function MessageCard({
             此留言已被刪除
           </div>
         </>
+      ) : msg.report_count >= 3 ? (
+        <>
+          <div
+            className="text-sm leading-relaxed"
+            style={{
+              color: 'var(--color-text-muted)',
+              background: 'rgba(255,77,106,0.05)',
+              border: '1px solid rgba(255,77,106,0.15)',
+              borderRadius: '0.5rem',
+              padding: '0.75rem 1rem',
+              fontStyle: 'italic',
+            }}
+          >
+            此留言因多次檢舉已隱藏
+          </div>
+        </>
       ) : (
             <>
             <div
@@ -367,8 +390,109 @@ function MessageCard({
               <span style={{ fontSize: '14px' }}>{liked ? '❤️' : '🤍'}</span>
               <span>{msg.like_count > 0 ? msg.like_count : ''}</span>
             </button>
+            {isLoggedIn && (
+              msg.reported_by_me ? (
+                <span
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs"
+                  style={{ color: 'var(--color-text-muted)', opacity: 0.5, border: 'none', cursor: 'default' }}
+                >
+                  已檢舉
+                </span>
+              ) : (
+                <button
+                  onClick={() => setShowReportDialog(true)}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                  style={{
+                    background: 'transparent',
+                    color: 'var(--color-text-muted)',
+                    border: 'none',
+                    cursor: 'pointer',
+                  }}
+                  title="檢舉留言"
+                >
+                  🚩 檢舉
+                </button>
+              )
+            )}
           </div>
         </>
+      )}
+
+      {showReportDialog && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.6)' }}
+          onClick={() => { setShowReportDialog(false); setReportReason(''); }}
+        >
+          <div
+            className="w-full max-w-sm rounded-2xl p-5"
+            style={{
+              background: 'var(--color-bg-card)',
+              border: '1px solid var(--color-border)',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-3">
+              <h4 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+                🚩 檢舉留言
+              </h4>
+              <button
+                onClick={() => { setShowReportDialog(false); setReportReason(''); }}
+                style={{ color: 'var(--color-text-muted)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px' }}
+              >
+                ×
+              </button>
+            </div>
+            <p className="text-xs mb-3" style={{ color: 'var(--color-text-muted)' }}>
+              請填寫檢舉原因，我們會儘快審核。
+            </p>
+            <textarea
+              value={reportReason}
+              onChange={(e) => setReportReason(e.target.value)}
+              placeholder="檢舉原因..."
+              rows={3}
+              maxLength={500}
+              className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-none mb-3"
+              style={{
+                background: 'var(--color-bg-surface)',
+                border: '1px solid var(--color-border)',
+                color: 'var(--color-text-primary)',
+              }}
+            />
+            <div className="flex items-center justify-end gap-2">
+              <button
+                onClick={() => { setShowReportDialog(false); setReportReason(''); }}
+                disabled={reportSubmitting}
+                className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
+                style={{
+                  background: 'transparent',
+                  color: 'var(--color-text-muted)',
+                  border: '1px solid var(--color-border)',
+                }}
+              >
+                取消
+              </button>
+              <button
+                onClick={async () => {
+                  if (!reportReason.trim()) return;
+                  setReportSubmitting(true);
+                  onReport(msg.id, reportReason.trim());
+                  setShowReportDialog(false);
+                  setReportReason('');
+                  setReportSubmitting(false);
+                }}
+                disabled={reportSubmitting || !reportReason.trim()}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-opacity"
+                style={{
+                  background: '#E94560',
+                  opacity: reportSubmitting || !reportReason.trim() ? 0.6 : 1,
+                }}
+              >
+                {reportSubmitting ? '送出中...' : '送出檢舉'}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );
@@ -425,6 +549,30 @@ export default function MessageBoard() {
       setLoading(false);
     }
   }, [user]);
+
+  const handleReport = async (messageId: number, reason: string) => {
+    try {
+      const res = await fetch(`/api/messages/${messageId}/report`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageId
+              ? { ...m, report_count: m.report_count + 1, reported_by_me: true }
+              : m
+          )
+        );
+      } else {
+        alert(data.error || '檢舉失敗');
+      }
+    } catch {
+      alert('網路錯誤，請稍後再試');
+    }
+  };
 
   useEffect(() => {
     if (!authLoading) {
@@ -795,6 +943,7 @@ export default function MessageBoard() {
               onDelete={handleDelete}
               onEdit={handleEdit}
               onPinToggle={handlePinToggle}
+              onReport={handleReport}
             />
           ))}
         </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -14,6 +14,7 @@ export const CHANGELOG: ChangelogEntry[] = [
       'feat(#90): 收到 resource 留言時投稿者自動獲得 +2 積分',
       'fix(#90): 修復 Dashboard 累計積分未正確顯示 points_ledger 總分問題',
       'fix(#88): AI 工具箱成員篩選下拉選單無內容 — 補上 fetchMembers useEffect',
+      'feat(#51-E6): 討論區留言檢舉機制 — message_reports 表 + POST /api/messages/:id/report + GET/DELETE /api/admin/reports + 前端檢舉按鈕與對話框 + Admin Panel 檢舉管理 + 被檢舉 3 次自動隱藏',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- 新增 message_reports 表
- API: POST /api/messages/:id/report, GET /api/admin/reports, DELETE /api/admin/reports/:id
- 前端: 留言檢舉按鈕 + 原因對話框 + Admin Panel 檢舉管理
- 被檢舉 3 次自動隱藏

## Test plan
- [ ] `bun run build` 通過
- [ ] 登入用戶可檢舉留言
- [ ] Admin 可查看/處理檢舉
- [ ] 被檢舉 3 次留言自動隱藏

🤖 Generated with [Claude Code](https://claude.com/claude-code)