### PR TITLE
fix(#70): Issue 建立表單權限控制 — 訪客需登入才能建立 Issue

### DIFF
--- a/functions/api/issues/[id].ts
+++ b/functions/api/issues/[id].ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../src/lib/auth.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -80,11 +81,12 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
 // POST add comment
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
+    const user = await requireAuth(context.request, context.env);
     const id = context.params.id;
-    const { author, author_tag, content } = await context.request.json() as Record<string, string>;
+    const { content } = await context.request.json() as Record<string, string>;
 
-    if (!author?.trim() || !content?.trim()) {
-      return new Response(JSON.stringify({ error: '請填寫暱稱和留言內容' }), {
+    if (!content?.trim()) {
+      return new Response(JSON.stringify({ error: '請填寫留言內容' }), {
         status: 400, headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -93,7 +95,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     await db.execute({
       sql: 'INSERT INTO issue_comments (issue_id, author, author_tag, content) VALUES (?, ?, ?, ?)',
-      args: [id as string, author.trim(), author_tag?.trim() || '', content.trim()],
+      args: [id as string, user.name, '', content.trim()],
     });
 
     await db.execute({
@@ -105,6 +107,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err: unknown) {
+    if (err instanceof Response) return err;
     const msg = err instanceof Error ? err.message : 'Unknown error';
     return new Response(JSON.stringify({ ok: false, error: msg }), {
       status: 500, headers: { 'Content-Type': 'application/json' },

--- a/functions/api/issues/index.ts
+++ b/functions/api/issues/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { requireAuth } from '../../../src/lib/auth.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -73,10 +74,11 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
-    const { title, description, author, author_tag, priority, category } = await context.request.json() as Record<string, string>;
+    const user = await requireAuth(context.request, context.env);
+    const { title, description, priority, category } = await context.request.json() as Record<string, string>;
 
-    if (!title?.trim() || !description?.trim() || !author?.trim()) {
-      return new Response(JSON.stringify({ error: '請填寫標題、描述和暱稱' }), {
+    if (!title?.trim() || !description?.trim()) {
+      return new Response(JSON.stringify({ error: '請填寫標題和描述' }), {
         status: 400, headers: { 'Content-Type': 'application/json' },
       });
     }
@@ -90,8 +92,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       args: [
         title.trim(),
         description.trim(),
-        author.trim(),
-        author_tag?.trim() || '',
+        user.name,
+        user.discord_id || '',
         priority || 'medium',
         category || 'bug',
       ],
@@ -101,6 +103,7 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (err: unknown) {
+    if (err instanceof Response) return err;
     const msg = err instanceof Error ? err.message : 'Unknown error';
     return new Response(JSON.stringify({ ok: false, error: msg }), {
       status: 500, headers: { 'Content-Type': 'application/json' },

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
-import { MEMBERS } from '@/lib/constants';
 import { ROLE_LEVEL } from '@/lib/auth';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -529,6 +528,7 @@ export default function ToolCardBoard() {
   const [contributorFilter, setContributorFilter] = useState<string>('');
   const [tagFilter, setTagFilter] = useState<string>('');
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
+  const [members, setMembers] = useState<{ id: string; name: string; avatar: string }[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingTool, setEditingTool] = useState<Tool | null>(null);
   const [deletingTool, setDeletingTool] = useState<Tool | null>(null);
@@ -565,6 +565,17 @@ export default function ToolCardBoard() {
   }
 
   useEffect(() => { fetchTags(); }, []);
+
+  useEffect(() => {
+    async function fetchMembers() {
+      try {
+        const res = await fetch('/api/members');
+        const data = await res.json();
+        if (data.ok) setMembers(data.members);
+      } catch { /* silent */ }
+    }
+    fetchMembers();
+  }, []);
 
   async function toggleFavorite(tool: Tool) {
     try {
@@ -666,7 +677,7 @@ export default function ToolCardBoard() {
           }}
         >
           <option value="">全部成員</option>
-          {MEMBERS.map((m) => (
+          {members.map((m) => (
             <option key={m.id} value={m.id} style={{ background: '#12122A' }}>
               {m.avatar} {m.name}
             </option>

--- a/src/components/auth/useAuth.ts
+++ b/src/components/auth/useAuth.ts
@@ -4,6 +4,7 @@ import type { GroupRole } from '@/lib/constants';
 export interface AuthUser {
   id: string;
   name: string;
+  display_name?: string;
   email: string;
   avatar_url: string | null;
   roles: GroupRole[];

--- a/src/components/bug/BugForm.tsx
+++ b/src/components/bug/BugForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
+import { useAuth } from '@/components/auth/useAuth';
 
 type FormData = {
-  nickname: string;
   bugType: string;
   bugPage: string;
   description: string;
@@ -10,7 +10,6 @@ type FormData = {
 };
 
 const initialFormData: FormData = {
-  nickname: '',
   bugType: '',
   bugPage: '',
   description: '',
@@ -80,6 +79,7 @@ export default function BugForm() {
   const [submitting, setSubmitting] = useState(false);
   const [issueId, setIssueId] = useState<number | null>(null);
   const [submitError, setSubmitError] = useState('');
+  const { user, loading: authLoading, login } = useAuth();
 
   const inputStyle: React.CSSProperties = {
     width: '100%',
@@ -107,7 +107,6 @@ export default function BugForm() {
 
   function validate(): boolean {
     const newErrors: Partial<FormData> = {};
-    if (!formData.nickname.trim()) newErrors.nickname = '請填寫回報者暱稱';
     if (!formData.bugType) newErrors.bugType = '請選擇問題類型';
     if (!formData.bugPage) newErrors.bugPage = '請選擇問題頁面';
     if (!formData.description.trim()) newErrors.description = '請描述你遇到的問題';
@@ -145,7 +144,6 @@ export default function BugForm() {
         body: JSON.stringify({
           title: `[Bug] ${formData.bugPage} — ${formData.bugType}`,
           description: buildDescription(),
-          author: formData.nickname.trim(),
           priority: 'medium',
           category: 'bug',
         }),
@@ -234,6 +232,34 @@ export default function BugForm() {
     );
   }
 
+  if (!authLoading && !user) {
+    return (
+      <div
+        className="rounded-xl p-8 flex flex-col items-center gap-4 text-center"
+        style={{
+          background: 'var(--color-glass-bg)',
+          backdropFilter: 'blur(12px)',
+          border: '1px solid var(--color-border)',
+        }}
+      >
+        <p className="text-3xl">🐛</p>
+        <p className="text-base font-semibold" style={{ color: 'var(--color-text-primary)' }}>
+          登入後即可回報 Bug
+        </p>
+        <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
+          已有帳號的隊員才能提交 Bug 回報
+        </p>
+        <button
+          onClick={login}
+          className="px-6 py-2.5 rounded-lg text-sm font-medium transition-opacity hover:opacity-80"
+          style={{ background: 'var(--color-primary)', color: '#fff' }}
+        >
+          🔐 登入
+        </button>
+      </div>
+    );
+  }
+
   return (
     <>
       <form
@@ -246,27 +272,17 @@ export default function BugForm() {
           padding: '2rem',
         }}
       >
-        {/* 回報者暱稱 */}
-        <div style={fieldStyle}>
-          <label style={labelStyle}>
-            回報者暱稱 <span style={{ color: 'var(--color-accent)' }}>*</span>
-          </label>
-          <input
-            type="text"
-            placeholder="請輸入你的暱稱"
-            value={formData.nickname}
-            onChange={(e) => setFormData({ ...formData, nickname: e.target.value })}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            style={{
-              ...inputStyle,
-              borderColor: errors.nickname ? 'var(--color-accent)' : 'var(--color-border)',
-            }}
-          />
-          {errors.nickname && (
-            <p style={{ color: 'var(--color-accent)', fontSize: '0.8rem', marginTop: '0.25rem' }}>{errors.nickname}</p>
+        <h3
+          className="text-base font-semibold mb-5"
+          style={{ color: 'var(--color-text-primary)' }}
+        >
+          🐛 回報 Bug
+          {user && (
+            <span className="ml-2 text-xs font-normal" style={{ color: 'var(--color-text-muted)' }}>
+              以 {user.display_name || user.name} 發表
+            </span>
           )}
-        </div>
+        </h3>
 
         {/* 問題類型 */}
         <div style={fieldStyle}>

--- a/src/components/bug/BugForm.tsx
+++ b/src/components/bug/BugForm.tsx
@@ -232,7 +232,22 @@ export default function BugForm() {
     );
   }
 
-  if (!authLoading && !user) {
+  if (authLoading) {
+    return (
+      <div
+        className="rounded-xl p-8 text-center"
+        style={{
+          background: 'var(--color-glass-bg)',
+          backdropFilter: 'blur(12px)',
+          border: '1px solid var(--color-border)',
+        }}
+      >
+        <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>載入中…</p>
+      </div>
+    );
+  }
+
+  if (!user) {
     return (
       <div
         className="rounded-xl p-8 flex flex-col items-center gap-4 text-center"

--- a/src/components/issues/IssueBoard.tsx
+++ b/src/components/issues/IssueBoard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { timeAgo } from '@/lib/time';
-import { useAuth } from '@/components/auth/useAuth';
+import { useAuth, type AuthUser } from '@/components/auth/useAuth';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -212,13 +212,12 @@ function StatusBadge({ status }: { status: IssueStatus }) {
 interface CreateFormProps {
   onCreated: () => void;
   onCancel: () => void;
+  user: AuthUser;
 }
 
-function CreateIssueForm({ onCreated, onCancel }: CreateFormProps) {
+function CreateIssueForm({ onCreated, onCancel, user }: CreateFormProps) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [author, setAuthor] = useState('');
-  const [authorTag, setAuthorTag] = useState('');
   const [priority, setPriority] = useState<IssuePriority>('medium');
   const [category, setCategory] = useState<IssueCategory>('bug');
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -229,7 +228,6 @@ function CreateIssueForm({ onCreated, onCancel }: CreateFormProps) {
     const newErrors: Record<string, string> = {};
     if (!title.trim()) newErrors.title = '請填寫標題';
     if (!description.trim()) newErrors.description = '請填寫描述';
-    if (!author.trim()) newErrors.author = '請填寫名稱';
     setErrors(newErrors);
     if (Object.keys(newErrors).length > 0) return;
 
@@ -238,7 +236,7 @@ function CreateIssueForm({ onCreated, onCancel }: CreateFormProps) {
       const res = await fetch('/api/issues', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title, description, author, author_tag: authorTag, priority, category }),
+        body: JSON.stringify({ title, description, priority, category }),
       });
       if (!res.ok) throw new Error('建立失敗');
       onCreated();
@@ -263,37 +261,10 @@ function CreateIssueForm({ onCreated, onCancel }: CreateFormProps) {
     >
       <h3 style={{ color: '#F0F0FF', fontWeight: 700, fontSize: '1rem', marginBottom: '1.25rem' }}>
         建立新 Issue
+        <span className="ml-2 text-xs font-normal" style={{ color: '#9090B0' }}>
+          以 {user.display_name || user.name} 發表
+        </span>
       </h3>
-
-      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem', marginBottom: '1rem' }}>
-        {/* Author */}
-        <div>
-          <label style={labelStyle}>姓名 <span style={{ color: '#E94560' }}>*</span></label>
-          <input
-            type="text"
-            placeholder="你的名稱"
-            value={author}
-            onChange={e => setAuthor(e.target.value)}
-            onFocus={handleFocusIn}
-            onBlur={handleFocusOut}
-            style={{ ...inputStyle, borderColor: errors.author ? '#E94560' : '#2A2A4A' }}
-          />
-          {errors.author && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{errors.author}</p>}
-        </div>
-        {/* Author tag */}
-        <div>
-          <label style={labelStyle}>Discord Tag（選填）</label>
-          <input
-            type="text"
-            placeholder="@username"
-            value={authorTag}
-            onChange={e => setAuthorTag(e.target.value)}
-            onFocus={handleFocusIn}
-            onBlur={handleFocusOut}
-            style={inputStyle}
-          />
-        </div>
-      </div>
 
       {/* Title */}
       <div style={{ marginBottom: '1rem' }}>
@@ -988,6 +959,7 @@ export default function IssueBoard() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedIssueId, setSelectedIssueId] = useState<number | null>(null);
   const [sourceTab, setSourceTab] = useState<SourceTab>('local');
+  const { user, loading: authLoading, login } = useAuth();
 
   async function fetchIssues() {
     setLoading(true);
@@ -1086,32 +1058,57 @@ export default function IssueBoard() {
               <span style={{ margin: '0 0.5rem', color: '#2A2A4A' }}>·</span>
               <span>{closedCount} 個 closed</span>
             </div>
-            <button
-              onClick={() => setShowCreateForm(v => !v)}
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: '0.4rem',
-                padding: '0.6rem 1.25rem',
-                background: showCreateForm ? 'rgba(108,99,255,0.15)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
-                border: showCreateForm ? '1px solid rgba(108,99,255,0.4)' : 'none',
-                borderRadius: '0.5rem',
-                color: '#F0F0FF',
-                fontSize: '0.875rem',
-                fontWeight: 600,
-                cursor: 'pointer',
-                transition: 'opacity 0.2s, transform 0.2s',
-              }}
-              onMouseEnter={e => e.currentTarget.style.opacity = '0.9'}
-              onMouseLeave={e => e.currentTarget.style.opacity = '1'}
-            >
-              {showCreateForm ? '✕ 關閉' : '+ 新增 Issue'}
-            </button>
+            {!authLoading && !user ? (
+              <button
+                onClick={login}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.4rem',
+                  padding: '0.6rem 1.25rem',
+                  background: 'linear-gradient(135deg, #6C63FF, #E94560)',
+                  border: 'none',
+                  borderRadius: '0.5rem',
+                  color: '#F0F0FF',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'opacity 0.2s, transform 0.2s',
+                }}
+                onMouseEnter={e => e.currentTarget.style.opacity = '0.9'}
+                onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+              >
+                🔐 登入
+              </button>
+            ) : !authLoading && user ? (
+              <button
+                onClick={() => setShowCreateForm(v => !v)}
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '0.4rem',
+                  padding: '0.6rem 1.25rem',
+                  background: showCreateForm ? 'rgba(108,99,255,0.15)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
+                  border: showCreateForm ? '1px solid rgba(108,99,255,0.4)' : 'none',
+                  borderRadius: '0.5rem',
+                  color: '#F0F0FF',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'opacity 0.2s, transform 0.2s',
+                }}
+                onMouseEnter={e => e.currentTarget.style.opacity = '0.9'}
+                onMouseLeave={e => e.currentTarget.style.opacity = '1'}
+              >
+                {showCreateForm ? '✕ 關閉' : '+ 新增 Issue'}
+              </button>
+            ) : null}
           </div>
 
           {/* Create form (collapsible) */}
-          {showCreateForm && (
+          {showCreateForm && user && (
             <CreateIssueForm
+              user={user}
               onCreated={() => {
                 setShowCreateForm(false);
                 fetchIssues();

--- a/src/components/issues/IssueBoard.tsx
+++ b/src/components/issues/IssueBoard.tsx
@@ -598,7 +598,7 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
             className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-80"
             style={{ background: '#6C63FF', color: '#fff' }}
           >
-            🔐 登入 Discord
+            🔐 登入
           </button>
         </div>
       ) : !authLoading && user ? (
@@ -606,7 +606,7 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
           <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
             新增留言
             <span className="ml-2 text-xs font-normal" style={{ color: '#9090B0' }}>
-              以 {user.name} 發表
+              以 {user.display_name || user.name} 發表
             </span>
           </h3>
           <form onSubmit={handleAddComment}>

--- a/src/components/issues/IssueBoard.tsx
+++ b/src/components/issues/IssueBoard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { timeAgo } from '@/lib/time';
+import { useAuth } from '@/components/auth/useAuth';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -416,11 +417,10 @@ interface DetailViewProps {
 function DetailView({ issueId, onBack }: DetailViewProps) {
   const [issue, setIssue] = useState<IssueDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [commentAuthor, setCommentAuthor] = useState('');
-  const [commentTag, setCommentTag] = useState('');
   const [commentContent, setCommentContent] = useState('');
   const [commentErrors, setCommentErrors] = useState<Record<string, string>>({});
   const [submittingComment, setSubmittingComment] = useState(false);
+  const { user, loading: authLoading, login } = useAuth();
 
   async function fetchIssue() {
     setLoading(true);
@@ -441,7 +441,6 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
   async function handleAddComment(e: React.FormEvent) {
     e.preventDefault();
     const errs: Record<string, string> = {};
-    if (!commentAuthor.trim()) errs.author = '請填寫名稱';
     if (!commentContent.trim()) errs.content = '請填寫留言內容';
     setCommentErrors(errs);
     if (Object.keys(errs).length > 0) return;
@@ -451,11 +450,9 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
       const res = await fetch(`/api/issues/${issueId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ author: commentAuthor, author_tag: commentTag, content: commentContent }),
+        body: JSON.stringify({ content: commentContent }),
       });
       if (!res.ok) throw new Error('留言失敗');
-      setCommentAuthor('');
-      setCommentTag('');
       setCommentContent('');
       setCommentErrors({});
       await fetchIssue();
@@ -613,72 +610,70 @@ function DetailView({ issueId, onBack }: DetailViewProps) {
       </div>
 
       {/* Add comment form */}
-      <div style={cardStyle}>
-        <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
-          新增留言
-        </h3>
-        <form onSubmit={handleAddComment}>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem', marginBottom: '0.75rem' }}>
-            <div>
-              <label style={labelStyle}>名稱 <span style={{ color: '#E94560' }}>*</span></label>
-              <input
-                type="text"
-                placeholder="你的名稱"
-                value={commentAuthor}
-                onChange={e => setCommentAuthor(e.target.value)}
+      {!authLoading && !user ? (
+        <div
+          className="rounded-xl p-5 flex flex-col items-center gap-3 text-center"
+          style={cardStyle}
+        >
+          <p className="text-2xl">💬</p>
+          <p className="text-sm font-medium" style={{ color: '#F0F0FF' }}>
+            登入後即可留言
+          </p>
+          <p className="text-xs" style={{ color: '#9090B0' }}>
+            已有帳號的隊員才能發表留言
+          </p>
+          <button
+            onClick={login}
+            className="px-5 py-2 rounded-lg text-sm font-medium transition-opacity hover:opacity-80"
+            style={{ background: '#6C63FF', color: '#fff' }}
+          >
+            🔐 登入 Discord
+          </button>
+        </div>
+      ) : !authLoading && user ? (
+        <div style={cardStyle}>
+          <h3 style={{ color: '#9090B0', fontWeight: 600, fontSize: '0.8rem', letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: '1rem' }}>
+            新增留言
+            <span className="ml-2 text-xs font-normal" style={{ color: '#9090B0' }}>
+              以 {user.name} 發表
+            </span>
+          </h3>
+          <form onSubmit={handleAddComment}>
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={labelStyle}>留言內容 <span style={{ color: '#E94560' }}>*</span></label>
+              <textarea
+                placeholder="輸入留言…"
+                rows={3}
+                value={commentContent}
+                onChange={e => setCommentContent(e.target.value)}
                 onFocus={handleFocusIn}
                 onBlur={handleFocusOut}
-                style={{ ...inputStyle, borderColor: commentErrors.author ? '#E94560' : '#2A2A4A' }}
+                style={{ ...inputStyle, resize: 'vertical', borderColor: commentErrors.content ? '#E94560' : '#2A2A4A' }}
               />
-              {commentErrors.author && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.author}</p>}
+              {commentErrors.content && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.content}</p>}
             </div>
-            <div>
-              <label style={labelStyle}>Discord Tag（選填）</label>
-              <input
-                type="text"
-                placeholder="@username"
-                value={commentTag}
-                onChange={e => setCommentTag(e.target.value)}
-                onFocus={handleFocusIn}
-                onBlur={handleFocusOut}
-                style={inputStyle}
-              />
+            {commentErrors.submit && <p style={{ color: '#E94560', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{commentErrors.submit}</p>}
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="submit"
+                disabled={submittingComment}
+                style={{
+                  padding: '0.6rem 1.5rem',
+                  background: submittingComment ? 'rgba(108,99,255,0.4)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
+                  border: 'none',
+                  borderRadius: '0.5rem',
+                  color: '#F0F0FF',
+                  fontSize: '0.875rem',
+                  fontWeight: 600,
+                  cursor: submittingComment ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {submittingComment ? '送出中…' : '送出留言'}
+              </button>
             </div>
-          </div>
-          <div style={{ marginBottom: '1rem' }}>
-            <label style={labelStyle}>留言內容 <span style={{ color: '#E94560' }}>*</span></label>
-            <textarea
-              placeholder="輸入留言…"
-              rows={3}
-              value={commentContent}
-              onChange={e => setCommentContent(e.target.value)}
-              onFocus={handleFocusIn}
-              onBlur={handleFocusOut}
-              style={{ ...inputStyle, resize: 'vertical', borderColor: commentErrors.content ? '#E94560' : '#2A2A4A' }}
-            />
-            {commentErrors.content && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{commentErrors.content}</p>}
-          </div>
-          {commentErrors.submit && <p style={{ color: '#E94560', fontSize: '0.8rem', marginBottom: '0.75rem' }}>{commentErrors.submit}</p>}
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <button
-              type="submit"
-              disabled={submittingComment}
-              style={{
-                padding: '0.6rem 1.5rem',
-                background: submittingComment ? 'rgba(108,99,255,0.4)' : 'linear-gradient(135deg, #6C63FF, #E94560)',
-                border: 'none',
-                borderRadius: '0.5rem',
-                color: '#F0F0FF',
-                fontSize: '0.875rem',
-                fontWeight: 600,
-                cursor: submittingComment ? 'not-allowed' : 'pointer',
-              }}
-            >
-              {submittingComment ? '送出中…' : '送出留言'}
-            </button>
-          </div>
-        </form>
-      </div>
+          </form>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
-import { MEMBERS } from '@/lib/constants';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -643,6 +642,7 @@ export default function KnowledgeBoard() {
   const [contributorFilter, setContributorFilter] = useState<string>('');
   const [tagFilter, setTagFilter] = useState<string>('');
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
+  const [members, setMembers] = useState<{ id: string; name: string; avatar: string }[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingEntry, setEditingEntry] = useState<KnowledgeEntry | null>(null);
   const [deletingEntry, setDeletingEntry] = useState<KnowledgeEntry | null>(null);
@@ -682,6 +682,17 @@ export default function KnowledgeBoard() {
 
   useEffect(() => {
     fetchTags();
+  }, []);
+
+  useEffect(() => {
+    async function fetchMembers() {
+      try {
+        const res = await fetch('/api/members');
+        const data = await res.json();
+        if (data.ok) setMembers(data.members);
+      } catch { /* silent */ }
+    }
+    fetchMembers();
   }, []);
 
   async function toggleFavorite(entry: KnowledgeEntry) {
@@ -810,7 +821,7 @@ export default function KnowledgeBoard() {
           }}
         >
           <option value="">全部成員</option>
-          {MEMBERS.map((m) => (
+          {members.map((m) => (
             <option key={m.id} value={m.id} style={{ background: '#12122A' }}>
               {m.avatar} {m.name}
             </option>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,14 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-20',
+    changes: [
+      'fix(#70): Issue 建立表單權限控制 — 訪客顯示登入按鈕、後端 POST /api/issues 新增 requireAuth、自動帶入登入者名稱',
+      'fix(#88): AI 工具箱╳知識庫成員╳標籤篩選下拉 — 還原動態 API fetch，移除過時的 static MEMBERS constant',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-15 00:15',
     changes: [
       'fix(#69): 公告系統前台修正 — 移除 X 按鈕、顯示 3 則公告、支援換行、字體放大',

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -6,6 +6,14 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
+    version: 'v20260414.1454',
+    date: '2026-04-15 15:30',
+    changes: [
+      'fix(#70): Issue 頁面留言權限控制 — 未登入隱藏輸入框並顯示登入提示，登入後自動帶入用戶身份',
+      'fix(#70): POST /api/issues/:id/comments 新增 requireAuth 驗證，禁止匿名留言',
+    ],
+  },
+  {
     version: 'v20260414.1451',
     date: '2026-04-14 23:55',
     changes: [

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -21,13 +21,6 @@ export const CHANGELOG: ChangelogEntry[] = [
     ],
   },
   {
-    version: '',
-    date: '2026-04-15 00:20',
-    changes: [
-      'fix(#70): Issue 頁面留言權限控制 — 未登入隱藏輸入框、後端 requireAuth 驗證',
-    ],
-  },
-  {
     version: 'v20260414.1451',
     date: '2026-04-14 23:55',
     changes: [


### PR DESCRIPTION
## Summary

Issue 頁面的**建立新 Issue 表單**先前沒有 auth 控制，訪客可以直接填寫姓名並建立 issue。本 PR 將其改為與討論區（PR #48）一致的權限模式：僅登入者可建立。

## Changes

- **後端** `functions/api/issues/index.ts`：
  - POST 新增 `requireAuth`，未登入者回傳 401
  - 移除請求 body 中的 `author` / `author_tag`，改為自動帶入 `user.name` / `user.discord_id`
  - 錯誤處理加上 `err instanceof Response` 直通（與其他 endpoint 一致）

- **前端** `src/components/issues/IssueBoard.tsx`：
  - `CreateIssueForm` 接受 `user: AuthUser` prop
  - 移除手動填寫「姓名」與「Discord Tag」欄位
  - 主元件引入 `useAuth`，訪客顯示「🔐 登入」按鈕（而非「登入 Discord」）
  - 登入後才顯示「+ 新增 Issue」按鈕與表單
  - 表單標題顯示發表者 `user.display_name || user.name`（配合 PR #123 慣例）

- **型別** `src/components/auth/useAuth.ts`：
  - `AuthUser` 補上 `display_name?: string`

## Test plan

- [ ] 未登入時 Issue 頁面顯示「🔐 登入」按鈕，點擊導向登入
- [ ] 登入後顯示「+ 新增 Issue」按鈕，點擊展開表單
- [ ] 表單不再顯示姓名/Discord Tag 輸入框
- [ ] 建立成功後自動帶入登入者名稱
- [ ] 未登入直接 POST /api/issues 回傳 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)