### PR TITLE
fix(#110): getStaticPaths 同時生成 slug + UUID 路由

### DIFF
--- a/src/pages/team/[id].astro
+++ b/src/pages/team/[id].astro
@@ -4,24 +4,23 @@ import MemberProfile from '@/components/team/MemberProfile';
 import { MEMBERS } from '@/lib/constants';
 
 export async function getStaticPaths() {
-  // Try to fetch live member IDs from API so OAuth UUID routes are generated too.
-  // If the API is unreachable during build, fall back to legacy MEMBERS constants.
+  // Always generate legacy slug routes (these are what TeamBoard links use).
+  const slugIds = MEMBERS.map((m) => m.id);
+
+  // Also try to fetch live member IDs so OAuth UUID routes exist too.
   try {
     const res = await fetch('https://cyclone.tw/api/members');
     const data = await res.json();
     if (data.ok && Array.isArray(data.members)) {
       const apiIds = data.members.map((m: { id: string }) => m.id);
-      // Deduplicate while preserving order
-      const unique = [...new Set(apiIds)];
-      return unique.map((id) => ({ params: { id } }));
+      const all = [...new Set([...slugIds, ...apiIds])];
+      return all.map((id) => ({ params: { id } }));
     }
   } catch {
-    /* API unavailable during build — fallback below */
+    /* API unreachable during build — slugs are enough */
   }
 
-  return MEMBERS.map((member) => ({
-    params: { id: member.id },
-  }));
+  return slugIds.map((id) => ({ params: { id } }));
 }
 
 const { id } = Astro.params;


### PR DESCRIPTION
## Summary

修正 PR #116 的後續問題：`getStaticPaths` 與 `TeamBoard` 連結來源失配可能導致 404。

### 問題

- `TeamBoard` 使用 `getMemberSlug()` 生成 slug 連結（如 `/team/dar`）
- `[id].astro` 的 `getStaticPaths` 優先從 API 取得 UUID，若 API 可用則只生成 UUID 路由
- 若 build 時 API 可用但 runtime 連結仍是 slug，靜態頁面只有 UUID 路由 → 404

### 修正

`[id].astro` 的 `getStaticPaths` 現在：
1. **總是**從 `MEMBERS` 生成 legacy slug 路由（供 TeamBoard 連結使用）
2. **額外**嘗試從 API 取得 OAuth UUID 生成 UUID 路由（供直接訪問）
3. 兩組路由 de-duplicate，避免重複生成

這樣無論 build 時 API 是否可用，slug 路由總是存在，與 TeamBoard 連結保持一致。

### Test plan
- [ ] Build 通過（82 pages，含 slug + UUID 路由）
- [ ] `/team/{slug}` 正確解析到 OAuth 帳號
- [ ] `/team/{uuid}` 直接訪問也有效

🤖 Generated with [Claude Code](https://claude.com/claude-code)