### PR TITLE
feat(#97): 討論區留言回覆串功能

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -294,6 +294,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE messages ADD COLUMN deleted_at TEXT`, note: 'messages.deleted_at' },
       { sql: `ALTER TABLE messages ADD COLUMN deleted_by TEXT`, note: 'messages.deleted_by' },
       { sql: `ALTER TABLE knowledge_entries ADD COLUMN url TEXT DEFAULT ''`, note: 'knowledge_entries.url' },
+      { sql: `ALTER TABLE messages ADD COLUMN parent_id INTEGER DEFAULT NULL REFERENCES messages(id)`, note: 'messages.parent_id' },
     ];
 
     // --- Migrate legacy wish.claimer_id → wish_claimers ---
@@ -353,6 +354,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     // announcements index for pinned + created_at ordering
     try {
       await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_announcements_pinned ON announcements(pinned DESC, created_at DESC)`, args: [] });
+    } catch { /* index already exists */ }
+
+    // messages parent_id index for reply threading
+    try {
+      await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_messages_parent_id ON messages(parent_id)`, args: [] });
     } catch { /* index already exists */ }
 
     // --- Seed members (from constants) ---

--- a/functions/api/messages/[id].ts
+++ b/functions/api/messages/[id].ts
@@ -25,7 +25,7 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
     const db = getDb(context.env);
 
     const existing = await db.execute({
-      sql: 'SELECT author_id FROM messages WHERE id = ?',
+      sql: 'SELECT author_id, parent_id FROM messages WHERE id = ?',
       args: [id],
     });
 
@@ -77,6 +77,13 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
           headers: { 'Content-Type': 'application/json' },
         });
       }
+    }
+
+    if (wantsPinned && existing.rows[0].parent_id !== null) {
+      return new Response(JSON.stringify({ ok: false, error: '回覆留言無法置頂' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     if (wantsPinned && !isAdminOrAbove(user)) {

--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -13,12 +13,11 @@ function getDb(env: Env) {
   });
 }
 
-// GET: Fetch all messages
+// GET: Fetch messages (top-level with nested replies)
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
     const db = getDb(context.env);
 
-    // 嘗試取得當前登入使用者（optional — 不強迫登入）
     let currentUserId: string | null = null;
     try {
       const { requireAuth } = await import('../../../src/lib/auth.ts');
@@ -28,7 +27,37 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       // 未登入，繼續以訪客身份
     }
 
+    // Top-level messages with reply_count
     const result = await db.execute({
+      sql: `SELECT m.*,
+                   COALESCE(lc.like_count, 0) as like_count,
+                   COALESCE(mr.report_count, 0) AS report_count,
+                   COALESCE(rc.reply_count, 0) AS reply_count
+            FROM messages m
+            LEFT JOIN (
+              SELECT message_id, COUNT(*) as like_count
+              FROM discussion_likes
+              GROUP BY message_id
+            ) lc ON lc.message_id = m.id
+            LEFT JOIN (
+              SELECT message_id, COUNT(*) AS report_count
+              FROM message_reports
+              WHERE status = 'pending'
+              GROUP BY message_id
+            ) mr ON mr.message_id = m.id
+            LEFT JOIN (
+              SELECT parent_id, COUNT(*) AS reply_count
+              FROM messages
+              WHERE parent_id IS NOT NULL AND deleted_at IS NULL
+              GROUP BY parent_id
+            ) rc ON rc.parent_id = m.id
+            WHERE m.deleted_at IS NULL AND m.parent_id IS NULL
+            ORDER BY m.pinned DESC, m.created_at DESC LIMIT 100`,
+      args: [],
+    });
+
+    // All replies (parent_id IS NOT NULL)
+    const repliesResult = await db.execute({
       sql: `SELECT m.*,
                    COALESCE(lc.like_count, 0) as like_count,
                    COALESCE(mr.report_count, 0) AS report_count
@@ -44,12 +73,12 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
               WHERE status = 'pending'
               GROUP BY message_id
             ) mr ON mr.message_id = m.id
-            WHERE m.deleted_at IS NULL
-            ORDER BY m.pinned DESC, m.created_at DESC LIMIT 100`,
+            WHERE m.deleted_at IS NULL AND m.parent_id IS NOT NULL
+            ORDER BY m.created_at ASC`,
       args: [],
     });
 
-    // 如果已登入，撈出該使用者的檢舉記錄
+    // User's report records
     let reportedByMe: Set<number> = new Set();
     if (currentUserId) {
       const reports = await db.execute({
@@ -61,9 +90,22 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       }
     }
 
+    // Group replies by parent_id
+    const repliesByParent = new Map<number, any[]>();
+    for (const row of repliesResult.rows) {
+      const pid = row.parent_id as number;
+      if (!repliesByParent.has(pid)) repliesByParent.set(pid, []);
+      repliesByParent.get(pid)!.push({
+        ...row,
+        reported_by_me: reportedByMe.has(row.id as number),
+      });
+    }
+
     const messages = result.rows.map((row) => ({
       ...row,
       reported_by_me: reportedByMe.has(row.id as number),
+      reply_count: Number(row.reply_count ?? 0),
+      replies: repliesByParent.get(row.id as number) ?? [],
     }));
 
     return new Response(JSON.stringify({ ok: true, messages }), {
@@ -81,15 +123,16 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
   }
 };
 
-// POST: Create a new message (requires login)
+// POST: Create a new message or reply (requires login)
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const user = await requireAuth(context.request, context.env);
 
-    const { content, tag, category } = await context.request.json() as {
+    const { content, tag, category, parent_id } = await context.request.json() as {
       content?: string;
       tag?: string;
       category?: string;
+      parent_id?: number | null;
     };
 
     const author = user.name;
@@ -110,9 +153,32 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     const db = getDb(context.env);
 
+    // Validate parent_id if provided (reply)
+    if (parent_id) {
+      const parent = await db.execute({
+        sql: 'SELECT id, parent_id FROM messages WHERE id = ? AND deleted_at IS NULL',
+        args: [parent_id],
+      });
+      if (parent.rows.length === 0) {
+        return new Response(JSON.stringify({ ok: false, error: '找不到要回覆的留言' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (parent.rows[0].parent_id !== null) {
+        return new Response(JSON.stringify({ ok: false, error: '只能回覆頂層留言' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
+    const effectiveTag = parent_id ? '' : (tag?.trim() || '');
+    const effectiveCategory = parent_id ? '' : (category || '閒聊');
+
     await db.execute({
-      sql: `INSERT INTO messages (author, author_id, content, tag, category) VALUES (?, ?, ?, ?, ?)`,
-      args: [author.trim(), user.id, content.trim(), tag?.trim() || '', category || '閒聊'],
+      sql: `INSERT INTO messages (author, author_id, content, tag, category, parent_id) VALUES (?, ?, ?, ?, ?, ?)`,
+      args: [author.trim(), user.id, content.trim(), effectiveTag, effectiveCategory, parent_id ?? null],
     });
 
     return new Response(JSON.stringify({ ok: true }), {

--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -56,27 +56,31 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       args: [],
     });
 
-    // All replies (parent_id IS NOT NULL)
-    const repliesResult = await db.execute({
-      sql: `SELECT m.*,
-                   COALESCE(lc.like_count, 0) as like_count,
-                   COALESCE(mr.report_count, 0) AS report_count
-            FROM messages m
-            LEFT JOIN (
-              SELECT message_id, COUNT(*) as like_count
-              FROM discussion_likes
-              GROUP BY message_id
-            ) lc ON lc.message_id = m.id
-            LEFT JOIN (
-              SELECT message_id, COUNT(*) AS report_count
-              FROM message_reports
-              WHERE status = 'pending'
-              GROUP BY message_id
-            ) mr ON mr.message_id = m.id
-            WHERE m.deleted_at IS NULL AND m.parent_id IS NOT NULL
-            ORDER BY m.created_at ASC`,
-      args: [],
-    });
+    // All replies (parent_id IS NOT NULL) — only for current top-level messages
+    const topLevelIds = result.rows.map((row) => row.id as number);
+    const repliesResult = topLevelIds.length > 0
+      ? await db.execute({
+          sql: `SELECT m.*,
+                       COALESCE(lc.like_count, 0) as like_count,
+                       COALESCE(mr.report_count, 0) AS report_count
+                FROM messages m
+                LEFT JOIN (
+                  SELECT message_id, COUNT(*) as like_count
+                  FROM discussion_likes
+                  GROUP BY message_id
+                ) lc ON lc.message_id = m.id
+                LEFT JOIN (
+                  SELECT message_id, COUNT(*) AS report_count
+                  FROM message_reports
+                  WHERE status = 'pending'
+                  GROUP BY message_id
+                ) mr ON mr.message_id = m.id
+                WHERE m.deleted_at IS NULL
+                  AND m.parent_id IN (${topLevelIds.map(() => '?').join(', ')})
+                ORDER BY m.created_at ASC`,
+          args: topLevelIds,
+        })
+      : { rows: [] as any[] };
 
     // User's report records
     let reportedByMe: Set<number> = new Set();
@@ -154,7 +158,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const db = getDb(context.env);
 
     // Validate parent_id if provided (reply)
-    if (parent_id) {
+    if (parent_id != null && parent_id !== undefined) {
       const parent = await db.execute({
         sql: 'SELECT id, parent_id FROM messages WHERE id = ? AND deleted_at IS NULL',
         args: [parent_id],
@@ -173,12 +177,12 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       }
     }
 
-    const effectiveTag = parent_id ? '' : (tag?.trim() || '');
-    const effectiveCategory = parent_id ? '' : (category || '閒聊');
+    const effectiveTag = parent_id != null ? '' : (tag?.trim() || '');
+    const effectiveCategory = parent_id != null ? '' : (category || '閒聊');
 
     await db.execute({
       sql: `INSERT INTO messages (author, author_id, content, tag, category, parent_id) VALUES (?, ?, ?, ?, ?, ?)`,
-      args: [author.trim(), user.id, content.trim(), effectiveTag, effectiveCategory, parent_id ?? null],
+      args: [author.trim(), user.id, content.trim(), effectiveTag, effectiveCategory, parent_id != null ? parent_id : null],
     });
 
     return new Response(JSON.stringify({ ok: true }), {

--- a/src/components/discuss/MessageBoard.tsx
+++ b/src/components/discuss/MessageBoard.tsx
@@ -1,502 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
-import { sanitizeUrl, sanitizeImgSrc, sanitizeMarkdown } from '../../lib/markdown';
 import { useAuth } from '@/components/auth/useAuth';
-import { ROLE_LEVEL } from '@/lib/auth';
-import { timeAgo } from '@/lib/time';
+import MessageCard, { type Message, CATEGORIES, CATEGORY_COLORS } from './MessageCard';
 
-interface Message {
-  id: number;
-  author: string;
-  author_id: string | null;
-  content: string;
-  tag: string;
-  category: string;
-  created_at: string;
-  edited_at: string | null;
-  pinned: number;
-  like_count: number;
-  deleted_at: string | null;
-  deleted_by: string | null;
-  report_count: number;
-  reported_by_me?: boolean;
-}
-
-const CATEGORIES = ['閒聊', '成果分享', '問題', '建議'];
 const SORT_OPTIONS = ['最新', '最舊', '最多回饋'] as const;
-
-const CATEGORY_COLORS: Record<string, string> = {
-  '閒聊': 'var(--color-primary)',
-  '成果分享': '#FFD93D',
-  '問題': 'var(--color-neon-blue)',
-  '建議': 'var(--color-neon-green)',
-};
-
-function MessageCard({
-  msg,
-  likedIds,
-  onToggleLike,
-  isLoggedIn,
-  likeLoadingIds,
-  currentUser,
-  onDelete,
-  onEdit,
-  onPinToggle,
-  onReport,
-}: {
-  msg: Message;
-  likedIds: Set<number>;
-  onToggleLike: (messageId: number, currentLiked: boolean) => void;
-  isLoggedIn: boolean;
-  likeLoadingIds: Set<number>;
-  currentUser: { id: string; effectiveRole: string } | null;
-  onDelete: (messageId: number) => void;
-  onEdit: (messageId: number, newContent: string) => void;
-  onPinToggle: (messageId: number, pinned: number) => void;
-  onReport: (messageId: number, reason: string) => void;
-}) {
-  const color = CATEGORY_COLORS[msg.category] || 'var(--color-primary)';
-  const liked = likedIds.has(msg.id);
-  const isLikeLoading = likeLoadingIds.has(msg.id);
-  const [isEditing, setIsEditing] = useState(false);
-  const [editContent, setEditContent] = useState(msg.content);
-  const [editSaving, setEditSaving] = useState(false);
-  const [pinLoading, setPinLoading] = useState(false);
-  const [showReportDialog, setShowReportDialog] = useState(false);
-  const [reportReason, setReportReason] = useState('');
-  const [reportSubmitting, setReportSubmitting] = useState(false);
-
-  const canModify = currentUser && (
-    msg.author_id === currentUser.id ||
-    (ROLE_LEVEL[currentUser.effectiveRole] ?? 0) >= (ROLE_LEVEL['admin'] ?? 0)
-  );
-  const canPin = currentUser &&
-    (ROLE_LEVEL[currentUser.effectiveRole] ?? 0) >= (ROLE_LEVEL['admin'] ?? 0);
-  const handlePinToggle = async () => {
-    if (pinLoading) return;
-    const nextPinned = msg.pinned ? 0 : 1;
-    setPinLoading(true);
-    try {
-      const res = await fetch(`/api/messages/${msg.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ pinned: nextPinned }),
-      });
-      const data = await res.json();
-      if (data.ok) {
-        onPinToggle(msg.id, nextPinned);
-      } else {
-        alert(data.error || '操作失敗');
-      }
-    } catch {
-      alert('網路錯誤，無法置頂');
-    } finally {
-      setPinLoading(false);
-    }
-  };
-
-  const handleSave = async () => {
-    const trimmed = editContent.trim();
-    if (!trimmed || trimmed === msg.content) {
-      setIsEditing(false);
-      return;
-    }
-    setEditSaving(true);
-    try {
-      const res = await fetch(`/api/messages/${msg.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content: trimmed }),
-      });
-      const data = await res.json();
-      if (data.ok) {
-        onEdit(msg.id, trimmed);
-        setIsEditing(false);
-      } else {
-        alert(data.error || '儲存失敗');
-      }
-    } catch {
-      alert('網路錯誤，無法儲存');
-    } finally {
-      setEditSaving(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setEditContent(msg.content);
-    setIsEditing(false);
-  };
-
-  return (
-    <div
-      className="rounded-xl p-4 transition-all min-w-0 overflow-hidden"
-      style={{
-        background: 'var(--color-bg-card)',
-        border: '1px solid var(--color-border)',
-        borderLeftWidth: '3px',
-        borderLeftColor: color,
-      }}
-    >
-      <div className="flex items-center justify-between mb-2 gap-2 min-w-0">
-        <div className="flex items-center gap-2 min-w-0">
-          <span
-            className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0"
-            style={{ background: `${color}20`, color }}
-          >
-            {msg.author[0]}
-          </span>
-          <div className="min-w-0">
-            <span className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
-              {msg.author}
-            </span>
-            {msg.tag && (
-              <span className="text-xs ml-1" style={{ color: 'var(--color-text-muted)' }}>
-                {msg.tag}
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
-          {msg.pinned ? (
-            <span className="text-xs" style={{ color: '#FFC107' }} title="置頂留言">
-              📌
-            </span>
-          ) : null}
-          <span
-            className="text-xs px-2 py-0.5 rounded-full"
-            style={{ background: `${color}20`, color }}
-          >
-            {msg.category}
-          </span>
-          <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-            {timeAgo(msg.created_at)}
-            {msg.edited_at && ' (已編輯)'}
-          </span>
-        </div>
-      </div>
-
-      {isEditing ? (
-        <div className="space-y-2">
-          <textarea
-            value={editContent}
-            onChange={(e) => setEditContent(e.target.value)}
-            disabled={editSaving}
-            rows={3}
-            maxLength={2000}
-            className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-y"
-            style={{
-              background: 'var(--color-bg-surface)',
-              border: '1px solid var(--color-border)',
-              color: 'var(--color-text-primary)',
-            }}
-          />
-          <div className="flex items-center justify-between">
-            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-              {editContent.length}/2000
-            </span>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={handleCancel}
-                disabled={editSaving}
-                className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
-                style={{
-                  background: 'transparent',
-                  color: 'var(--color-text-muted)',
-                  border: '1px solid var(--color-border)',
-                  opacity: editSaving ? 0.6 : 1,
-                }}
-              >
-                取消
-              </button>
-              <button
-                onClick={handleSave}
-                disabled={editSaving}
-                className="px-3 py-1.5 rounded-lg text-xs font-medium transition-opacity"
-                style={{
-                  background: 'var(--color-primary)',
-                  color: '#fff',
-                  opacity: editSaving ? 0.6 : 1,
-                }}
-              >
-                {editSaving ? '儲存中...' : '儲存'}
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : msg.deleted_at ? (
-        <>
-          <div
-            className="text-sm leading-relaxed"
-            style={{
-              color: 'var(--color-text-muted)',
-              background: 'rgba(255,77,106,0.05)',
-              border: '1px solid rgba(255,77,106,0.15)',
-              borderRadius: '0.5rem',
-              padding: '0.75rem 1rem',
-              fontStyle: 'italic',
-            }}
-          >
-            此留言已被刪除
-          </div>
-        </>
-      ) : msg.report_count >= 3 ? (
-        <>
-          <div
-            className="text-sm leading-relaxed"
-            style={{
-              color: 'var(--color-text-muted)',
-              background: 'rgba(255,77,106,0.05)',
-              border: '1px solid rgba(255,77,106,0.15)',
-              borderRadius: '0.5rem',
-              padding: '0.75rem 1rem',
-              fontStyle: 'italic',
-            }}
-          >
-            此留言因多次檢舉已隱藏
-          </div>
-        </>
-      ) : (
-            <>
-            <div
-              className="text-sm leading-relaxed break-words prose prose-sm max-w-none"
-              style={{ color: 'var(--color-text-secondary)', overflowWrap: 'anywhere' }}
-            >
-            <ReactMarkdown
-              remarkPlugins={[remarkGfm]}
-              rehypePlugins={[rehypeRaw]}
-              components={{
-                code({ className, children, ...props }) {
-                  const match = /language-(\w+)/.exec(className || '');
-                  const isInline = !match && !String(children).includes('\n');
-                  if (isInline) {
-                    return (
-                      <code
-                        className="px-1.5 py-0.5 rounded text-xs font-mono"
-                        style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--color-neon-green)' }}
-                        {...props}
-                      >
-                        {children}
-                      </code>
-                    );
-                  }
-                  return (
-                    <code
-                      className="block p-3 rounded-lg text-xs font-mono overflow-x-auto"
-                      style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--color-neon-blue)' }}
-                      {...props}
-                    >
-                      {children}
-                    </code>
-                  );
-                },
-                a({ href, children, ...props }) {
-                  if (!href) return <span {...props}>{children}</span>;
-                  const safe = sanitizeUrl(href);
-                  if (!safe) return <span {...props}>{children}</span>;
-                  return (
-                    <a
-                      href={safe}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline hover:opacity-80"
-                      style={{ color: 'var(--color-neon-blue)' }}
-                    >
-                      {children}
-                    </a>
-                  );
-                },
-                img({ src, alt, ...props }) {
-                  const safeSrc = sanitizeImgSrc(src);
-                  if (!safeSrc) return null;
-                  return (
-                    <img
-                      src={safeSrc}
-                      alt={alt || ''}
-                      loading="lazy"
-                      style={{ maxWidth: '100%', height: 'auto', borderRadius: '0.5rem' }}
-                    />
-                  );
-                },
-              }}
-            >
-              {sanitizeMarkdown(msg.content)}
-            </ReactMarkdown>
-          </div>
-          <div className="flex items-center justify-end mt-2 gap-2">
-            {canPin && (
-              <button
-                onClick={handlePinToggle}
-                disabled={pinLoading}
-                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
-                style={{
-                  background: msg.pinned ? 'rgba(255, 193, 7, 0.1)' : 'transparent',
-                  color: msg.pinned ? '#FFC107' : 'var(--color-text-muted)',
-                  border: 'none',
-                  cursor: pinLoading ? 'not-allowed' : 'pointer',
-                  opacity: pinLoading ? 0.5 : 1,
-                }}
-                title={msg.pinned ? '取消置頂' : '置頂留言'}
-              >
-                {pinLoading ? '處理中...' : (msg.pinned ? '🔽 取消置頂' : '📌 置頂')}
-              </button>
-            )}
-            {canModify && (
-              <button
-                onClick={() => setIsEditing(true)}
-                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
-                style={{
-                  background: 'transparent',
-                  color: 'var(--color-text-muted)',
-                  border: 'none',
-                  cursor: 'pointer',
-                }}
-                title="編輯留言"
-              >
-                ✏️ 編輯
-              </button>
-            )}
-            {canModify && (
-              <button
-                onClick={() => {
-                  if (confirm('確定要刪除這則留言嗎？')) onDelete(msg.id);
-                }}
-                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
-                style={{
-                  background: 'transparent',
-                  color: 'var(--color-text-muted)',
-                  border: 'none',
-                  cursor: 'pointer',
-                }}
-                title="刪除留言"
-              >
-                🗑️ 刪除
-              </button>
-            )}
-            <button
-              onClick={() => onToggleLike(msg.id, liked)}
-              disabled={!isLoggedIn || isLikeLoading}
-              className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all"
-              style={{
-                background: liked ? 'rgba(255, 77, 106, 0.1)' : 'transparent',
-                color: liked ? '#FF4D6A' : 'var(--color-text-muted)',
-                cursor: !isLoggedIn || isLikeLoading ? 'not-allowed' : 'pointer',
-                opacity: !isLoggedIn ? 0.5 : 1,
-                border: 'none',
-              }}
-              title={!isLoggedIn ? '請先登入才能按讚' : liked ? '收回讚' : '按讚'}
-            >
-              <span style={{ fontSize: '14px' }}>{liked ? '❤️' : '🤍'}</span>
-              <span>{msg.like_count > 0 ? msg.like_count : ''}</span>
-            </button>
-            {isLoggedIn && (
-              msg.reported_by_me ? (
-                <span
-                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs"
-                  style={{ color: 'var(--color-text-muted)', opacity: 0.5, border: 'none', cursor: 'default' }}
-                >
-                  已檢舉
-                </span>
-              ) : (
-                <button
-                  onClick={() => setShowReportDialog(true)}
-                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
-                  style={{
-                    background: 'transparent',
-                    color: 'var(--color-text-muted)',
-                    border: 'none',
-                    cursor: 'pointer',
-                  }}
-                  title="檢舉留言"
-                >
-                  🚩 檢舉
-                </button>
-              )
-            )}
-          </div>
-        </>
-      )}
-
-      {showReportDialog && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          style={{ background: 'rgba(0,0,0,0.6)' }}
-          onClick={() => { setShowReportDialog(false); setReportReason(''); }}
-        >
-          <div
-            className="w-full max-w-sm rounded-2xl p-5"
-            style={{
-              background: 'var(--color-bg-card)',
-              border: '1px solid var(--color-border)',
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between mb-3">
-              <h4 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>
-                🚩 檢舉留言
-              </h4>
-              <button
-                onClick={() => { setShowReportDialog(false); setReportReason(''); }}
-                style={{ color: 'var(--color-text-muted)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px' }}
-              >
-                ×
-              </button>
-            </div>
-            <p className="text-xs mb-3" style={{ color: 'var(--color-text-muted)' }}>
-              請填寫檢舉原因，我們會儘快審核。
-            </p>
-            <textarea
-              value={reportReason}
-              onChange={(e) => setReportReason(e.target.value)}
-              placeholder="檢舉原因..."
-              rows={3}
-              maxLength={500}
-              className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-none mb-3"
-              style={{
-                background: 'var(--color-bg-surface)',
-                border: '1px solid var(--color-border)',
-                color: 'var(--color-text-primary)',
-              }}
-            />
-            <div className="flex items-center justify-end gap-2">
-              <button
-                onClick={() => { setShowReportDialog(false); setReportReason(''); }}
-                disabled={reportSubmitting}
-                className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
-                style={{
-                  background: 'transparent',
-                  color: 'var(--color-text-muted)',
-                  border: '1px solid var(--color-border)',
-                }}
-              >
-                取消
-              </button>
-              <button
-                onClick={async () => {
-                  if (!reportReason.trim()) return;
-                  setReportSubmitting(true);
-                  onReport(msg.id, reportReason.trim());
-                  setShowReportDialog(false);
-                  setReportReason('');
-                  setReportSubmitting(false);
-                }}
-                disabled={reportSubmitting || !reportReason.trim()}
-                className="px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-opacity"
-                style={{
-                  background: '#E94560',
-                  opacity: reportSubmitting || !reportReason.trim() ? 0.6 : 1,
-                }}
-              >
-                {reportSubmitting ? '送出中...' : '送出檢舉'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
 
 export default function MessageBoard() {
   const [messages, setMessages] = useState<Message[]>([]);
@@ -514,6 +20,16 @@ export default function MessageBoard() {
   const formRef = useRef<HTMLFormElement>(null);
   const { user, loading: authLoading, login } = useAuth();
 
+  // Flatten all messages (top-level + nested replies) for like checking
+  const flattenMessages = (msgs: Message[]): Message[] => {
+    const flat: Message[] = [];
+    for (const m of msgs) {
+      flat.push(m);
+      if (m.replies?.length) flat.push(...m.replies);
+    }
+    return flat;
+  };
+
   const fetchMessages = useCallback(async () => {
     try {
       const res = await fetch('/api/messages');
@@ -522,11 +38,11 @@ export default function MessageBoard() {
         const msgs = data.messages as Message[];
         setMessages(msgs);
 
-        // If logged in, fetch which messages the user has liked
         if (user && msgs.length > 0) {
           try {
+            const allMsgs = flattenMessages(msgs);
             const likeChecks = await Promise.all(
-              msgs.map((m: Message) =>
+              allMsgs.map((m: Message) =>
                 fetch(`/api/messages/likes?message_id=${m.id}`)
                   .then((r) => r.json())
                   .then((d) => ({ id: m.id, liked: d.ok ? d.liked : false }))
@@ -538,9 +54,7 @@ export default function MessageBoard() {
               if (lc.liked) newLiked.add(lc.id);
             }
             setLikedIds(newLiked);
-          } catch {
-            // Non-critical — proceed without like state
-          }
+          } catch { /* Non-critical */ }
         }
       }
     } catch {
@@ -560,11 +74,15 @@ export default function MessageBoard() {
       const data = await res.json();
       if (data.ok) {
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === messageId
-              ? { ...m, report_count: m.report_count + 1, reported_by_me: true }
-              : m
-          )
+          prev.map((m) => {
+            if (m.id === messageId) return { ...m, report_count: m.report_count + 1, reported_by_me: true };
+            if (m.replies?.length) {
+              return { ...m, replies: m.replies.map((r) =>
+                r.id === messageId ? { ...r, report_count: r.report_count + 1, reported_by_me: true } : r
+              )};
+            }
+            return m;
+          })
         );
       } else {
         alert(data.error || '檢舉失敗');
@@ -575,61 +93,46 @@ export default function MessageBoard() {
   };
 
   useEffect(() => {
-    if (!authLoading) {
-      fetchMessages();
-    }
+    if (!authLoading) fetchMessages();
   }, [authLoading, fetchMessages]);
 
   const handleToggleLike = async (messageId: number, currentLiked: boolean) => {
     if (!user) return;
     if (likeLoadingIds.has(messageId)) return;
 
-    // Snapshot current liked state so we can revert on failure
     const prevLiked = currentLiked;
 
-    // Optimistic update
     setLikedIds((prev) => {
       const next = new Set(prev);
-      if (currentLiked) {
-        next.delete(messageId);
-      } else {
-        next.add(messageId);
-      }
+      if (currentLiked) next.delete(messageId); else next.add(messageId);
       return next;
     });
 
-    // Optimistic count update
+    const delta = currentLiked ? -1 : 1;
+    const updateLikeCount = (ms: Message[]) =>
+      ms.map((m) => m.id === messageId ? { ...m, like_count: Math.max(0, m.like_count + delta) } : m);
+
     setMessages((prev) =>
-      prev.map((m) =>
-        m.id === messageId
-          ? { ...m, like_count: Math.max(0, m.like_count + (currentLiked ? -1 : 1)) }
-          : m
-      )
+      prev.map((m) => {
+        if (m.id === messageId) return { ...m, like_count: Math.max(0, m.like_count + delta) };
+        if (m.replies?.length) return { ...m, replies: updateLikeCount(m.replies) };
+        return m;
+      })
     );
 
-    // Mark this message as in-flight (other messages stay clickable)
-    setLikeLoadingIds((prev) => {
-      const next = new Set(prev);
-      next.add(messageId);
-      return next;
-    });
+    setLikeLoadingIds((prev) => { const n = new Set(prev); n.add(messageId); return n; });
 
     const revert = () => {
-      setLikedIds((prev) => {
-        const next = new Set(prev);
-        if (prevLiked) {
-          next.add(messageId);
-        } else {
-          next.delete(messageId);
-        }
-        return next;
-      });
+      setLikedIds((prev) => { const n = new Set(prev); if (prevLiked) n.add(messageId); else n.delete(messageId); return n; });
+      const revertDelta = prevLiked ? 1 : -1;
+      const revertCount = (ms: Message[]) =>
+        ms.map((m) => m.id === messageId ? { ...m, like_count: m.like_count + revertDelta } : m);
       setMessages((prev) =>
-        prev.map((m) =>
-          m.id === messageId
-            ? { ...m, like_count: m.like_count + (prevLiked ? 1 : -1) }
-            : m
-        )
+        prev.map((m) => {
+          if (m.id === messageId) return { ...m, like_count: m.like_count + revertDelta };
+          if (m.replies?.length) return { ...m, replies: revertCount(m.replies) };
+          return m;
+        })
       );
     };
 
@@ -641,45 +144,29 @@ export default function MessageBoard() {
       });
       const data = await res.json().catch(() => ({ ok: false }));
       if (data.ok) {
-        // Sync authoritative values from the server
-        setLikedIds((prev) => {
-          const next = new Set(prev);
-          if (data.liked) {
-            next.add(messageId);
-          } else {
-            next.delete(messageId);
-          }
-          return next;
-        });
+        setLikedIds((prev) => { const n = new Set(prev); if (data.liked) n.add(messageId); else n.delete(messageId); return n; });
         setMessages((prev) =>
-          prev.map((m) =>
-            m.id === messageId ? { ...m, like_count: Number(data.count ?? m.like_count) } : m
-          )
+          prev.map((m) => {
+            if (m.id === messageId) return { ...m, like_count: Number(data.count ?? m.like_count) };
+            if (m.replies?.length) return { ...m, replies: m.replies.map((r) => r.id === messageId ? { ...r, like_count: Number(data.count ?? r.like_count) } : r) };
+            return m;
+          })
         );
       } else {
         revert();
-        if (res.status === 401) {
-          setError('請先登入才能按讚');
-        }
+        if (res.status === 401) setError('請先登入才能按讚');
       }
     } catch (err) {
       console.error('Toggle like failed:', err);
       revert();
     } finally {
-      setLikeLoadingIds((prev) => {
-        const next = new Set(prev);
-        next.delete(messageId);
-        return next;
-      });
+      setLikeLoadingIds((prev) => { const n = new Set(prev); n.delete(messageId); return n; });
     }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!content.trim()) {
-      setError('請填寫留言內容');
-      return;
-    }
+    if (!content.trim()) { setError('請填寫留言內容'); return; }
     setPosting(true);
     setError('');
     try {
@@ -704,24 +191,40 @@ export default function MessageBoard() {
     }
   };
 
-  const filtered = filter === '全部' ? messages : messages.filter((m) => m.category === filter);
-  const sortedFiltered = [...filtered].sort((a, b) => {
-    if (b.pinned !== a.pinned) return b.pinned - a.pinned;
-    if (sortBy === '最新') return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-    if (sortBy === '最舊') return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
-    if (sortBy === '最多回饋') return b.like_count - a.like_count;
-    return 0;
-  });
+  const handleReply = async (parentId: number, replyContent: string) => {
+    if (!user || !replyContent.trim()) return;
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: replyContent.trim(), parent_id: parentId }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        fetchMessages();
+      } else {
+        alert(data.error || '回覆失敗');
+      }
+    } catch {
+      alert('網路錯誤，無法回覆');
+    }
+  };
 
   const handleDelete = async (messageId: number) => {
     try {
       const res = await fetch(`/api/messages/${messageId}`, { method: 'DELETE' });
       const data = await res.json();
       if (data.ok) {
-        // Soft delete: mark locally so placeholder renders
-        setMessages((prev) => prev.map((m) =>
-          m.id === messageId ? { ...m, deleted_at: new Date().toISOString(), deleted_by: user?.id ?? null } : m
-        ));
+        const now = new Date().toISOString();
+        const markDeleted = (ms: Message[]) =>
+          ms.map((m) => m.id === messageId ? { ...m, deleted_at: now, deleted_by: user?.id ?? null } : m);
+        setMessages((prev) =>
+          prev.map((m) => {
+            if (m.id === messageId) return { ...m, deleted_at: now, deleted_by: user?.id ?? null };
+            if (m.replies?.length) return { ...m, replies: markDeleted(m.replies) };
+            return m;
+          })
+        );
       } else {
         setError(data.error || '刪除失敗');
       }
@@ -731,10 +234,15 @@ export default function MessageBoard() {
   };
 
   const handleEdit = (messageId: number, newContent: string) => {
+    const now = new Date().toISOString();
+    const updateContent = (ms: Message[]) =>
+      ms.map((m) => m.id === messageId ? { ...m, content: newContent, edited_at: now } : m);
     setMessages((prev) =>
-      prev.map((m) =>
-        m.id === messageId ? { ...m, content: newContent, edited_at: new Date().toISOString() } : m
-      )
+      prev.map((m) => {
+        if (m.id === messageId) return { ...m, content: newContent, edited_at: now };
+        if (m.replies?.length) return { ...m, replies: updateContent(m.replies) };
+        return m;
+      })
     );
   };
 
@@ -748,121 +256,52 @@ export default function MessageBoard() {
     });
   };
 
+  const filtered = filter === '全部' ? messages : messages.filter((m) => m.category === filter);
+  const sortedFiltered = [...filtered].sort((a, b) => {
+    if (b.pinned !== a.pinned) return b.pinned - a.pinned;
+    if (sortBy === '最新') return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    if (sortBy === '最舊') return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+    if (sortBy === '最多回饋') return (b.like_count + b.reply_count) - (a.like_count + a.reply_count);
+    return 0;
+  });
+
   return (
     <div className="space-y-6">
-      {/* Post form — login required */}
+      {/* Post form */}
       {!authLoading && !user ? (
-        <div
-          className="rounded-xl p-5 flex flex-col items-center gap-3 text-center"
-          style={{
-            background: 'var(--color-bg-card)',
-            border: '1px solid var(--color-border)',
-          }}
-        >
+        <div className="rounded-xl p-5 flex flex-col items-center gap-3 text-center" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}>
           <p className="text-2xl">💬</p>
-          <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
-            請先登入再留言
-          </p>
-          <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-            已有帳號的隊員才能發表討論留言
-          </p>
-          <button
-            onClick={login}
-            className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-80"
-            style={{ background: 'var(--color-primary)', color: '#fff' }}
-          >
+          <p className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>請先登入再留言</p>
+          <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>已有帳號的隊員才能發表討論留言</p>
+          <button onClick={login} className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-80" style={{ background: 'var(--color-primary)', color: '#fff' }}>
             🔐 登入 Discord
           </button>
         </div>
       ) : !authLoading && user ? (
-        <form
-          ref={formRef}
-          onSubmit={handleSubmit}
-          className="rounded-xl p-5 space-y-4"
-          style={{
-            background: 'var(--color-bg-card)',
-            border: '1px solid var(--color-border)',
-          }}
-        >
-          <h3
-            className="text-base font-semibold"
-            style={{ color: 'var(--color-text-primary)' }}
-          >
+        <form ref={formRef} onSubmit={handleSubmit} className="rounded-xl p-5 space-y-4" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}>
+          <h3 className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>
             ✍️ 發表留言
-            <span className="ml-2 text-xs font-normal" style={{ color: 'var(--color-text-muted)' }}>
-              以 {user.name} 發表
-            </span>
+            <span className="ml-2 text-xs font-normal" style={{ color: 'var(--color-text-muted)' }}>以 {user.name} 發表</span>
           </h3>
-
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <input
-              type="text"
-              value={tag}
-              onChange={(e) => setTag(e.target.value)}
-              placeholder="Discord Tag (選填)"
+            <input type="text" value={tag} onChange={(e) => setTag(e.target.value)} placeholder="Discord Tag (選填)"
               className="px-3 py-2 rounded-lg text-sm outline-none"
-              style={{
-                background: 'var(--color-bg-surface)',
-                border: '1px solid var(--color-border)',
-                color: 'var(--color-text-primary)',
-              }}
-            />
-            <select
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              className="px-3 py-2 rounded-lg text-sm outline-none"
-              style={{
-                background: 'var(--color-bg-surface)',
-                border: '1px solid var(--color-border)',
-                color: 'var(--color-text-primary)',
-              }}
-            >
-              {CATEGORIES.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
+              style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }} />
+            <select value={category} onChange={(e) => setCategory(e.target.value)} className="px-3 py-2 rounded-lg text-sm outline-none"
+              style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }}>
+              {CATEGORIES.map((c) => <option key={c} value={c}>{c}</option>)}
             </select>
           </div>
-
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="說點什麼... 可以討論功能建議、許願樹改版、成果分享等 *"
-            required
-            rows={3}
-            maxLength={2000}
+          <textarea value={content} onChange={(e) => setContent(e.target.value)} placeholder="說點什麼... 可以討論功能建議、許願樹改版、成果分享等 *" required rows={3} maxLength={2000}
             className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-y"
-            style={{
-              background: 'var(--color-bg-surface)',
-              border: '1px solid var(--color-border)',
-              color: 'var(--color-text-primary)',
-            }}
-          />
-
+            style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }} />
           <div className="flex items-center justify-between">
-            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-              {content.length}/2000
-            </span>
+            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{content.length}/2000</span>
             <div className="flex items-center gap-3">
-              {success && (
-                <span className="text-xs" style={{ color: 'var(--color-neon-green)' }}>
-                  ✅ 留言成功！
-                </span>
-              )}
-              {error && (
-                <span className="text-xs" style={{ color: 'var(--color-accent)' }}>
-                  {error}
-                </span>
-              )}
-              <button
-                type="submit"
-                disabled={posting}
-                className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity"
-                style={{
-                  background: 'var(--color-primary)',
-                  color: '#fff',
-                  opacity: posting ? 0.6 : 1,
-                }}
-              >
+              {success && <span className="text-xs" style={{ color: 'var(--color-neon-green)' }}>✅ 留言成功！</span>}
+              {error && <span className="text-xs" style={{ color: 'var(--color-accent)' }}>{error}</span>}
+              <button type="submit" disabled={posting} className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity"
+                style={{ background: 'var(--color-primary)', color: '#fff', opacity: posting ? 0.6 : 1 }}>
                 {posting ? '送出中...' : '📤 送出留言'}
               </button>
             </div>
@@ -877,16 +316,8 @@ export default function MessageBoard() {
             const color = c === '全部' ? 'var(--color-text-muted)' : (CATEGORY_COLORS[c] || 'var(--color-primary)');
             const active = filter === c;
             return (
-              <button
-                key={c}
-                onClick={() => setFilter(c)}
-                className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all"
-                style={{
-                  background: active ? `${color}20` : 'transparent',
-                  color: active ? color : 'var(--color-text-muted)',
-                  border: `1px solid ${active ? color : 'var(--color-border)'}`,
-                }}
-              >
+              <button key={c} onClick={() => setFilter(c)} className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all"
+                style={{ background: active ? `${color}20` : 'transparent', color: active ? color : 'var(--color-text-muted)', border: `1px solid ${active ? color : 'var(--color-border)'}` }}>
                 {c} {c !== '全部' && `(${messages.filter((m) => m.category === c).length})`}
               </button>
             );
@@ -894,36 +325,19 @@ export default function MessageBoard() {
         </div>
         <div className="flex items-center gap-2">
           <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>排序</span>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as (typeof SORT_OPTIONS)[number])}
+          <select value={sortBy} onChange={(e) => setSortBy(e.target.value as (typeof SORT_OPTIONS)[number])}
             className="px-2 py-1.5 rounded-lg text-xs outline-none"
-            style={{
-              background: 'var(--color-bg-surface)',
-              border: '1px solid var(--color-border)',
-              color: 'var(--color-text-primary)',
-            }}
-          >
-            {SORT_OPTIONS.map((opt) => (
-              <option key={opt} value={opt}>{opt}</option>
-            ))}
+            style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }}>
+            {SORT_OPTIONS.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
           </select>
         </div>
       </div>
 
       {/* Messages list */}
       {loading ? (
-        <div className="text-center py-12" style={{ color: 'var(--color-text-muted)' }}>
-          載入留言中...
-        </div>
+        <div className="text-center py-12" style={{ color: 'var(--color-text-muted)' }}>載入留言中...</div>
       ) : sortedFiltered.length === 0 ? (
-        <div
-          className="text-center py-12 rounded-xl"
-          style={{
-            background: 'var(--color-bg-card)',
-            border: '1px solid var(--color-border)',
-          }}
-        >
+        <div className="text-center py-12 rounded-xl" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}>
           <p className="text-3xl mb-3">💬</p>
           <p style={{ color: 'var(--color-text-muted)' }}>
             {filter === '全部' ? '還沒有留言，成為第一個發言的人！' : `「${filter}」分類還沒有留言`}
@@ -944,6 +358,9 @@ export default function MessageBoard() {
               onEdit={handleEdit}
               onPinToggle={handlePinToggle}
               onReport={handleReport}
+              replies={msg.replies || []}
+              replyCount={msg.reply_count || 0}
+              onReply={handleReply}
             />
           ))}
         </div>

--- a/src/components/discuss/MessageCard.tsx
+++ b/src/components/discuss/MessageCard.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import { sanitizeUrl, sanitizeImgSrc, sanitizeMarkdown } from '../../lib/markdown';
+import { ROLE_LEVEL } from '@/lib/auth';
+import { timeAgo } from '@/lib/time';
+import ReplyForm from './ReplyForm';
+
+export interface Message {
+  id: number;
+  author: string;
+  author_id: string | null;
+  content: string;
+  tag: string;
+  category: string;
+  created_at: string;
+  edited_at: string | null;
+  pinned: number;
+  like_count: number;
+  deleted_at: string | null;
+  deleted_by: string | null;
+  report_count: number;
+  reported_by_me?: boolean;
+  parent_id: number | null;
+  reply_count: number;
+  replies: Message[];
+}
+
+export const CATEGORIES = ['閒聊', '成果分享', '問題', '建議'];
+
+export const CATEGORY_COLORS: Record<string, string> = {
+  '閒聊': 'var(--color-primary)',
+  '成果分享': '#FFD93D',
+  '問題': 'var(--color-neon-blue)',
+  '建議': 'var(--color-neon-green)',
+};
+
+export default function MessageCard({
+  msg,
+  likedIds,
+  onToggleLike,
+  isLoggedIn,
+  likeLoadingIds,
+  currentUser,
+  onDelete,
+  onEdit,
+  onPinToggle,
+  onReport,
+  replies,
+  replyCount,
+  onReply,
+  isReply = false,
+}: {
+  msg: Message;
+  likedIds: Set<number>;
+  onToggleLike: (messageId: number, currentLiked: boolean) => void;
+  isLoggedIn: boolean;
+  likeLoadingIds: Set<number>;
+  currentUser: { id: string; name?: string; effectiveRole: string } | null;
+  onDelete: (messageId: number) => void;
+  onEdit: (messageId: number, newContent: string) => void;
+  onPinToggle: (messageId: number, pinned: number) => void;
+  onReport: (messageId: number, reason: string) => void;
+  replies: Message[];
+  replyCount: number;
+  onReply: (parentId: number, content: string) => void;
+  isReply?: boolean;
+}) {
+  const color = CATEGORY_COLORS[msg.category] || 'var(--color-primary)';
+  const liked = likedIds.has(msg.id);
+  const isLikeLoading = likeLoadingIds.has(msg.id);
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(msg.content);
+  const [editSaving, setEditSaving] = useState(false);
+  const [pinLoading, setPinLoading] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
+  const [reportReason, setReportReason] = useState('');
+  const [reportSubmitting, setReportSubmitting] = useState(false);
+  const [showReplyForm, setShowReplyForm] = useState(false);
+
+  const canModify = currentUser && (
+    msg.author_id === currentUser.id ||
+    (ROLE_LEVEL[currentUser.effectiveRole] ?? 0) >= (ROLE_LEVEL['admin'] ?? 0)
+  );
+  const canPin = !isReply && currentUser &&
+    (ROLE_LEVEL[currentUser.effectiveRole] ?? 0) >= (ROLE_LEVEL['admin'] ?? 0);
+
+  const handlePinToggle = async () => {
+    if (pinLoading) return;
+    const nextPinned = msg.pinned ? 0 : 1;
+    setPinLoading(true);
+    try {
+      const res = await fetch(`/api/messages/${msg.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pinned: nextPinned }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        onPinToggle(msg.id, nextPinned);
+      } else {
+        alert(data.error || '操作失敗');
+      }
+    } catch {
+      alert('網路錯誤，無法置頂');
+    } finally {
+      setPinLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    const trimmed = editContent.trim();
+    if (!trimmed || trimmed === msg.content) {
+      setIsEditing(false);
+      return;
+    }
+    setEditSaving(true);
+    try {
+      const res = await fetch(`/api/messages/${msg.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: trimmed }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        onEdit(msg.id, trimmed);
+        setIsEditing(false);
+      } else {
+        alert(data.error || '儲存失敗');
+      }
+    } catch {
+      alert('網路錯誤，無法儲存');
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setEditContent(msg.content);
+    setIsEditing(false);
+  };
+
+  return (
+    <>
+      <div
+        className="rounded-xl transition-all min-w-0 overflow-hidden"
+        style={{
+          background: 'var(--color-bg-card)',
+          border: '1px solid var(--color-border)',
+          borderLeftWidth: '3px',
+          borderLeftColor: isReply ? 'var(--color-border)' : color,
+          padding: isReply ? '0.75rem' : '1rem',
+        }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-2 gap-2 min-w-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <span
+              className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
+              style={{ background: `${color}20`, color }}
+            >
+              {msg.author[0]}
+            </span>
+            <div className="min-w-0">
+              <span className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
+                {msg.author}
+              </span>
+              {msg.tag && (
+                <span className="text-xs ml-1" style={{ color: 'var(--color-text-muted)' }}>{msg.tag}</span>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {msg.pinned ? <span className="text-xs" style={{ color: '#FFC107' }} title="置頂留言">📌</span> : null}
+            {!isReply && msg.category && (
+              <span className="text-xs px-2 py-0.5 rounded-full" style={{ background: `${color}20`, color }}>
+                {msg.category}
+              </span>
+            )}
+            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+              {timeAgo(msg.created_at)}{msg.edited_at && ' (已編輯)'}
+            </span>
+          </div>
+        </div>
+
+        {/* Content area */}
+        {isEditing ? (
+          <div className="space-y-2">
+            <textarea
+              value={editContent}
+              onChange={(e) => setEditContent(e.target.value)}
+              disabled={editSaving}
+              rows={3}
+              maxLength={2000}
+              className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-y"
+              style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }}
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{editContent.length}/2000</span>
+              <div className="flex items-center gap-2">
+                <button onClick={handleCancel} disabled={editSaving}
+                  className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
+                  style={{ background: 'transparent', color: 'var(--color-text-muted)', border: '1px solid var(--color-border)', opacity: editSaving ? 0.6 : 1 }}>
+                  取消
+                </button>
+                <button onClick={handleSave} disabled={editSaving}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium transition-opacity"
+                  style={{ background: 'var(--color-primary)', color: '#fff', opacity: editSaving ? 0.6 : 1 }}>
+                  {editSaving ? '儲存中...' : '儲存'}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : msg.deleted_at ? (
+          <div className="text-sm leading-relaxed italic" style={{ color: 'var(--color-text-muted)', background: 'rgba(255,77,106,0.05)', border: '1px solid rgba(255,77,106,0.15)', borderRadius: '0.5rem', padding: '0.75rem 1rem' }}>
+            此留言已被刪除
+          </div>
+        ) : msg.report_count >= 3 ? (
+          <div className="text-sm leading-relaxed italic" style={{ color: 'var(--color-text-muted)', background: 'rgba(255,77,106,0.05)', border: '1px solid rgba(255,77,106,0.15)', borderRadius: '0.5rem', padding: '0.75rem 1rem' }}>
+            此留言因多次檢舉已隱藏
+          </div>
+        ) : (
+          <>
+            <div className="text-sm leading-relaxed break-words prose prose-sm max-w-none" style={{ color: 'var(--color-text-secondary)', overflowWrap: 'anywhere' }}>
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={{
+                  code({ className, children, ...props }) {
+                    const match = /language-(\w+)/.exec(className || '');
+                    const isInline = !match && !String(children).includes('\n');
+                    if (isInline) {
+                      return <code className="px-1.5 py-0.5 rounded text-xs font-mono" style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--color-neon-green)' }} {...props}>{children}</code>;
+                    }
+                    return <code className="block p-3 rounded-lg text-xs font-mono overflow-x-auto" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--color-neon-blue)' }} {...props}>{children}</code>;
+                  },
+                  a({ href, children, ...props }) {
+                    if (!href) return <span {...props}>{children}</span>;
+                    const safe = sanitizeUrl(href);
+                    if (!safe) return <span {...props}>{children}</span>;
+                    return <a href={safe} target="_blank" rel="noopener noreferrer" className="underline hover:opacity-80" style={{ color: 'var(--color-neon-blue)' }}>{children}</a>;
+                  },
+                  img({ src, alt, ...props }) {
+                    const safeSrc = sanitizeImgSrc(src);
+                    if (!safeSrc) return null;
+                    return <img src={safeSrc} alt={alt || ''} loading="lazy" style={{ maxWidth: '100%', height: 'auto', borderRadius: '0.5rem' }} />;
+                  },
+                }}
+              >
+                {sanitizeMarkdown(msg.content)}
+              </ReactMarkdown>
+            </div>
+            {/* Action buttons */}
+            <div className="flex items-center justify-end mt-2 gap-2 flex-wrap">
+              {canPin && (
+                <button onClick={handlePinToggle} disabled={pinLoading}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                  style={{ background: msg.pinned ? 'rgba(255, 193, 7, 0.1)' : 'transparent', color: msg.pinned ? '#FFC107' : 'var(--color-text-muted)', border: 'none', cursor: pinLoading ? 'not-allowed' : 'pointer', opacity: pinLoading ? 0.5 : 1 }}
+                  title={msg.pinned ? '取消置頂' : '置頂留言'}>
+                  {pinLoading ? '處理中...' : (msg.pinned ? '🔽 取消置頂' : '📌 置頂')}
+                </button>
+              )}
+              {canModify && (
+                <button onClick={() => setIsEditing(true)}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                  style={{ background: 'transparent', color: 'var(--color-text-muted)', border: 'none', cursor: 'pointer' }} title="編輯留言">✏️</button>
+              )}
+              {canModify && (
+                <button onClick={() => { if (confirm('確定要刪除這則留言嗎？')) onDelete(msg.id); }}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                  style={{ background: 'transparent', color: 'var(--color-text-muted)', border: 'none', cursor: 'pointer' }} title="刪除留言">🗑️</button>
+              )}
+              <button onClick={() => onToggleLike(msg.id, liked)} disabled={!isLoggedIn || isLikeLoading}
+                className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all"
+                style={{ background: liked ? 'rgba(255, 77, 106, 0.1)' : 'transparent', color: liked ? '#FF4D6A' : 'var(--color-text-muted)', cursor: !isLoggedIn || isLikeLoading ? 'not-allowed' : 'pointer', opacity: !isLoggedIn ? 0.5 : 1, border: 'none' }}
+                title={!isLoggedIn ? '請先登入才能按讚' : liked ? '收回讚' : '按讚'}>
+                <span style={{ fontSize: '14px' }}>{liked ? '❤️' : '🤍'}</span>
+                <span>{msg.like_count > 0 ? msg.like_count : ''}</span>
+              </button>
+              {!isReply && isLoggedIn && (
+                <button onClick={() => setShowReplyForm(!showReplyForm)}
+                  className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                  style={{ background: 'transparent', color: 'var(--color-text-muted)', border: 'none', cursor: 'pointer' }} title="回覆留言">
+                  💬 回覆{replyCount > 0 ? ` (${replyCount})` : ''}
+                </button>
+              )}
+              {isLoggedIn && (
+                msg.reported_by_me
+                  ? <span className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs" style={{ color: 'var(--color-text-muted)', opacity: 0.5, border: 'none', cursor: 'default' }}>已檢舉</span>
+                  : <button onClick={() => setShowReportDialog(true)}
+                      className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs transition-all hover:opacity-80"
+                      style={{ background: 'transparent', color: 'var(--color-text-muted)', border: 'none', cursor: 'pointer' }} title="檢舉留言">🚩</button>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Report dialog */}
+        {showReportDialog && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4" style={{ background: 'rgba(0,0,0,0.6)' }}
+            onClick={() => { setShowReportDialog(false); setReportReason(''); }}>
+            <div className="w-full max-w-sm rounded-2xl p-5" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}
+              onClick={(e) => e.stopPropagation()}>
+              <div className="flex items-center justify-between mb-3">
+                <h4 className="text-sm font-semibold" style={{ color: 'var(--color-text-primary)' }}>🚩 檢舉留言</h4>
+                <button onClick={() => { setShowReportDialog(false); setReportReason(''); }}
+                  style={{ color: 'var(--color-text-muted)', background: 'none', border: 'none', cursor: 'pointer', fontSize: '18px' }}>×</button>
+              </div>
+              <p className="text-xs mb-3" style={{ color: 'var(--color-text-muted)' }}>請填寫檢舉原因，我們會儘快審核。</p>
+              <textarea value={reportReason} onChange={(e) => setReportReason(e.target.value)} placeholder="檢舉原因..." rows={3} maxLength={500}
+                className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-none mb-3"
+                style={{ background: 'var(--color-bg-surface)', border: '1px solid var(--color-border)', color: 'var(--color-text-primary)' }} />
+              <div className="flex items-center justify-end gap-2">
+                <button onClick={() => { setShowReportDialog(false); setReportReason(''); }} disabled={reportSubmitting}
+                  className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
+                  style={{ background: 'transparent', color: 'var(--color-text-muted)', border: '1px solid var(--color-border)' }}>取消</button>
+                <button
+                  onClick={async () => {
+                    if (!reportReason.trim()) return;
+                    setReportSubmitting(true);
+                    onReport(msg.id, reportReason.trim());
+                    setShowReportDialog(false);
+                    setReportReason('');
+                    setReportSubmitting(false);
+                  }}
+                  disabled={reportSubmitting || !reportReason.trim()}
+                  className="px-3 py-1.5 rounded-lg text-xs font-medium text-white transition-opacity"
+                  style={{ background: '#E94560', opacity: reportSubmitting || !reportReason.trim() ? 0.6 : 1 }}>
+                  {reportSubmitting ? '送出中...' : '送出檢舉'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Inline reply form */}
+      {showReplyForm && isLoggedIn && (
+        <div className="ml-6 mt-1">
+          <ReplyForm
+            parentId={msg.id}
+            onReply={(pid, content) => { onReply(pid, content); setShowReplyForm(false); }}
+            onCancel={() => setShowReplyForm(false)}
+            authorName={currentUser?.name ?? ''}
+          />
+        </div>
+      )}
+
+      {/* Nested replies */}
+      {replies.length > 0 && (
+        <div className="ml-6 mt-2 space-y-2" style={{ borderLeft: '2px solid var(--color-border)', paddingLeft: '12px' }}>
+          {replies.map((reply) => (
+            <MessageCard
+              key={reply.id}
+              msg={reply}
+              isReply={true}
+              likedIds={likedIds}
+              onToggleLike={onToggleLike}
+              isLoggedIn={isLoggedIn}
+              likeLoadingIds={likeLoadingIds}
+              currentUser={currentUser}
+              onDelete={onDelete}
+              onEdit={onEdit}
+              onPinToggle={onPinToggle}
+              onReport={onReport}
+              replies={[]}
+              replyCount={0}
+              onReply={onReply}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/discuss/MessageCard.tsx
+++ b/src/components/discuss/MessageCard.tsx
@@ -64,7 +64,7 @@ export default function MessageCard({
   onReport: (messageId: number, reason: string) => void;
   replies: Message[];
   replyCount: number;
-  onReply: (parentId: number, content: string) => void;
+  onReply: (parentId: number, content: string) => Promise<void>;
   isReply?: boolean;
 }) {
   const color = CATEGORY_COLORS[msg.category] || 'var(--color-primary)';
@@ -340,7 +340,7 @@ export default function MessageCard({
         <div className="ml-6 mt-1">
           <ReplyForm
             parentId={msg.id}
-            onReply={(pid, content) => { onReply(pid, content); setShowReplyForm(false); }}
+            onReply={async (pid, content) => { await onReply(pid, content); setShowReplyForm(false); }}
             onCancel={() => setShowReplyForm(false)}
             authorName={currentUser?.name ?? ''}
           />

--- a/src/components/discuss/ReplyForm.tsx
+++ b/src/components/discuss/ReplyForm.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+interface ReplyFormProps {
+  parentId: number;
+  onReply: (parentId: number, content: string) => void;
+  onCancel: () => void;
+  authorName: string;
+}
+
+export default function ReplyForm({ parentId, onReply, onCancel, authorName }: ReplyFormProps) {
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!content.trim()) return;
+    setSubmitting(true);
+    onReply(parentId, content.trim());
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="mt-2 space-y-2">
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        placeholder={`以 ${authorName} 回覆...`}
+        rows={2}
+        maxLength={2000}
+        className="w-full px-3 py-2 rounded-lg text-sm outline-none resize-y"
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          color: 'var(--color-text-primary)',
+        }}
+      />
+      <div className="flex items-center justify-between">
+        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+          {content.length}/2000
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onCancel}
+            disabled={submitting}
+            className="px-3 py-1.5 rounded-lg text-xs transition-opacity"
+            style={{
+              background: 'transparent',
+              color: 'var(--color-text-muted)',
+              border: '1px solid var(--color-border)',
+              opacity: submitting ? 0.6 : 1,
+            }}
+          >
+            取消
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !content.trim()}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium transition-opacity"
+            style={{
+              background: 'var(--color-primary)',
+              color: '#fff',
+              opacity: submitting || !content.trim() ? 0.6 : 1,
+            }}
+          >
+            {submitting ? '送出中...' : '送出回覆'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/discuss/ReplyForm.tsx
+++ b/src/components/discuss/ReplyForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 interface ReplyFormProps {
   parentId: number;
-  onReply: (parentId: number, content: string) => void;
+  onReply: (parentId: number, content: string) => Promise<void>;
   onCancel: () => void;
   authorName: string;
 }
@@ -14,8 +14,11 @@ export default function ReplyForm({ parentId, onReply, onCancel, authorName }: R
   const handleSubmit = async () => {
     if (!content.trim()) return;
     setSubmitting(true);
-    onReply(parentId, content.trim());
-    setSubmitting(false);
+    try {
+      await onReply(parentId, content.trim());
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,15 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-18',
+    changes: [
+      'feat(#97): 討論區留言回覆串 — messages 表新增 parent_id 欄位、回覆 API（單層巢狀）、前端回覆按鈕 + inline form + 縮排顯示',
+      'feat(#97): 回覆留言支援按讚/編輯/刪除/檢舉，不支援置頂',
+      'refactor(#97): MessageCard / ReplyForm 抽出獨立元件，MessageBoard 954→290 行',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-17',
     changes: [
       'refactor(#98): 新增 src/lib/api.ts 統一 apiFetch<T>() client — discriminated union 回傳、整合 logger、消除 fetch → json → data.ok → throw 四步樣板',


### PR DESCRIPTION
## Summary
- 討論區新增單層巢狀回覆功能，用戶可回覆頂層留言
- DB: messages 表新增 `parent_id` 欄位 + index
- API: GET 回傳頂層留言 + 巢狀 replies[]；POST 接受 parent_id 並驗證單層；PATCH 防止回覆置頂
- 前端: MessageCard/ReplyForm 抽出獨立元件，MessageBoard 954→370 行
- 回覆支援按讚/編輯/刪除/檢舉，不支援置頂
- 「最多回饋」排序含 reply_count

## Test plan
- [ ] 部署後到 /discuss 點「💬 回覆」按鈕，送出回覆
- [ ] 確認回覆縮排顯示在該留言下方
- [ ] 確認回覆可按讚、編輯、刪除、檢舉
- [ ] 確認回覆無置頂按鈕
- [ ] 確認只能回覆頂層留言（回覆的回覆應被 API 拒絕）
- [ ] 確認未登入看不到回覆按鈕
- [ ] 確認「最多回饋」排序正確

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)