### PR TITLE
fix(#110): 成員空間載入失敗 + 投稿連結導正

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
+        "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.2.2",
       },
@@ -724,6 +725,8 @@
 
     "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
 
+    "mdast-util-newline-to-break": ["mdast-util-newline-to-break@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-find-and-replace": "^3.0.0" } }, "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog=="],
+
     "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
@@ -891,6 +894,8 @@
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
+    "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 

--- a/functions/api/members/[id].ts
+++ b/functions/api/members/[id].ts
@@ -27,13 +27,29 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       args: [id],
     });
 
-    if (!result.rows.length) {
+    // Fallback: try matching by name when ID is a MEMBERS constant slug (e.g. 'dar')
+    let rows = result.rows;
+    if (!rows.length) {
+      const byName = await db.execute({
+        sql: `SELECT u.id, u.name, u.discord_id, u.avatar_url, u.color,
+                u.display_name, u.emoji, u.bio,
+                GROUP_CONCAT(ur.role) AS roles
+              FROM users u
+              LEFT JOIN user_roles ur ON ur.user_id = u.id
+              WHERE LOWER(u.name) = LOWER(?) AND u.status = 'active'
+              GROUP BY u.id`,
+        args: [id],
+      });
+      rows = byName.rows;
+    }
+
+    if (!rows.length) {
       return new Response(JSON.stringify({ ok: false, error: '找不到該成員' }), {
         status: 404, headers: { 'Content-Type': 'application/json' },
       });
     }
 
-    const row = result.rows[0];
+    const row = rows[0];
     const roles = String(row.roles ?? '').split(',').filter(Boolean);
     const effectiveRole = roles.length > 0 ? getEffectiveRole(roles) : 'companion';
 

--- a/functions/api/members/[id].ts
+++ b/functions/api/members/[id].ts
@@ -22,7 +22,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
               GROUP_CONCAT(ur.role) AS roles
             FROM users u
             LEFT JOIN user_roles ur ON ur.user_id = u.id
-            WHERE u.id = ? AND u.status = 'active' AND u.archived_at IS NULL
+            WHERE u.id = ? AND u.status = 'active'
             GROUP BY u.id`,
       args: [id],
     });

--- a/functions/api/members/index.ts
+++ b/functions/api/members/index.ts
@@ -21,7 +21,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
               GROUP_CONCAT(ur.role) AS roles
             FROM users u
             LEFT JOIN user_roles ur ON ur.user_id = u.id
-            WHERE u.status = 'active' AND u.archived_at IS NULL
+            WHERE u.status = 'active'
             GROUP BY u.id`,
       args: [],
     });

--- a/src/components/team/MemberProfile.tsx
+++ b/src/components/team/MemberProfile.tsx
@@ -175,7 +175,18 @@ export default function MemberProfile({ memberId }: { memberId: string }) {
         </div>
         {aiTools.length === 0 ? (
           <div className="glass rounded-xl p-6 text-center text-[var(--color-text-muted)]">
-            尚無 AI 工具投稿
+            <p className="mb-3">尚無 AI 工具投稿</p>
+            <a
+              href="/ai-tools"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-80"
+              style={{
+                background: 'rgba(108, 99, 255, 0.15)',
+                color: '#8B83FF',
+                border: '1px solid rgba(108, 99, 255, 0.3)',
+              }}
+            >
+              🤖 前往 AI 工具箱投稿
+            </a>
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">
@@ -213,7 +224,18 @@ export default function MemberProfile({ memberId }: { memberId: string }) {
         </div>
         {knowledge.length === 0 ? (
           <div className="glass rounded-xl p-6 text-center text-[var(--color-text-muted)]">
-            尚無知識庫貢獻
+            <p className="mb-3">尚無知識庫貢獻</p>
+            <a
+              href="/knowledge"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all hover:opacity-80"
+              style={{
+                background: 'rgba(0, 245, 160, 0.15)',
+                color: '#00F5A0',
+                border: '1px solid rgba(0, 245, 160, 0.3)',
+              }}
+            >
+              📚 前往知識庫投稿
+            </a>
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2">

--- a/src/components/team/TeamBoard.tsx
+++ b/src/components/team/TeamBoard.tsx
@@ -1,4 +1,13 @@
 import { useState, useEffect } from 'react';
+import { MEMBERS } from '@/lib/constants';
+
+const MEMBER_SLUG_MAP = new Map<string, string>();
+MEMBERS.forEach((m) => MEMBER_SLUG_MAP.set(m.name.toLowerCase(), m.id));
+
+function getMemberSlug(displayName: string, name: string, id: string): string {
+  return MEMBER_SLUG_MAP.get((displayName || name).toLowerCase()) || id;
+}
+
 
 interface TeamMember {
   id: string;
@@ -168,7 +177,7 @@ export default function TeamBoard() {
 
                 {/* View Profile Button */}
                 <a
-                  href={`/team/${member.id}`}
+                  href={`/team/${getMemberSlug(member.display_name, member.name, member.id)}`}
                   className="mt-3 px-3 py-1.5 rounded-lg text-xs font-medium transition-all hover:opacity-80"
                   style={{
                     background: `${member.color}15`,

--- a/src/components/team/TeamBoard.tsx
+++ b/src/components/team/TeamBoard.tsx
@@ -30,7 +30,14 @@ export default function TeamBoard() {
       .then((r) => r.json())
       .then((data) => {
         if (data.ok) {
-          setMembers(data.members);
+          // Deduplicate: same person may have both legacy and OAuth accounts
+          const seen = new Set<string>();
+          const unique = (data.members as TeamMember[]).filter((m: TeamMember) => {
+            if (seen.has(m.name)) return false;
+            seen.add(m.name);
+            return true;
+          });
+          setMembers(unique);
         } else {
           setError(true);
         }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,9 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-18',
     changes: [
+      'fix(#110): 成員空間 API 移除 archived_at 篩選 — /api/members/[id] 與 /api/members 不再排除 archived 成員，讓 legacy ID 的靜態頁面能正確載入',
+      'fix(#110): TeamBoard 成員去重 — 過濾同名重複帳號（legacy + OAuth），避免團隊頁顯示重複成員',
+      'fix(#110): 成員空間空狀態導引 — MemberProfile AI 工具投稿與知識庫貢獻區塊新增前往投稿頁面的連結按鈕',
       'fix(#106): 討論區發文/回覆/編輯輸入框改為自動隨內容高度擴展，移除固定 rows 限制',
       'fix(#106): 討論區留言顯示保留使用者換行，加入 remark-breaks 讓單一 \\n 渲染為 <br>',
       'fix(#112): AI 工具箱「新增工具」無法送出 — ToolModal 補上缺失的 githubUrl useState、POST/PATCH API 接收 github_url 並做 http/https 格式驗證、[id].ts 補上 github_url 欄位 migration',


### PR DESCRIPTION
## Summary

修復 Issue #110 的兩個 bug：

### Bug 1: 成員空間只有部分成員可看

**Root Cause:** `[id].astro` 使用 `MEMBERS` 常量（legacy IDs）生成靜態路徑，但 API `/api/members/[id]` 篩選 `archived_at IS NULL`，導致大部分 legacy users（被 soft-delete）回傳 404。

**Fix:**
- `functions/api/members/[id].ts` — 移除 `archived_at IS NULL` 篩選
- `functions/api/members/index.ts` — 同樣移除篩選
- `TeamBoard.tsx` — 新增去重邏輯，過濾同名重複帳號（legacy + OAuth），避免團隊頁顯示重複成員

### Bug 2: 成員空間投稿導引缺失

**Fix:**
- `MemberProfile.tsx` AI 工具投稿區塊空狀態 — 新增「🤖 前往 AI 工具箱投稿」連結按鈕
- `MemberProfile.tsx` 知識庫貢獻區塊空狀態 — 新增「📚 前往知識庫投稿」連結按鈕

## Test plan
- [ ] Build 通過 (`bun run build`)
- [ ] `/team/{legacyId}` 頁面能正確載入成員資料
- [ ] TeamBoard 不顯示重複成員
- [ ] MemberProfile 空狀態顯示正確的投稿導引連結

🤖 Generated with [Claude Code](https://claude.com/claude-code)