### PR TITLE
feat(#109): 知識庫多網址 + 標籤多選 + 概念補充 tag

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -260,6 +260,19 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
         args: [],
       },
       {
+        sql: `CREATE TABLE IF NOT EXISTS resource_urls (
+          id TEXT PRIMARY KEY,
+          resource_id TEXT NOT NULL,
+          resource_type TEXT NOT NULL CHECK(resource_type IN ('knowledge', 'ai-tool')),
+          url TEXT NOT NULL,
+          label TEXT DEFAULT '',
+          sort_order INTEGER DEFAULT 0,
+          created_at TEXT DEFAULT (datetime('now')),
+          UNIQUE(resource_id, resource_type, url)
+        )`,
+        args: [],
+      },
+      {
         sql: `CREATE TABLE IF NOT EXISTS message_reports (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           message_id INTEGER NOT NULL REFERENCES messages(id),
@@ -360,6 +373,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     try {
       await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_messages_parent_id ON messages(parent_id)`, args: [] });
     } catch { /* index already exists */ }
+
+    // resource_urls index for resource lookup
+    try {
+      await db.execute({ sql: `CREATE INDEX IF NOT EXISTS idx_resource_urls_resource ON resource_urls(resource_id, resource_type)`, args: [] });
+    } catch { /* index already exists */ }
+
+    // Seed default tags for knowledge base
+    const defaultTags = [
+      ['concept', '概念補充', 'knowledge', '#FFA500'],
+    ] as const;
+    for (const [id, name, category, color] of defaultTags) {
+      await db.execute({
+        sql: `INSERT OR IGNORE INTO tags (id, name, category, color) VALUES (?, ?, ?, ?)`,
+        args: [id, name, category, color],
+      });
+    }
 
     // --- Seed members (from constants) ---
     // Each entry: [id, name, groupRole, tag]

--- a/functions/api/knowledge/[id].ts
+++ b/functions/api/knowledge/[id].ts
@@ -52,11 +52,22 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       args: [id],
     });
 
+    // Fetch resource_urls
+    let urls: { id: string; url: string; label: string }[] = [];
+    try {
+      const urlResult = await db.execute({
+        sql: `SELECT id, url, label FROM resource_urls WHERE resource_type = 'knowledge' AND resource_id = ? ORDER BY sort_order`,
+        args: [id],
+      });
+      urls = urlResult.rows.map((r) => ({ id: r.id as string, url: r.url as string, label: (r.label as string) || '' }));
+    } catch { /* resource_urls table may not exist yet */ }
+
     const entry = {
       ...row,
       contributor_name: row.contributor_name,
       contributor_avatar: row.contributor_avatar,
       tags: tagResult.rows.map((t) => ({ id: t.id, name: t.name, color: t.color })),
+      urls,
     };
 
     return new Response(JSON.stringify({ ok: true, entry }), {
@@ -77,8 +88,9 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
   try {
     const user = await requireAuth(context.request, context.env);
     const id = context.params.id as string;
-    const body = (await context.request.json()) as Record<string, string>;
+    const body = (await context.request.json()) as Record<string, unknown>;
     const db = getDb(context.env);
+    const urls = Array.isArray(body.urls) ? body.urls as { url: string; label?: string }[] : [];
 
     // Check ownership or admin+
     const existing = await db.execute({
@@ -101,7 +113,7 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       });
     }
 
-    const { title, content, category, icon, url: entryUrl } = body;
+    const { title, content, category, icon, url: entryUrl } = body as Record<string, string>;
     const sets: string[] = [];
     const args: string[] = [];
 
@@ -139,6 +151,25 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       sql: `UPDATE knowledge_entries SET ${sets.join(', ')} WHERE id = ?`,
       args,
     });
+
+    // Update resource_urls: always delete old, then insert new
+    if (Array.isArray(body.urls)) {
+      await db.execute({ sql: `DELETE FROM resource_urls WHERE resource_id = ? AND resource_type = 'knowledge'`, args: [id] });
+      for (let i = 0; i < urls.length; i++) {
+        const u = urls[i];
+        const uUrl = (u.url || '').trim();
+        if (!uUrl) continue;
+        if (!uUrl.startsWith('http://') && !uUrl.startsWith('https://')) {
+          return new Response(JSON.stringify({ ok: false, error: '所有連結必須以 http:// 或 https:// 開頭' }), {
+            status: 400, headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        await db.execute({
+          sql: `INSERT INTO resource_urls (id, resource_id, resource_type, url, label, sort_order) VALUES (?, ?, 'knowledge', ?, ?, ?)`,
+          args: [crypto.randomUUID(), id, uUrl, (u.label || '').trim(), i],
+        });
+      }
+    }
 
     return new Response(JSON.stringify({ ok: true }), {
       headers: { 'Content-Type': 'application/json' },
@@ -182,11 +213,17 @@ export const onRequestDelete: PagesFunction<Env> = async (context) => {
       });
     }
 
-    // Delete resource_tags first, then the entry
+    // Delete resource_tags and resource_urls first, then the entry
     await db.execute({
       sql: `DELETE FROM resource_tags WHERE resource_id = ? AND resource_type = 'knowledge'`,
       args: [id],
     });
+    try {
+      await db.execute({
+        sql: `DELETE FROM resource_urls WHERE resource_id = ? AND resource_type = 'knowledge'`,
+        args: [id],
+      });
+    } catch { /* resource_urls table may not exist yet */ }
     await db.execute({
       sql: 'DELETE FROM knowledge_entries WHERE id = ?',
       args: [id],

--- a/functions/api/knowledge/index.ts
+++ b/functions/api/knowledge/index.ts
@@ -25,6 +25,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const url = new URL(context.request.url);
     const category = url.searchParams.get('category');
     const tag = url.searchParams.get('tag');
+    const tags = url.searchParams.get('tags'); // comma-separated for multi-select
     const contributor_id = url.searchParams.get('contributor_id');
 
     let sql = `
@@ -54,6 +55,17 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       conditions.push('t.name = ?');
       args.push(tag);
     }
+    // Multi-tag filter: entry must have ALL specified tags
+    if (tags) {
+      const tagList = tags.split(',').map((t) => t.trim()).filter(Boolean);
+      for (const tagName of tagList) {
+        const alias = `rt_${tagName.replace(/[^a-zA-Z0-9]/g, '')}`;
+        sql += ` JOIN resource_tags ${alias} ON ${alias}.resource_id = ke.id AND ${alias}.resource_type = 'knowledge'
+                 JOIN tags t_${alias} ON t_${alias}.id = ${alias}.tag_id `;
+        conditions.push(`t_${alias}.name = ?`);
+        args.push(tagName);
+      }
+    }
 
     if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ');
     sql += ' ORDER BY ke.created_at DESC LIMIT 200';
@@ -75,6 +87,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       created_at: row.created_at,
       updated_at: row.updated_at,
       tags: [] as { id: string; name: string; color: string }[],
+      urls: [] as { id: string; url: string; label: string }[],
     }));
 
     if (entries.length > 0) {
@@ -95,6 +108,20 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           entry.tags.push({ id: tr.tag_id as string, name: tr.name as string, color: tr.color as string });
         }
       }
+
+      // Fetch resource_urls for all entries
+      try {
+        const urlResult = await db.execute({
+          sql: `SELECT id, resource_id, url, label, sort_order FROM resource_urls WHERE resource_type = 'knowledge' AND resource_id IN (${placeholders}) ORDER BY sort_order`,
+          args: ids,
+        });
+        for (const ur of urlResult.rows) {
+          const entry = entries.find((e) => e.id === ur.resource_id);
+          if (entry) {
+            entry.urls.push({ id: ur.id as string, url: ur.url as string, label: (ur.label as string) || '' });
+          }
+        }
+      } catch { /* resource_urls table may not exist yet */ }
     }
 
     // Attach is_favorited for logged-in users
@@ -129,8 +156,9 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
     const user = await requireAuth(context.request, context.env);
 
-    const body = (await context.request.json()) as Record<string, string>;
-    const { title, content, category, icon, url } = body;
+    const body = (await context.request.json()) as Record<string, unknown>;
+    const { title, content, category, icon, url } = body as Record<string, string>;
+    const urls = Array.isArray(body.urls) ? body.urls as { url: string; label?: string }[] : [];
 
     if (!title?.trim() || !content?.trim()) {
       return new Response(JSON.stringify({ ok: false, error: '請填寫標題和內容' }), {
@@ -164,6 +192,22 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       args: [id, title.trim(), content.trim(), finalCategory, icon?.trim() || '📘', user.id, now, now, trimmedUrl],
     });
 
+    // Insert resource_urls
+    for (let i = 0; i < urls.length; i++) {
+      const u = urls[i];
+      const uUrl = (u.url || '').trim();
+      if (!uUrl) continue;
+      if (!uUrl.startsWith('http://') && !uUrl.startsWith('https://')) {
+        return new Response(JSON.stringify({ ok: false, error: '所有連結必須以 http:// 或 https:// 開頭' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      await db.execute({
+        sql: `INSERT INTO resource_urls (id, resource_id, resource_type, url, label, sort_order) VALUES (?, ?, 'knowledge', ?, ?, ?)`,
+        args: [crypto.randomUUID(), id, uUrl, (u.label || '').trim(), i],
+      });
+    }
+
     return new Response(JSON.stringify({ ok: true, id }), {
       headers: { 'Content-Type': 'application/json' },
     });
@@ -186,8 +230,9 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
     const id = url.pathname.split('/').filter(Boolean).pop();
     if (!id) return new Response(JSON.stringify({ ok: false, error: '缺少 ID' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
 
-    const body = (await context.request.json()) as Record<string, string>;
-    const { title, content, category, icon, url: entryUrl } = body;
+    const body = (await context.request.json()) as Record<string, unknown>;
+    const { title, content, category, icon, url: entryUrl } = body as Record<string, string>;
+    const urls = Array.isArray(body.urls) ? body.urls as { url: string; label?: string }[] : [];
 
     if (!title?.trim() || !content?.trim()) {
       return new Response(JSON.stringify({ ok: false, error: '請填寫標題和內容' }), { status: 400, headers: { 'Content-Type': 'application/json' } });
@@ -212,6 +257,25 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       sql: `UPDATE knowledge_entries SET title=?, content=?, category=?, icon=?, updated_at=?, url=? WHERE id=? AND contributor_id=?`,
       args: [title.trim(), content.trim(), finalCategory, icon?.trim() || '📘', now, trimmedUrl, id, user.id],
     });
+
+    // Update resource_urls: delete old + insert new
+    if (urls.length > 0) {
+      await db.execute({ sql: `DELETE FROM resource_urls WHERE resource_id = ? AND resource_type = 'knowledge'`, args: [id] });
+      for (let i = 0; i < urls.length; i++) {
+        const u = urls[i];
+        const uUrl = (u.url || '').trim();
+        if (!uUrl) continue;
+        if (!uUrl.startsWith('http://') && !uUrl.startsWith('https://')) {
+          return new Response(JSON.stringify({ ok: false, error: '所有連結必須以 http:// 或 https:// 開頭' }), {
+            status: 400, headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        await db.execute({
+          sql: `INSERT INTO resource_urls (id, resource_id, resource_type, url, label, sort_order) VALUES (?, ?, 'knowledge', ?, ?, ?)`,
+          args: [crypto.randomUUID(), id, uUrl, (u.label || '').trim(), i],
+        });
+      }
+    }
 
     return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
   } catch (err: unknown) {

--- a/functions/api/knowledge/index.ts
+++ b/functions/api/knowledge/index.ts
@@ -58,13 +58,13 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     // Multi-tag filter: entry must have ALL specified tags
     if (tags) {
       const tagList = tags.split(',').map((t) => t.trim()).filter(Boolean);
-      for (const tagName of tagList) {
-        const alias = `rt_${tagName.replace(/[^a-zA-Z0-9]/g, '')}`;
+      tagList.forEach((tagName, i) => {
+        const alias = `rt${i}`;
         sql += ` JOIN resource_tags ${alias} ON ${alias}.resource_id = ke.id AND ${alias}.resource_type = 'knowledge'
                  JOIN tags t_${alias} ON t_${alias}.id = ${alias}.tag_id `;
         conditions.push(`t_${alias}.name = ?`);
         args.push(tagName);
-      }
+      });
     }
 
     if (conditions.length) sql += ' WHERE ' + conditions.join(' AND ');
@@ -258,10 +258,9 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       args: [title.trim(), content.trim(), finalCategory, icon?.trim() || '📘', now, trimmedUrl, id, user.id],
     });
 
-    // Update resource_urls: delete old + insert new
-    if (urls.length > 0) {
-      await db.execute({ sql: `DELETE FROM resource_urls WHERE resource_id = ? AND resource_type = 'knowledge'`, args: [id] });
-      for (let i = 0; i < urls.length; i++) {
+    // Update resource_urls: delete old + insert new (even if empty, to clear all)
+    await db.execute({ sql: `DELETE FROM resource_urls WHERE resource_id = ? AND resource_type = 'knowledge'`, args: [id] });
+    for (let i = 0; i < urls.length; i++) {
         const u = urls[i];
         const uUrl = (u.url || '').trim();
         if (!uUrl) continue;
@@ -275,7 +274,6 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
           args: [crypto.randomUUID(), id, uUrl, (u.label || '').trim(), i],
         });
       }
-    }
 
     return new Response(JSON.stringify({ ok: true }), { headers: { 'Content-Type': 'application/json' } });
   } catch (err: unknown) {

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -25,6 +25,7 @@ interface KnowledgeEntry {
   created_at: string;
   updated_at: string;
   tags: Tag[];
+  urls: { id: string; url: string; label: string }[];
   is_favorited?: boolean;
 }
 
@@ -90,6 +91,9 @@ function EntryModal({ entry, onClose, onSaved }: ModalProps) {
   const [showIconPicker, setShowIconPicker] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
+  const [urls, setUrls] = useState<{ url: string; label: string }[]>(
+    entry?.urls?.map((u) => ({ url: u.url, label: u.label })) || [{ url: '', label: '' }],
+  );
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -105,7 +109,7 @@ function EntryModal({ entry, onClose, onSaved }: ModalProps) {
         const res = await fetch(`/api/knowledge/${entry!.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: title.trim(), content: content.trim(), category, icon }),
+          body: JSON.stringify({ title: title.trim(), content: content.trim(), category, icon, urls: urls.filter((u) => u.url.trim()) }),
         });
         if (!res.ok) {
           const data = await res.json();
@@ -115,7 +119,7 @@ function EntryModal({ entry, onClose, onSaved }: ModalProps) {
         const res = await fetch('/api/knowledge', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ title: title.trim(), content: content.trim(), category, icon }),
+          body: JSON.stringify({ title: title.trim(), content: content.trim(), category, icon, urls: urls.filter((u) => u.url.trim()) }),
         });
         if (!res.ok) {
           const data = await res.json();
@@ -242,6 +246,57 @@ function EntryModal({ entry, onClose, onSaved }: ModalProps) {
               style={{ ...inputStyle, resize: 'vertical', borderColor: errors.content ? '#E94560' : '#2A2A4A' }}
             />
             {errors.content && <p style={{ color: '#E94560', fontSize: '0.75rem', marginTop: '0.2rem' }}>{errors.content}</p>}
+          </div>
+
+          {/* URLs */}
+          <div style={{ marginBottom: '1rem' }}>
+            <label style={labelStyle}>相關連結</label>
+            {urls.map((u, i) => (
+              <div key={i} style={{ display: 'flex', gap: 6, marginBottom: 6 }}>
+                <input
+                  type="url"
+                  placeholder="https://..."
+                  value={u.url}
+                  onChange={(e) => {
+                    const next = [...urls];
+                    next[i] = { ...next[i], url: e.target.value };
+                    setUrls(next);
+                  }}
+                  onFocus={handleFocusIn}
+                  onBlur={handleFocusOut}
+                  style={{ ...inputStyle, flex: 2, marginBottom: 0 }}
+                />
+                <input
+                  type="text"
+                  placeholder="連結名稱（選填）"
+                  value={u.label}
+                  onChange={(e) => {
+                    const next = [...urls];
+                    next[i] = { ...next[i], label: e.target.value };
+                    setUrls(next);
+                  }}
+                  onFocus={handleFocusIn}
+                  onBlur={handleFocusOut}
+                  style={{ ...inputStyle, flex: 1, marginBottom: 0 }}
+                />
+                {urls.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => setUrls(urls.filter((_, idx) => idx !== i))}
+                    style={{ background: 'none', border: 'none', color: '#E94560', cursor: 'pointer', fontSize: '1rem', padding: '0 4px' }}
+                  >
+                    ✕
+                  </button>
+                )}
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => setUrls([...urls, { url: '', label: '' }])}
+              style={{ background: 'none', border: '1px dashed #2A2A4A', borderRadius: '0.375rem', color: '#9090B0', fontSize: '0.8rem', cursor: 'pointer', padding: '0.35rem 0.75rem', width: '100%' }}
+            >
+              + 新增連結
+            </button>
           </div>
 
           {errors.submit && (
@@ -538,6 +593,30 @@ function EntryCard({
         </div>
       )}
 
+      {/* Resource URLs */}
+      {entry.urls.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4, marginTop: 2 }}>
+          {entry.urls.map((u) => (
+            <a
+              key={u.id}
+              href={u.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                fontSize: '0.75rem',
+                color: '#00D9FF',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 4,
+              }}
+            >
+              🔗 {u.label || u.url}
+            </a>
+          ))}
+        </div>
+      )}
+
       {/* Footer */}
       <div
         style={{
@@ -640,7 +719,7 @@ export default function KnowledgeBoard() {
   const [loadError, setLoadError] = useState(false);
   const [categoryFilter, setCategoryFilter] = useState<KnowledgeCategory | 'all'>('all');
   const [contributorFilter, setContributorFilter] = useState<string>('');
-  const [tagFilter, setTagFilter] = useState<string>('');
+  const [tagFilter, setTagFilter] = useState<string[]>([]);
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
   const [members, setMembers] = useState<{ id: string; name: string; avatar: string }[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -654,7 +733,7 @@ export default function KnowledgeBoard() {
       const params = new URLSearchParams();
       if (categoryFilter !== 'all') params.set('category', categoryFilter);
       if (contributorFilter) params.set('contributor_id', contributorFilter);
-      if (tagFilter) params.set('tag', tagFilter);
+      if (tagFilter.length > 0) params.set('tags', tagFilter.join(','));
       const res = await fetch(`/api/knowledge?${params}`);
       if (!res.ok) throw new Error('載入失敗');
       const data = await res.json();
@@ -827,27 +906,44 @@ export default function KnowledgeBoard() {
             </option>
           ))}
         </select>
-        <select
-          value={tagFilter}
-          onChange={(e) => setTagFilter(e.target.value)}
-          style={{
-            ...inputStyle,
-            width: 'auto',
-            minWidth: 140,
-            maxWidth: 200,
-            fontSize: '0.8rem',
-            padding: '0.4rem 0.75rem',
-            cursor: 'pointer',
-            marginLeft: '0.5rem',
-          }}
-        >
-          <option value="">全部標籤</option>
-          {availableTags.map((t) => (
-            <option key={t.id} value={t.name} style={{ background: '#12122A' }}>
-              {t.name}
-            </option>
-          ))}
-        </select>
+        {availableTags.length > 0 && (
+          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginLeft: '0.5rem' }}>
+            {availableTags.map((t) => {
+              const active = tagFilter.includes(t.name);
+              return (
+                <button
+                  key={t.id}
+                  onClick={() => setTagFilter(active ? tagFilter.filter((n) => n !== t.name) : [...tagFilter, t.name])}
+                  style={{
+                    padding: '0.35rem 0.75rem',
+                    borderRadius: '999px',
+                    border: active ? `1px solid ${t.color}` : '1px solid #2A2A4A',
+                    background: active ? `${t.color}20` : 'transparent',
+                    color: active ? t.color : '#9090B0',
+                    cursor: 'pointer',
+                    fontSize: '0.8rem',
+                    fontWeight: 500,
+                    transition: 'all 0.15s ease',
+                  }}
+                >
+                  {t.name}
+                </button>
+              );
+            })}
+            {tagFilter.length > 0 && (
+              <button
+                onClick={() => setTagFilter([])}
+                style={{
+                  padding: '0.35rem 0.5rem', borderRadius: '999px', border: 'none',
+                  background: 'rgba(233,69,96,0.1)', color: '#E94560',
+                  cursor: 'pointer', fontSize: '0.75rem',
+                }}
+              >
+                清除
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Content */}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,15 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-21',
     changes: [
+      'feat(#109): 知識庫多網址支援 — resource_urls 表、表單動態增減連結、卡片顯示連結列表',
+      'feat(#109): 知識庫標籤多選篩選 — pill 按鈕多選 + 後端 tags 參數',
+      'feat(#109): 新增「概念補充」tag seed',
+    ],
+  },
+  {
+    version: '',
+    date: '2026-04-21',
+    changes: [
       'fix(#70): Issue 建立/留言/Bug 回報表單權限控制 — 訪客顯示登入按鈕、後端 requireAuth、自動帶入登入者名稱',
       'fix(#88): AI 工具箱╳知識庫成員篩選下拉 — 還原動態 API fetch，移除過時的 static MEMBERS constant',
     ],


### PR DESCRIPTION
## Summary
- 新增 `resource_urls` 表支援多網址，表單可動態增減連結
- 標籤篩選改為 multi-select pill 按鈕
- Seed「概念補充」tag
- 卡片顯示連結列表

## Test plan
- [ ] 新建知識庫文章可加入多個連結
- [ ] 編輯文章可增刪連結
- [ ] 卡片正確顯示連結
- [ ] 標籤可多選篩選
- [ ] 「概念補充」tag 出現在篩選選項
- [ ] 既有文章不受影響

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)