### PR TITLE
feat(#89): 知識庫 Markdown 渲染支援

### DIFF
--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -489,7 +489,7 @@ function EntryCard({
 
       {/* Content */}
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
-        <p
+        <div
           ref={contentRef}
           id={`knowledge-content-${entry.id}`}
           style={{
@@ -524,7 +524,7 @@ function EntryCard({
           >
             {sanitizeMarkdown(entry.content)}
           </ReactMarkdown>
-        </p>
+        </div>
         {(!expanded && isOverflowing) && (
           <div
             style={{

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -543,6 +543,8 @@ function EntryCard({
       </h3>
 
       {/* Content */}
+      {entry.content.trim() ? (
+      <>
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
         <div
           ref={contentRef}
@@ -604,6 +606,8 @@ function EntryCard({
           {expanded ? '收納 ↑' : '展開更多 ↓'}
         </button>
       )}
+      </>
+      ) : null}
 
       {/* Tags */}
       {entry.tags.length > 0 && (

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
+import rehypeRaw from 'rehype-raw';
 import { useAuth } from '@/components/auth/useAuth';
 import { timeAgo } from '@/lib/time';
+import { sanitizeMarkdown, sanitizeUrl, sanitizeImgSrc } from '@/lib/markdown';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -493,7 +498,32 @@ function EntryCard({
             ...(expanded ? {} : { maxHeight: '4.8em', overflow: 'hidden' }),
           }}
         >
-          {entry.content}
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm, remarkBreaks]}
+            rehypePlugins={[rehypeRaw]}
+            components={{
+              code({ className, children, ...props }) {
+                const langMatch = /language-(\w+)/.test(className || '');
+                const isInline = !langMatch && !String(children).includes('\n');
+                return isInline
+                  ? <code className="px-1.5 py-0.5 rounded text-xs font-mono" style={{ background: 'rgba(255,255,255,0.08)', color: 'var(--color-neon-green)' }} {...props}>{children}</code>
+                  : <code className="block p-3 rounded-lg text-xs font-mono overflow-x-auto" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--color-neon-blue)' }} {...props}>{children}</code>;
+              },
+              a({ href, children, ...props }) {
+                if (!href) return <span {...props}>{children}</span>;
+                const safe = sanitizeUrl(href);
+                if (!safe) return <span {...props}>{children}</span>;
+                return <a href={safe} target="_blank" rel="noopener noreferrer" className="underline hover:opacity-80" style={{ color: 'var(--color-neon-blue)' }}>{children}</a>;
+              },
+              img({ src, alt }) {
+                const safeSrc = sanitizeImgSrc(src);
+                if (!safeSrc) return null;
+                return <img src={safeSrc} alt={alt || ''} loading="lazy" style={{ maxWidth: '100%', height: 'auto', borderRadius: '0.5rem' }} />;
+              },
+            }}
+          >
+            {sanitizeMarkdown(entry.content)}
+          </ReactMarkdown>
         </p>
         {(!expanded && isOverflowing) && (
           <div

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,13 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-21',
     changes: [
+      'feat(#89): 知識庫 Markdown 渲染 — 複用討論區 ReactMarkdown + sanitize 方案',
+    ],
+  },
+  {
+    version: '',
+    date: '2026-04-21',
+    changes: [
       'fix(#70): Issue 建立/留言/Bug 回報表單權限控制 — 訪客顯示登入按鈕、後端 requireAuth、自動帶入登入者名稱',
       'fix(#88): AI 工具箱╳知識庫成員篩選下拉 — 還原動態 API fetch，移除過時的 static MEMBERS constant',
     ],


### PR DESCRIPTION
## Summary
- 知識庫卡片內容從純文字改為 ReactMarkdown 渲染
- 複用討論區 `sanitizeMarkdown` + XSS 防護方案
- 支援粗體、斜體、程式碼區塊、超連結、圖片、列表

## Note
AI 工具箱已有 Markdown 渲染，本次只改知識庫。

## Test plan
- [ ] 知識庫文章顯示 Markdown 格式（粗體、程式碼、連結）
- [ ] 展開/收合仍正常運作
- [ ] XSS 輸入被過濾

🤖 Generated with [Claude Code](https://claude.com/claude-code)