### PR TITLE
fix(#121,#122): 暱稱覆寫 + 許願樹留言頁面空白

### DIFF
--- a/functions/api/auth/callback.ts
+++ b/functions/api/auth/callback.ts
@@ -116,8 +116,8 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       userId = existingUser.rows[0].id as string;
       isPending = (existingUser.rows[0].status as string) === 'pending';
       await db.execute({
-        sql: `UPDATE users SET name = ?, avatar_url = ?, updated_at = datetime('now') WHERE id = ?`,
-        args: [googleUser.name, googleUser.picture, userId],
+        sql: `UPDATE users SET avatar_url = ?, updated_at = datetime('now') WHERE id = ?`,
+        args: [googleUser.picture, userId],
       });
     } else {
       // No email match — try to claim a seed user with matching name and empty email

--- a/functions/api/wishes/[id]/comments.ts
+++ b/functions/api/wishes/[id]/comments.ts
@@ -32,11 +32,9 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       id: r.id,
       content: r.content,
       created_at: r.created_at,
-      author: {
-        id: r.author_id,
-        name: r.author_name,
-        avatarUrl: r.author_avatar,
-      },
+      author_id: r.author_id,
+      author_name: r.author_name,
+      author_avatar: r.author_avatar,
     }));
 
     return new Response(JSON.stringify({ ok: true, comments }), {

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -14,6 +14,7 @@ interface Comment {
 interface User {
   id: string;
   name: string;
+  display_name?: string;
   avatar_url?: string | null;
   effectiveRole: string;
 }
@@ -210,7 +211,7 @@ export default function ResourceComments({ resourceType, resourceId, user, color
 
           {user && (
             <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
-              <Avatar name={user.name} avatarUrl={user.avatar_url ?? null} size={28} />
+              <Avatar name={user.display_name || user.name} avatarUrl={user.avatar_url ?? null} size={28} />
               <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
                 <textarea
                   value={content}

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -233,7 +233,7 @@ function ToolModal({ tool, onClose, onSaved }: ModalProps) {
 
           {!isEdit && user && (
             <p style={{ fontSize: '0.8rem', color: '#606080', marginBottom: '0.75rem' }}>
-              投稿者：{user.name}
+              投稿者：{user.display_name || user.name}
             </p>
           )}
 

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -91,7 +91,7 @@ export default function LoginButton() {
         {user.avatar_url ? (
           <img
             src={user.avatar_url}
-            alt={user.name}
+            alt={user.display_name || user.name}
             className="w-7 h-7 rounded-full object-cover ring-2 ring-[var(--color-border)]"
           />
         ) : (
@@ -99,11 +99,11 @@ export default function LoginButton() {
             className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white"
             style={{ backgroundColor: roleColor }}
           >
-            {getInitials(user.name)}
+            {getInitials(user.display_name || user.name)}
           </div>
         )}
         <span className="hidden sm:inline text-sm font-medium text-[var(--color-text-secondary)] max-w-[80px] truncate">
-          {user.name}
+          {user.display_name || user.name}
         </span>
         <svg
           className={`w-3 h-3 text-[var(--color-text-muted)] transition-transform ${menuOpen ? 'rotate-180' : ''}`}
@@ -121,7 +121,7 @@ export default function LoginButton() {
           {/* User info */}
           <div className="px-4 py-3 border-b border-[var(--color-border)]">
             <p className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
-              {user.name}
+              {user.display_name || user.name}
             </p>
             <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">
               {user.email}

--- a/src/components/auth/LoginButton.tsx
+++ b/src/components/auth/LoginButton.tsx
@@ -80,6 +80,7 @@ export default function LoginButton() {
 
   const roleColor = ROLE_BADGE_COLORS[user.effectiveRole] || '#9090B0';
   const roleLabel = ROLE_LABELS[user.effectiveRole] || user.effectiveRole;
+  const displayName = user.display_name || user.name;
 
   return (
     <div className="relative" ref={menuRef}>
@@ -91,7 +92,7 @@ export default function LoginButton() {
         {user.avatar_url ? (
           <img
             src={user.avatar_url}
-            alt={user.display_name || user.name}
+            alt={displayName}
             className="w-7 h-7 rounded-full object-cover ring-2 ring-[var(--color-border)]"
           />
         ) : (
@@ -99,11 +100,11 @@ export default function LoginButton() {
             className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold text-white"
             style={{ backgroundColor: roleColor }}
           >
-            {getInitials(user.display_name || user.name)}
+            {getInitials(displayName)}
           </div>
         )}
         <span className="hidden sm:inline text-sm font-medium text-[var(--color-text-secondary)] max-w-[80px] truncate">
-          {user.display_name || user.name}
+          {displayName}
         </span>
         <svg
           className={`w-3 h-3 text-[var(--color-text-muted)] transition-transform ${menuOpen ? 'rotate-180' : ''}`}
@@ -121,7 +122,7 @@ export default function LoginButton() {
           {/* User info */}
           <div className="px-4 py-3 border-b border-[var(--color-border)]">
             <p className="text-sm font-semibold text-[var(--color-text-primary)] truncate">
-              {user.display_name || user.name}
+              {displayName}
             </p>
             <p className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">
               {user.email}

--- a/src/components/discuss/MessageBoard.tsx
+++ b/src/components/discuss/MessageBoard.tsx
@@ -283,7 +283,7 @@ export default function MessageBoard() {
         <form ref={formRef} onSubmit={handleSubmit} className="rounded-xl p-5 space-y-4" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)' }}>
           <h3 className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>
             ✍️ 發表留言
-            <span className="ml-2 text-xs font-normal" style={{ color: 'var(--color-text-muted)' }}>以 {user.name} 發表</span>
+            <span className="ml-2 text-xs font-normal" style={{ color: 'var(--color-text-muted)' }}>以 {user.display_name || user.name} 發表</span>
           </h3>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <input type="text" value={tag} onChange={(e) => setTag(e.target.value)} placeholder="Discord Tag (選填)"

--- a/src/components/issues/IssueBoard.tsx
+++ b/src/components/issues/IssueBoard.tsx
@@ -635,7 +635,7 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
           <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
             新增留言
             <span className="ml-2 text-xs font-normal" style={{ color: '#9090B0' }}>
-              以 {user.name} 發表
+              以 {user.display_name || user.name} 發表
             </span>
           </h3>
           <form onSubmit={handleAddComment}>

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -958,7 +958,7 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
 
             {user && (
               <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
-                <Avatar name={user.name} avatarUrl={user.avatar_url} size={28} />
+                <Avatar name={user.display_name || user.name} avatarUrl={user.avatar_url} size={28} />
                 <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 6 }}>
                   <textarea
                     value={commentContent}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,9 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-19',
     changes: [
+      'fix(#122): 許願樹留言 API 回傳格式修正 — 從巢狀 author 物件改為扁平 author_name/author_avatar，防止頁面 crash',
+      'fix(#121): OAuth callback 不再覆寫 name 欄位，保留使用者自訂暱稱',
+      'fix(#121): Navbar、留言區、投稿區等元件統一使用 display_name || name 顯示使用者名稱',
       'feat(#120): Gemini AI 分析建議 — POST /api/admin/ai-insights + AdminAIInsights tab 元件',
       'feat(#120): Admin Panel 整合 AI 建議按鈕，分析 GA4 數據生成改善建議',
       'fix(security): /api/members 成員列表補上 archived_at IS NULL 過濾，防止已封存帳號洩漏',


### PR DESCRIPTION
## Summary
- **#122**: 許願樹留言 API 回傳格式從巢狀 `author` 物件改為扁平 `author_name`/`author_avatar`，匹配前端 `WishComment` 介面，修正點留言時 React crash 導致整頁空白
- **#121**: OAuth callback 不再覆寫 `name` 欄位（僅更新 `avatar_url`），保留使用者自訂暱碼
- **#121**: LoginButton、IssueBoard、MessageBoard、ToolCardBoard、ResourceComments、WishBoard 統一使用 `display_name || name`

## Root Cause
- #122: API 回傳 `{ author: { name: "..." } }` 但前端期待 `{ author_name: "..." }` → `getInitial(undefined)` → TypeError → React unmount
- #121: `callback.ts` 每次 Google 登入都 `UPDATE users SET name = googleUser.name`，覆寫使用者自訂的 name

## Test plan
- [ ] 登入 → 設定自訂暱稱 → 登出 → 重新登入 → 暱稱應保留
- [ ] `/wishlist` 點任一卡片的留言按鈕 → 留言展開正常，頁面不空白
- [ ] Navbar 顯示 display_name（若有設定）而非 Google 名稱
- [ ] `bun run build` 通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)