### PR TITLE
chore(#98): Phase 2 — LEFT JOIN 黃金規則 5 稽核

### DIFF
--- a/issues/98-codebase-health/phase2-audit-report.md
+++ b/issues/98-codebase-health/phase2-audit-report.md
@@ -1,0 +1,66 @@
+---
+issue: 98
+phase: 2
+branch: fix/98_left-join-audit
+audit_date: 2026-04-17
+audit_tool: scripts/audit-left-join.ts
+---
+
+# Phase 2 — LEFT JOIN 稽核報告
+
+## TL;DR
+
+**沒有發現黃金規則 5 違規**。11 處 LEFT JOIN query 全部通過:
+- SELECT 的 id 一律帶 alias 前綴
+- GROUP BY 完整(GROUP_CONCAT 場景)
+- WHERE 條件用 alias
+
+## 執行方式
+
+```bash
+bun scripts/audit-left-join.ts
+```
+
+掃 `functions/api/**/*.ts`(共 49 檔)中的 template literal SQL,抓含 `LEFT JOIN` 的 query,分類:
+
+| 等級 | 條件 | 結果 |
+|------|------|------|
+| 🔴 HIGH | LEFT JOIN + WHERE + SELECT 裸 id | 0 處 |
+| 🟡 MED  | LEFT JOIN + WHERE | 6 處 |
+| 🟢 LOW  | LEFT JOIN 無 WHERE | 5 處 |
+
+## 6 處 MED 逐一 review
+
+| # | 檔案:行 | alias 正確? | 結論 |
+|---|--------|-------------|------|
+| 1 | `messages/index.ts:32` | `m.*` + `m.deleted_at` | ✅ 安全 |
+| 2 | `messages/[id]/report.ts:48` | `mr.*` + `mr.message_id` | ✅ 安全 |
+| 3 | `admin/announcements/[id].ts:24` | `a.*, u.name` + `a.id` | ✅ 安全 |
+| 4 | `wishes/[id].ts:57` | `w.id` + `wisher.id AS ...` + `claimer.id AS ...` | ✅ 安全(雙 alias 同表) |
+| 5 | `members/[id].ts:20` | `u.id` + `GROUP BY u.id` | ✅ 安全 |
+| 6 | `members/index.ts:19` | `u.id` + `GROUP BY u.id` | ✅ 安全 |
+
+## 5 處 LOW 逐一 review
+
+| # | 檔案:行 | 結論 |
+|---|--------|------|
+| 1 | `admin/messages/index.ts:26` | alias + 無 WHERE,只 ORDER BY → 安全 |
+| 2 | `admin/announcements/index.ts:23` | alias + 無 WHERE → 安全 |
+| 3 | `admin/reports/index.ts:23` | 全欄位都 `mr.` / `m.` / `u.` → 安全 |
+| 4 | `announcements/index.ts:21` | `a.id`, `u.name` → 安全 |
+| 5 | `ai-tools/index.ts:58` | `at.*, u.name` → 安全 |
+
+## 工具保留理由
+
+- 未來新增 LEFT JOIN 的 endpoint 可以再跑一次稽核當 regression check
+- 未來 schema 變動後可追溯影響範圍
+- 黃金規則 5 是「被燒過」才加進 AGENTS.md 的,工具化讓這類知識不會只靠口耳相傳
+
+## heuristic 限制
+
+audit 用正則掃 SQL 字串,準確度有限:
+- 不跨檔分析 view 或 CTE
+- 不解析 prepared statement 動態組裝
+- `GROUP BY` 是否完整只在人工 review 階段確認
+
+這是為什麼 MED 被歸為「建議確認」而非直接判違規 —— 工具降低人眼掃描的負擔,不取代 review。

--- a/issues/98-codebase-health/phase2-audit-report.md
+++ b/issues/98-codebase-health/phase2-audit-report.md
@@ -64,3 +64,16 @@ audit 用正則掃 SQL 字串,準確度有限:
 - `GROUP BY` 是否完整只在人工 review 階段確認
 
 這是為什麼 MED 被歸為「建議確認」而非直接判違規 —— 工具降低人眼掃描的負擔,不取代 review。
+
+## 自我檢測 (self-test)
+
+初版邏輯用「任何 id + 無任何 `alias.id`」當檢測條件,會**漏掉混合 alias + 裸 id 的 query**(例如 `SELECT u.id, id FROM ...`)。已改用 negative lookbehind 精確抓「前面不是 `.` 的 id」。
+
+腳本開頭會跑 5 個固定 fixtures:
+- 裸 id + LEFT JOIN + WHERE → 應判 HIGH
+- 混合 aliased + 裸 id → 應判 HIGH
+- 全 aliased → 應判 non-HIGH
+- `AS id` 命名(非欄位 ref) → 應判 non-HIGH
+- `wisher_id` 類內含 id 的複合欄位 → 應判 non-HIGH
+
+self-test 失敗則直接 exit 1,避免在邏輯錯誤的情況下產出「全綠」假報告。

--- a/scripts/audit-left-join.ts
+++ b/scripts/audit-left-join.ts
@@ -66,18 +66,79 @@ function extractSqlBlocks(source: string): Array<{ sql: string; startLine: numbe
   return blocks;
 }
 
+/**
+ * 判斷 SELECT 子句中是否含「裸 id」—— 即任何 `id` 詞元前面不是 `.` 的參照。
+ * 先拆掉 `AS name` 的命名子句(那個 name 只是欄位別名不是 column ref),
+ * 再用 negative lookbehind 找沒被 alias 前綴的 id。
+ *
+ * 會抓到的 pattern:
+ *   SELECT id, name FROM t              -> true  (裸 id)
+ *   SELECT u.id, id FROM u LEFT JOIN x  -> true  (混合 —— 裸 id 仍在)
+ *
+ * 不會誤判:
+ *   SELECT u.id, u.name                 -> false (全 alias)
+ *   SELECT u.id AS user_id              -> false (AS 命名不算 ref)
+ *   SELECT COUNT(*) AS id               -> false (命名為 id,不是欄位 id 的 ref)
+ */
+function hasBareId(selectPart: string): boolean {
+  const stripped = selectPart
+    .replace(/\bAS\s+\w+/gi, '')  // 去掉 AS alias 的命名子句
+    .replace(/--.*$/gm, '');       // 去掉 SQL 行註解
+  return /(?<![\w.])id\b/i.test(stripped);
+}
+
 function analyze(sql: string): { hasWhere: boolean; selectsUnaliasedId: boolean } {
   const hasWhere = /\bWHERE\b/i.test(sql);
-  // 簡化:檢查 SELECT 區段是否有「裸欄位 id」或「表名.id」且那個表名沒被 alias
-  //   - `SELECT id,` 或 `SELECT id FROM` -> 裸 id,需 review
-  //   - `SELECT main_table.id` -> 若 main_table 有被 alias 為 t,則視為違規
-  // 暫以 heuristic:只要出現 ` id,` 或 ` id\n` 或 ` id FROM` 就標記
-  const selectPart = sql.match(/SELECT([\s\S]*?)FROM/i)?.[1] ?? '';
-  const selectsUnaliasedId = /\bid\s*[,\s]/i.test(selectPart) && !/[A-Za-z_]\w*\.id/i.test(selectPart);
-  return { hasWhere, selectsUnaliasedId };
+  const selectPart = sql.match(/SELECT([\s\S]*?)\bFROM\b/i)?.[1] ?? '';
+  return { hasWhere, selectsUnaliasedId: hasBareId(selectPart) };
+}
+
+function selfTest(): void {
+  const cases: Array<{ name: string; sql: string; expectUnaliased: boolean }> = [
+    {
+      name: 'bare id in SELECT',
+      sql: 'SELECT id, name FROM users u LEFT JOIN orders o ON o.uid = u.id WHERE u.status = 1',
+      expectUnaliased: true,
+    },
+    {
+      name: 'mixed aliased + bare id',
+      sql: 'SELECT u.id, id FROM users u LEFT JOIN orders o ON o.uid = u.id WHERE u.status = 1',
+      expectUnaliased: true,
+    },
+    {
+      name: 'all aliased',
+      sql: 'SELECT u.id, u.name FROM users u LEFT JOIN orders o ON o.uid = u.id WHERE u.status = 1',
+      expectUnaliased: false,
+    },
+    {
+      name: 'AS id rename (not a ref)',
+      sql: 'SELECT COUNT(*) AS id FROM users u LEFT JOIN orders o ON o.uid = u.id',
+      expectUnaliased: false,
+    },
+    {
+      name: 'alias with id in name',
+      sql: 'SELECT wisher_id FROM wishes w LEFT JOIN users u ON u.id = w.wisher_id',
+      expectUnaliased: false,  // wisher_id 不是裸 id
+    },
+  ];
+  let pass = 0;
+  for (const c of cases) {
+    const { selectsUnaliasedId } = analyze(c.sql);
+    const ok = selectsUnaliasedId === c.expectUnaliased;
+    if (ok) pass++;
+    else {
+      console.error(`SELF-TEST FAIL: "${c.name}" — expected ${c.expectUnaliased}, got ${selectsUnaliasedId}`);
+    }
+  }
+  if (pass !== cases.length) {
+    console.error(`\nself-test: ${pass}/${cases.length} passed — 稽核邏輯有 bug,請先修`);
+    process.exit(1);
+  }
+  console.log(`self-test: ${pass}/${cases.length} ✓`);
 }
 
 function main(): void {
+  selfTest();
   const root = join(process.cwd(), 'functions/api');
   const files = walk(root);
   const findings: Finding[] = [];

--- a/scripts/audit-left-join.ts
+++ b/scripts/audit-left-join.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+/**
+ * 掃 functions/api/**\/*.ts 裡含 LEFT JOIN 的 SQL,尤其是同時有 WHERE 的。
+ * 依 AGENTS.md 黃金規則 5,這類 query 的 SELECT 必須用 alias,不能從主表取 id。
+ *
+ * 這支工具只產出 "需人工 review" 的清單,不做自動改寫 —— SQL 語意判斷太細。
+ * 用法:bun scripts/audit-left-join.ts
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+interface Finding {
+  file: string;
+  startLine: number;
+  sql: string;
+  hasWhere: boolean;
+  selectsUnaliasedId: boolean;
+}
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else if (full.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * 抓 db.execute 或 backtick 字串字面值的 SQL。
+ * 做簡化:把 backtick template literal 完整 slice 下來,不解析插值。
+ */
+function extractSqlBlocks(source: string): Array<{ sql: string; startLine: number }> {
+  const blocks: Array<{ sql: string; startLine: number }> = [];
+  const lines = source.split('\n');
+  let inBacktick = false;
+  let buf: string[] = [];
+  let startLine = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const ch of line) {
+      if (ch === '`') {
+        if (inBacktick) {
+          const sql = buf.join('\n');
+          if (/\bLEFT\s+JOIN\b/i.test(sql)) blocks.push({ sql, startLine });
+          buf = [];
+        } else {
+          startLine = i + 1;
+        }
+        inBacktick = !inBacktick;
+      } else if (inBacktick) {
+        // collect char to current line buffer
+      }
+    }
+    if (inBacktick) {
+      // 當前行整行(含換行)納入
+      if (buf.length === 0 && line.includes('`')) {
+        buf.push(line.slice(line.indexOf('`') + 1));
+      } else {
+        buf.push(line);
+      }
+    }
+  }
+  return blocks;
+}
+
+function analyze(sql: string): { hasWhere: boolean; selectsUnaliasedId: boolean } {
+  const hasWhere = /\bWHERE\b/i.test(sql);
+  // 簡化:檢查 SELECT 區段是否有「裸欄位 id」或「表名.id」且那個表名沒被 alias
+  //   - `SELECT id,` 或 `SELECT id FROM` -> 裸 id,需 review
+  //   - `SELECT main_table.id` -> 若 main_table 有被 alias 為 t,則視為違規
+  // 暫以 heuristic:只要出現 ` id,` 或 ` id\n` 或 ` id FROM` 就標記
+  const selectPart = sql.match(/SELECT([\s\S]*?)FROM/i)?.[1] ?? '';
+  const selectsUnaliasedId = /\bid\s*[,\s]/i.test(selectPart) && !/[A-Za-z_]\w*\.id/i.test(selectPart);
+  return { hasWhere, selectsUnaliasedId };
+}
+
+function main(): void {
+  const root = join(process.cwd(), 'functions/api');
+  const files = walk(root);
+  const findings: Finding[] = [];
+
+  for (const file of files) {
+    const source = readFileSync(file, 'utf-8');
+    const blocks = extractSqlBlocks(source);
+    for (const { sql, startLine } of blocks) {
+      const { hasWhere, selectsUnaliasedId } = analyze(sql);
+      findings.push({ file: relative(process.cwd(), file), startLine, sql, hasWhere, selectsUnaliasedId });
+    }
+  }
+
+  // 分類輸出
+  const highRisk = findings.filter((f) => f.hasWhere && f.selectsUnaliasedId);
+  const medRisk = findings.filter((f) => f.hasWhere && !f.selectsUnaliasedId);
+  const lowRisk = findings.filter((f) => !f.hasWhere);
+
+  console.log(`\n# LEFT JOIN 稽核報告 — ${new Date().toISOString().slice(0, 10)}\n`);
+  console.log(`掃描範圍:functions/api/**/*.ts(共 ${files.length} 檔)`);
+  console.log(`找到 LEFT JOIN query 共 ${findings.length} 處:\n`);
+  console.log(`- 🔴 HIGH:LEFT JOIN + WHERE + 可能裸 id  → ${highRisk.length} 處(**必看**)`);
+  console.log(`- 🟡 MED :LEFT JOIN + WHERE             → ${medRisk.length} 處(建議確認 SELECT 用 alias)`);
+  console.log(`- 🟢 LOW :LEFT JOIN,無 WHERE           → ${lowRisk.length} 處(通常安全)`);
+
+  const section = (title: string, items: Finding[]) => {
+    if (items.length === 0) return;
+    console.log(`\n## ${title}\n`);
+    for (const f of items) {
+      console.log(`### ${f.file}:${f.startLine}`);
+      console.log('```sql');
+      console.log(f.sql.trim());
+      console.log('```\n');
+    }
+  };
+
+  section('🔴 HIGH 風險(必看)', highRisk);
+  section('🟡 MED 風險(建議確認)', medRisk);
+  section('🟢 LOW 風險(LEFT JOIN 無 WHERE,貼上供完整追溯)', lowRisk);
+}
+
+main();

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -17,6 +17,14 @@ export const CHANGELOG: ChangelogEntry[] = [
   },
   {
     version: '',
+    date: '2026-04-17',
+    changes: [
+      'chore(#98): LEFT JOIN 黃金規則 5 稽核 — 新增 scripts/audit-left-join.ts,掃 49 個 API endpoint 的 11 處 LEFT JOIN,0 處違規',
+      'docs(#98): issues/98-codebase-health/phase2-audit-report.md — 逐 query 標註 alias 狀態 + 工具限制說明',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-16',
     changes: [
       'feat(#89): 知識庫 / AI 工具箱 Markdown 渲染支援 — 支援 GFM 語法（表格、刪除線等），所有內容經 XSS 防護過濾',


### PR DESCRIPTION
## Summary

Meta issue:#98 的 **Phase 2**(3 階段中的第 2 階段,與 [PR #99](https://github.com/cyclone-tw/cyclone-workflow/pull/99) 平行、獨立)。

執行 AGENTS.md 黃金規則 5(LEFT JOIN + WHERE 的 SELECT 要用 alias)的完整稽核,**沒有發現違規**。留下可重用的稽核工具 + 完整逐筆 review 報告。

## 結果

| 等級 | 條件 | 數量 |
|------|------|------|
| 🔴 HIGH | LEFT JOIN + WHERE + 裸 id | **0** |
| 🟡 MED  | LEFT JOIN + WHERE(review 確認合規) | 6 |
| 🟢 LOW  | LEFT JOIN 無 WHERE | 5 |

總計 11 處 LEFT JOIN,遍佈 5 個檔案。逐筆 review 清單見 `issues/98-codebase-health/phase2-audit-report.md`。

## What's in this PR

| 檔案 | 角色 | 行數 |
|------|------|------|
| `scripts/audit-left-join.ts` | 稽核工具,執行 `bun scripts/audit-left-join.ts` | 118 |
| `issues/98-codebase-health/phase2-audit-report.md` | 逐 query 標註 + 工具限制說明 | 70 |
| `src/lib/changelog.ts` | 2 條 entry | +7 |

## 為什麼值得保留工具而不是一次性掃完丟掉

- 新增 LEFT JOIN endpoint 時可再跑,當 regression check
- schema 變動後追溯影響範圍
- 黃金規則 5 是「燒過才加到 AGENTS.md」的 war story,工具化讓這類知識不只靠記

## heuristic 限制(寫進報告)

- 只掃 template literal 字串,不解析動態組裝的 prepared statement
- 不跨檔看 view / CTE
- GROUP BY 完整性由人眼確認

## Test plan

- [x] `bun scripts/audit-left-join.ts` 正常跑完
- [x] `bun run build` 綠(48 pages, 2.56s)
- [x] 逐 query 人工 review,確認 0 違規
- [ ] reviewer 再抽查 2-3 個 MED 項目

## 與 Phase 1 / Phase 3 關係

- PR #99(Phase 1):apiFetch + logger — 獨立
- 本 PR (Phase 2):LEFT JOIN 稽核 — 獨立
- Phase 3:拆 AdminPanel — 另開

三個 PR 可按任何順序 merge。

🤖 Generated with [Claude Code](https://claude.com/claude-code)