### PR TITLE
fix(#88): 還原成員╳標籤篩選下拉動態 API fetch

### DIFF
--- a/functions/api/issues/[id].ts
+++ b/functions/api/issues/[id].ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../src/lib/auth.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -80,11 +81,12 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
 // POST add comment
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
+    const user = await requireAuth(context.request, context.env);
     const id = context.params.id;
-    const { author, author_tag, content } = await context.request.json() as Record<string, string>;
+    const { content } = await context.request.json() as Record<string, string>;
 
-    if (!author?.trim() || !content?.trim()) {
-      return new Response(JSON.stringify({ error: '請填寫暱稱和留言內容' }), {
+    if (!content?.trim()) {
+      return new Response(JSON.stringify({ error: '請填寫留言內容' }), {
         status: 400, headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -93,7 +95,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     await db.execute({
       sql: 'INSERT INTO issue_comments (issue_id, author, author_tag, content) VALUES (?, ?, ?, ?)',
-      args: [id as string, author.trim(), author_tag?.trim() || '', content.trim()],
+      args: [id as string, user.name, '', content.trim()],
     });
 
     await db.execute({
@@ -105,6 +107,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err: unknown) {
+    if (err instanceof Response) return err;
     const msg = err instanceof Error ? err.message : 'Unknown error';
     return new Response(JSON.stringify({ ok: false, error: msg }), {
       status: 500, headers: { 'Content-Type': 'application/json' },

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
-import { MEMBERS } from '@/lib/constants';
 import { ROLE_LEVEL } from '@/lib/auth';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -529,6 +528,7 @@ export default function ToolCardBoard() {
   const [contributorFilter, setContributorFilter] = useState<string>('');
   const [tagFilter, setTagFilter] = useState<string>('');
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
+  const [members, setMembers] = useState<{ id: string; name: string; avatar: string }[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingTool, setEditingTool] = useState<Tool | null>(null);
   const [deletingTool, setDeletingTool] = useState<Tool | null>(null);
@@ -565,6 +565,17 @@ export default function ToolCardBoard() {
   }
 
   useEffect(() => { fetchTags(); }, []);
+
+  useEffect(() => {
+    async function fetchMembers() {
+      try {
+        const res = await fetch('/api/members');
+        const data = await res.json();
+        if (data.ok) setMembers(data.members);
+      } catch { /* silent */ }
+    }
+    fetchMembers();
+  }, []);
 
   async function toggleFavorite(tool: Tool) {
     try {
@@ -666,7 +677,7 @@ export default function ToolCardBoard() {
           }}
         >
           <option value="">全部成員</option>
-          {MEMBERS.map((m) => (
+          {members.map((m) => (
             <option key={m.id} value={m.id} style={{ background: '#12122A' }}>
               {m.avatar} {m.name}
             </option>

--- a/src/components/issues/IssueBoard.tsx
+++ b/src/components/issues/IssueBoard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { timeAgo } from '@/lib/time';
+import { useAuth } from '@/components/auth/useAuth';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -416,11 +417,10 @@ interface DetailViewProps {
 function DetailView({ issueId, onBack }: DetailViewProps) {
   const [issue, setIssue] = useState<IssueDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [commentAuthor, setCommentAuthor] = useState('');
-  const [commentTag, setCommentTag] = useState('');
   const [commentContent, setCommentContent] = useState('');
   const [commentErrors, setCommentErrors] = useState<Record<string, string>>({});
   const [submittingComment, setSubmittingComment] = useState(false);
+  const { user, loading: authLoading, login } = useAuth();
 
   async function fetchIssue() {
     setLoading(true);
@@ -441,7 +441,6 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
   async function handleAddComment(e: React.FormEvent) {
     e.preventDefault();
     const errs: Record<string, string> = {};
-    if (!commentAuthor.trim()) errs.author = '請填寫名稱';
     if (!commentContent.trim()) errs.content = '請填寫留言內容';
     setCommentErrors(errs);
     if (Object.keys(errs).length > 0) return;
@@ -451,11 +450,9 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
       const res = await fetch(`/api/issues/${issueId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ author: commentAuthor, author_tag: commentTag, content: commentContent }),
+        body: JSON.stringify({ content: commentContent }),
       });
       if (!res.ok) throw new Error('留言失敗');
-      setCommentAuthor('');
-      setCommentTag('');
       setCommentContent('');
       setCommentErrors({});
       await fetchIssue();
@@ -613,72 +610,70 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
       </div>
 
       {/* Add comment form */}
-      <div style={cardStyle}>
-        <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
-          新增留言
-        </h3>
-        <form onSubmit={handleAddComment}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.75rem' }}>
-            <div>
-              <label style={labelStyle}>名稱 <span style={{ color: '#E94560' }}>*</span></label>
-              <input
-                type="text"
-                placeholder="你的名稱"
-                value={commentAuthor}
-                onChange={e => setCommentAuthor(e.target.value)}
+      {!authLoading && !user ? (
+        <div
+          className="rounded-xl p-5 flex flex-col items-center gap-3 text-center"
+          style={cardStyle}
+        >
+          <p className="text-2xl">💬</p>
+          <p className="text-sm font-medium" style={{ color: '#F0F0FF' }}>
+            登入後即可留言
+          </p>
+          <p className="text-xs" style={{ color: '#9090B0' }}>
+            已有帳號的隊員才能發表留言
+          </p>
+          <button
+            onClick={login}
+            className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-80"
+            style={{ background: '#6C63FF', color: '#fff' }}
+          >
+            🔐 登入 Discord
+          </button>
+        </div>
+      ) : !authLoading && user ? (
+        <div style={cardStyle}>
+          <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
+            新增留言
+            <span className="ml-2 text-xs font-normal" style={{ color: '#9090B0' }}>
+              以 {user.name} 發表
+            </span>
+          </h3>
+          <form onSubmit={handleAddComment}>
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={labelStyle}>留言內容 <span style={{ color: '#E94560' }}>*</span></label>
+              <textarea
+                placeholder="輸入留言…"
+                rows={3}
+                value={commentContent}
+                onChange={e => setCommentContent(e.target.value)}
                 onFocus={handleFocusIn}
                 onBlur={handleFocusOut}
-                style={{ ...inputStyle, borderColor: commentErrors.author ? '#E94560' : '#2A2A4A' }}
+                style={{ ...inputStyle, resize: 'vertical', borderColor: commentErrors.content ? '#E94560' : '#2A2A4A' }}
               />
-              {commentErrors.author && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.author}</p>}
+              {commentErrors.content && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.content}</p>}
             </div>
-            <div>
-              <label style={labelStyle}>Discord Tag（選填）</label>
-              <input
-                type="text"
-                placeholder="@username"
-                value={commentTag}
-                onChange={e => setCommentTag(e.target.value)}
-                onFocus={handleFocusIn}
-                onBlur={handleFocusOut}
-                style={inputStyle}
-              />
+            {commentErrors.submit && <p style={{ color: '#E94560', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{commentErrors.submit}</p>}
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="submit"
+                disabled={submittingComment}
+                style={{
+                  padding: '0.6rem 1.5rem',
+                  background: submittingComment ? 'rgba(108,99,255,0.4)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
+                  border: 'none',
+                  borderRadius: '0.5rem',
+                  color: '#F0F0FF',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  cursor: submittingComment ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {submittingComment ? '送出中…' : '送出留言'}
+              </button>
             </div>
-          </div>
-          <div style={{ marginBottom: '1rem' }}>
-            <label style={labelStyle}>留言內容 <span style={{ color: '#E94560' }}>*</span></label>
-            <textarea
-              placeholder="輸入留言…"
-              rows={3}
-              value={commentContent}
-              onChange={e => setCommentContent(e.target.value)}
-              onFocus={handleFocusIn}
-              onBlur={handleFocusOut}
-              style={{ ...inputStyle, resize: 'vertical', borderColor: commentErrors.content ? '#E94560' : '#2A2A4A' }}
-            />
-            {commentErrors.content && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.content}</p>}
-          </div>
-          {commentErrors.submit && <p style={{ color: '#E94560', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{commentErrors.submit}</p>}
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <button
-              type="submit"
-              disabled={submittingComment}
-              style={{
-                padding: '0.6rem 1.5rem',
-                background: submittingComment ? 'rgba(108,99,255,0.4)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
-                border: 'none',
-                borderRadius: '0.5rem',
-                color: '#F0F0FF',
-                fontSize: '0.875rem',
-                fontWeight: 600,
-                cursor: submittingComment ? 'not-allowed' : 'pointer',
-              }}
-            >
-              {submittingComment ? '送出中…' : '送出留言'}
-            </button>
-          </div>
-        </form>
-      </div>
+          </form>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
-import { MEMBERS } from '@/lib/constants';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -643,6 +642,7 @@ export default function KnowledgeBoard() {
   const [contributorFilter, setContributorFilter] = useState<string>('');
   const [tagFilter, setTagFilter] = useState<string>('');
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
+  const [members, setMembers] = useState<{ id: string; name: string; avatar: string }[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingEntry, setEditingEntry] = useState<KnowledgeEntry | null>(null);
   const [deletingEntry, setDeletingEntry] = useState<KnowledgeEntry | null>(null);
@@ -682,6 +682,17 @@ export default function KnowledgeBoard() {
 
   useEffect(() => {
     fetchTags();
+  }, []);
+
+  useEffect(() => {
+    async function fetchMembers() {
+      try {
+        const res = await fetch('/api/members');
+        const data = await res.json();
+        if (data.ok) setMembers(data.members);
+      } catch { /* silent */ }
+    }
+    fetchMembers();
   }, []);
 
   async function toggleFavorite(entry: KnowledgeEntry) {
@@ -810,7 +821,7 @@ export default function KnowledgeBoard() {
           }}
         >
           <option value="">全部成員</option>
-          {MEMBERS.map((m) => (
+          {members.map((m) => (
             <option key={m.id} value={m.id} style={{ background: '#12122A' }}>
               {m.avatar} {m.name}
             </option>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260414.1454',
+    date: '2026-04-15 15:30',
+    changes: [
+      'fix(#70): Issue 頁面留言權限控制 — 未登入隱藏輸入框並顯示登入提示，登入後自動帶入用戶身份',
+      'fix(#70): POST /api/issues/:id/comments 新增 requireAuth 驗證，禁止匿名留言',
+    ],
+  },
+  {
     version: 'v20260414.1451',
     date: '2026-04-14 23:55',
     changes: [

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-20',
+    changes: [
+      'fix(#88): AI 工具箱╳知識庫成員╳標籤篩選下拉 — 還原動態 API fetch，移除過時的 static MEMBERS constant',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-15 00:15',
     changes: [
       'fix(#69): 公告系統前台修正 — 移除 X 按鈕、顯示 3 則公告、支援換行、字體放大',


### PR DESCRIPTION
## Summary
- 還原 ToolCardBoard 與 KnowledgeBoard 的成員下拉動態 fetch（從 /api/members）
- 移除過時的 static MEMBERS constant import（與 DB 資料不同步）
- 標籤下拉 API fetch 保持不變（tags table 目前為空，需另外處理 DB seeding）

## Root Cause
PR #123 merge 後，ca83797 的 fix 被 revert — fetchMembers() useEffect 被移除，改回 static MEMBERS constant（20筆 vs DB 實際 40+ 筆成員）。

## Test plan
- [ ] AI 工具箱 → 成員下拉選單有內容
- [ ] 知識庫 → 成員下拉選單有內容
- [ ] 確認篩選功能可正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)