### PR TITLE
fix(#105): 成員心聲編輯視窗誤關閉保護

### DIFF
--- a/src/components/member-voices/MemberVoiceBoard.tsx
+++ b/src/components/member-voices/MemberVoiceBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
 import { ROLE_LEVEL } from '@/lib/auth';
@@ -162,12 +162,17 @@ function VoiceModal({
   const [category, setCategory] = useState(voice?.metadata?.category || '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const savedRef = useRef(false);
 
   const hasUnsaved = !isEdit
-    ? title.trim() || content.trim()
-    : title !== (voice?.title || '') || content !== (voice?.content || '');
+    ? title.trim() || content.trim() || toolUrl.trim() || rating || priceModel.trim() || useCase.trim() || category
+    : title !== (voice?.title || '') || content !== (voice?.content || '')
+      || toolUrl !== (voice?.metadata?.tool_url || '') || rating !== (voice?.metadata?.rating || 0)
+      || priceModel !== (voice?.metadata?.price_model || '') || useCase !== (voice?.metadata?.use_case || '')
+      || category !== (voice?.metadata?.category || '');
 
   const handleClose = () => {
+    if (savedRef.current) { onClose(); return; }
     if (hasUnsaved && !confirm('有未儲存的內容，確定要關閉嗎？')) return;
     onClose();
   };
@@ -210,6 +215,7 @@ function VoiceModal({
         const data = await res.json();
         if (!data.ok) throw new Error(data.error || '發表失敗');
       }
+      savedRef.current = true;
       onSaved();
     } catch (err) {
       setError(err instanceof Error ? err.message : '操作失敗');
@@ -222,6 +228,7 @@ function VoiceModal({
     <div
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+      onKeyDown={(e) => { if (e.key === 'Escape') handleClose(); }}
     >
       <div
         style={{

--- a/src/components/member-voices/MemberVoiceBoard.tsx
+++ b/src/components/member-voices/MemberVoiceBoard.tsx
@@ -163,6 +163,15 @@ function VoiceModal({
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
+  const hasUnsaved = !isEdit
+    ? title.trim() || content.trim()
+    : title !== (voice?.title || '') || content !== (voice?.content || '');
+
+  const handleClose = () => {
+    if (hasUnsaved && !confirm('有未儲存的內容，確定要關閉嗎？')) return;
+    onClose();
+  };
+
   const handleSubmit = async () => {
     const t = title.trim();
     const c = content.trim();
@@ -212,7 +221,7 @@ function VoiceModal({
   return (
     <div
       style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000, padding: '1rem' }}
-      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div
         style={{
@@ -229,7 +238,7 @@ function VoiceModal({
           <h3 style={{ fontSize: '1.125rem', fontWeight: 700, color: '#F0F0FF', margin: 0 }}>
             {isEdit ? '編輯內容' : `發表${TYPE_CONFIG[type].label}`}
           </h3>
-          <button onClick={onClose} style={{ background: 'none', border: 'none', color: '#9090B0', fontSize: '1.25rem', cursor: 'pointer', lineHeight: 1 }}>✕</button>
+          <button onClick={handleClose} style={{ background: 'none', border: 'none', color: '#9090B0', fontSize: '1.25rem', cursor: 'pointer', lineHeight: 1 }}>✕</button>
         </div>
 
         {!isEdit && (
@@ -374,7 +383,7 @@ function VoiceModal({
 
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
           <button
-            onClick={onClose}
+            onClick={handleClose}
             style={{ padding: '0.625rem 1rem', borderRadius: '0.75rem', border: '1px solid #2A2A4A', background: 'transparent', color: '#9090B0', cursor: 'pointer', fontSize: '0.875rem' }}
           >
             取消


### PR DESCRIPTION
## Summary
- 成員心聲新增/編輯貼文的 Modal 有未儲存內容時，click-outside 或按 X/取消會彈 confirm 防止內容遺失
- 新增 `hasUnsaved` 判斷 + `handleClose` 統一保護

## Test plan
- [ ] 開啟成員心聲 → 點「發表內容」→ 不輸入任何內容 → click outside → 應直接關閉
- [ ] 輸入標題或內容後 → click outside → 應彈「有未儲存的內容」確認
- [ ] 輸入內容後 → 按 X 或取消 → 應彈確認
- [ ] 確認後內容遺失；取消確認則保留

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)