### PR TITLE
fix(#112): AI 工具箱「新增工具」無法送出

### DIFF
--- a/functions/api/ai-tools/[id].ts
+++ b/functions/api/ai-tools/[id].ts
@@ -28,6 +28,9 @@ async function ensureMigration(db: ReturnType<typeof createClient>) {
   try {
     await db.execute({ sql: `ALTER TABLE ai_tools ADD COLUMN contributor_id TEXT DEFAULT ''`, args: [] });
   } catch { /* column already exists */ }
+  try {
+    await db.execute({ sql: `ALTER TABLE ai_tools ADD COLUMN github_url TEXT DEFAULT ''`, args: [] });
+  } catch { /* column already exists */ }
 }
 
 function isAdminOrAbove(user: { effectiveRole: string }): boolean {
@@ -63,7 +66,7 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
     const user = await requireAuth(context.request, context.env);
     const id = context.params.id;
     const body = await context.request.json() as Record<string, string>;
-    const { name, description, url, category } = body;
+    const { name, description, url, category, github_url } = body;
 
     const db = getDb(context.env);
     await db.execute({ sql: INIT_SQL, args: [] });
@@ -89,8 +92,25 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
 
     if (name !== undefined) { sets.push('name = ?'); args.push(name.trim()); }
     if (description !== undefined) { sets.push('description = ?'); args.push(description.trim()); }
-    if (url !== undefined) { sets.push('url = ?'); args.push(url.trim()); }
+    if (url !== undefined) {
+      const trimmedUrl = url.trim();
+      if (trimmedUrl && !trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
+        return new Response(JSON.stringify({ error: '連結必須以 http:// 或 https:// 開頭' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      sets.push('url = ?'); args.push(trimmedUrl);
+    }
     if (category !== undefined) { sets.push('category = ?'); args.push(category); }
+    if (github_url !== undefined) {
+      const trimmedGithubUrl = github_url.trim();
+      if (trimmedGithubUrl && !trimmedGithubUrl.startsWith('http://') && !trimmedGithubUrl.startsWith('https://')) {
+        return new Response(JSON.stringify({ error: 'GitHub 連結必須以 http:// 或 https:// 開頭' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      sets.push('github_url = ?'); args.push(trimmedGithubUrl);
+    }
 
     if (sets.length === 0) {
       return new Response(JSON.stringify({ error: '沒有提供更新欄位' }), {

--- a/functions/api/ai-tools/index.ts
+++ b/functions/api/ai-tools/index.ts
@@ -133,7 +133,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const user = await requireAuth(context.request, context.env);
-    const { name, description, url, category, author, author_tag, wish_id } = await context.request.json() as Record<string, string>;
+    const { name, description, url, category, author, author_tag, wish_id, github_url } = await context.request.json() as Record<string, string>;
 
     if (!name?.trim() || !description?.trim() || !url?.trim()) {
       return new Response(JSON.stringify({ error: '請填寫工具名稱、簡介和連結' }), {
@@ -145,6 +145,13 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const trimmedUrl = url.trim();
     if (!trimmedUrl.startsWith('http://') && !trimmedUrl.startsWith('https://')) {
       return new Response(JSON.stringify({ error: '連結必須以 http:// 或 https:// 開頭' }), {
+        status: 400, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const trimmedGithubUrl = github_url?.trim() || '';
+    if (trimmedGithubUrl && !trimmedGithubUrl.startsWith('http://') && !trimmedGithubUrl.startsWith('https://')) {
+      return new Response(JSON.stringify({ error: 'GitHub 連結必須以 http:// 或 https:// 開頭' }), {
         status: 400, headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -167,8 +174,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     }
 
     const result = await db.execute({
-      sql: `INSERT INTO ai_tools (name, description, url, category, author, author_tag, contributor_id, wish_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+      sql: `INSERT INTO ai_tools (name, description, url, category, author, author_tag, contributor_id, wish_id, github_url)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
       args: [
         name.trim(),
         description.trim(),
@@ -178,6 +185,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         author_tag?.trim() || '',
         user.id,
         wish_id?.trim() || '',
+        trimmedGithubUrl,
       ],
     });
 

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -103,6 +103,7 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
   const [name, setName] = useState(tool?.name ?? '');
   const [description, setDescription] = useState(tool?.description ?? '');
   const [url, setUrl] = useState(tool?.url ?? '');
+  const [githubUrl, setGithubUrl] = useState(tool?.github_url ?? '');
   const [category, setCategory] = useState<ToolCategory>(tool?.category ?? 'other');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
@@ -113,8 +114,19 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
     if (!name.trim()) errs.name = '請填寫工具名稱';
     if (!description.trim()) errs.description = '請填寫簡介';
     if (!url.trim()) errs.url = '請填寫連結';
+    if (githubUrl.trim() && !/^https?:\/\//.test(githubUrl.trim())) {
+      errs.githubUrl = 'GitHub 連結必須以 http:// 或 https:// 開頭';
+    }
     setErrors(errs);
     if (Object.keys(errs).length > 0) return;
+
+    const payload = {
+      name: name.trim(),
+      description: description.trim(),
+      url: url.trim(),
+      github_url: githubUrl.trim(),
+      category,
+    };
 
     setSubmitting(true);
     try {
@@ -122,7 +134,7 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
         const res = await fetch(`/api/ai-tools/${tool!.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: name.trim(), description: description.trim(), url: url.trim(), category }),
+          body: JSON.stringify(payload),
         });
         if (!res.ok) {
           const data = await res.json();
@@ -132,7 +144,7 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
         const res = await fetch('/api/ai-tools', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ name: name.trim(), description: description.trim(), url: url.trim(), category }),
+          body: JSON.stringify(payload),
         });
         if (!res.ok) {
           const data = await res.json();
@@ -206,7 +218,8 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
             <label style={labelStyle}>GitHub Repo <span style={{ color: '#9090B0', fontWeight: 400 }}>(選填)</span></label>
             <input type="url" placeholder="https://github.com/..." value={githubUrl}
               onChange={e => setGithubUrl(e.target.value)} onFocus={handleFocusIn} onBlur={handleFocusOut}
-              style={inputStyle} />
+              style={{ ...inputStyle, borderColor: errors.githubUrl ? '#E94560' : '#2A2A4A' }} />
+            {errors.githubUrl && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{errors.githubUrl}</p>}
           </div>
 
           {/* Description */}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-18',
     changes: [
+      'fix(#112): AI 工具箱「新增工具」無法送出 — ToolModal 補上缺失的 githubUrl useState、POST/PATCH API 接收 github_url 並做 http/https 格式驗證、[id].ts 補上 github_url 欄位 migration',
       'feat(#97): 討論區留言回覆串 — messages 表新增 parent_id 欄位、回覆 API（單層巢狀）、前端回覆按鈕 + inline form + 縮排顯示',
       'feat(#97): 回覆留言支援按讚/編輯/刪除/檢舉，不支援置頂',
       'refactor(#97): MessageCard / ReplyForm 抽出獨立元件，MessageBoard 954→290 行',


### PR DESCRIPTION
Closes #112

## 問題

AI 工具箱點「新增工具」開啟 modal 後，表單直接壞掉：`ToolModal` 使用了從未宣告的 `githubUrl` / `setGithubUrl`，React 一 render 就 ReferenceError，自然也送不出去。commit 080a983（feat #50 新增 URL 欄位）加了 input 但漏了 `useState`。

而且就算 state 補上，後端 POST / PATCH 也沒接 `github_url`，寫不進 DB。

## Changes

- `src/components/ai-tools/ToolCardBoard.tsx`
  - `ToolModal` 補 `const [githubUrl, setGithubUrl] = useState(tool?.github_url ?? '')`
  - `handleSubmit` 改走共用 `payload` 帶 `github_url`（POST 與 PATCH 同步）
  - 前端先驗 http/https 格式，空字串允許
  - 錯誤訊息顯示在 GitHub URL 輸入框下方
- `functions/api/ai-tools/index.ts`
  - POST 接收 `github_url` 並 INSERT
  - 驗 http/https 格式
- `functions/api/ai-tools/[id].ts`
  - PATCH 接收 `github_url` 並 UPDATE
  - `ensureMigration` 補 `github_url` column（這個檔之前只 migrate `contributor_id`）
  - 順手補上 PATCH url 欄位的 http/https 驗證（跟 POST 對齊）
- `src/lib/changelog.ts` 更新 2026-04-18 條目

## Test plan

- [ ] `npm run build` 在 CI 通過
- [ ] 手動：打開 AI 工具箱 → 新增工具 → 不填 GitHub URL → 送出成功
- [ ] 手動：打開新增工具 → 填 `https://github.com/foo/bar` → 送出成功，重整後看得到
- [ ] 手動：填 `not-a-url` 當 GitHub URL → 前端顯示錯誤，不送出
- [ ] 手動：編輯既有工具 → 修改 GitHub URL → 儲存成功
- [ ] 手動：空 DB 欄位的舊工具編輯後，github_url migration 自動跑過

https://claude.ai/code/session_01EFFmdxfasaFBDRaLnEXQ27