### PR TITLE
fix(#60): 許願樹認領機制 4 項修復

### DIFF
--- a/functions/api/checkin/leaderboard.ts
+++ b/functions/api/checkin/leaderboard.ts
@@ -19,14 +19,15 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const result = await db.execute({
       sql: `
         SELECT
-          c.user_id,
+          u.id AS user_id,
           u.name AS user_name,
           u.avatar_url,
-          SUM(c.points) AS total_points,
-          COUNT(c.id) AS total_checkins
-        FROM checkins c
-        JOIN users u ON u.id = c.user_id AND u.archived_at IS NULL AND u.status = 'active'
-        GROUP BY c.user_id
+          COALESCE(pl.total, 0) AS total_points,
+          COALESCE(cc.cnt, 0) AS total_checkins
+        FROM users u
+        INNER JOIN (SELECT user_id, SUM(points) AS total FROM points_ledger GROUP BY user_id) pl ON pl.user_id = u.id
+        LEFT JOIN (SELECT user_id, COUNT(*) AS cnt FROM checkins GROUP BY user_id) cc ON cc.user_id = u.id
+        WHERE u.archived_at IS NULL AND u.status = 'active'
         ORDER BY total_points DESC
       `,
       args: [],

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -222,6 +222,11 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
 
     // ── Unclaim action ───────────────────────────────────────────────────
     if (body.action === 'unclaim') {
+      if (wish.status === 'completed') {
+        return new Response(JSON.stringify({ ok: false, error: '已完成的許願無法取消認領' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
       const existingClaim = await db.execute({
         sql: `SELECT id FROM wish_claimers WHERE wish_id = ? AND user_id = ? AND status = 'claimed'`,
         args: [id, user.id],

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -220,6 +220,42 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
       });
     }
 
+    // ── Unclaim action ───────────────────────────────────────────────────
+    if (body.action === 'unclaim') {
+      const existingClaim = await db.execute({
+        sql: `SELECT id FROM wish_claimers WHERE wish_id = ? AND user_id = ? AND status = 'claimed'`,
+        args: [id, user.id],
+      });
+      if (existingClaim.rows.length === 0) {
+        return new Response(JSON.stringify({ ok: false, error: '你沒有認領此許願' }), {
+          status: 400, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await db.execute({
+        sql: `DELETE FROM wish_claimers WHERE wish_id = ? AND user_id = ?`,
+        args: [id, user.id],
+      });
+
+      // If no claimers remain, revert wish status to pending
+      const remaining = await db.execute({
+        sql: `SELECT COUNT(*) AS cnt FROM wish_claimers WHERE wish_id = ?`,
+        args: [id],
+      });
+      if (Number(remaining.rows[0]?.cnt ?? 0) === 0 && wish.status === 'claimed') {
+        await db.execute({
+          sql: `UPDATE wishes SET status = 'pending', updated_at = datetime('now') WHERE id = ?`,
+          args: [id],
+        });
+        await ensureWishHistoryMigration(db);
+        await recordStatusChange(db, id, 'claimed', 'pending', user.id);
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     // ── Complete action ──────────────────────────────────────────────────
     if (body.action === 'complete') {
       const wishRow = wish;

--- a/functions/api/wishes/[id].ts
+++ b/functions/api/wishes/[id].ts
@@ -242,13 +242,14 @@ export const onRequestPatch: PagesFunction<Env> = async (context) => {
         sql: `SELECT COUNT(*) AS cnt FROM wish_claimers WHERE wish_id = ?`,
         args: [id],
       });
-      if (Number(remaining.rows[0]?.cnt ?? 0) === 0 && wish.status === 'claimed') {
+      if (Number(remaining.rows[0]?.cnt ?? 0) === 0 && (wish.status === 'claimed' || wish.status === 'in-progress')) {
+        const oldStatus = wish.status as string;
         await db.execute({
           sql: `UPDATE wishes SET status = 'pending', updated_at = datetime('now') WHERE id = ?`,
           args: [id],
         });
         await ensureWishHistoryMigration(db);
-        await recordStatusChange(db, id, 'claimed', 'pending', user.id);
+        await recordStatusChange(db, id, oldStatus, 'pending', user.id);
       }
 
       return new Response(JSON.stringify({ ok: true }), {

--- a/src/components/dashboard/DashboardPanel.tsx
+++ b/src/components/dashboard/DashboardPanel.tsx
@@ -514,11 +514,11 @@ export default function DashboardPanel() {
               >
                 <div className="flex items-center gap-3">
                   <span className="text-lg">
-                    {r.action === 'checkin' ? '🔥' : r.action === 'knowledge' ? '📚' : r.action === 'ai-tool' ? '🛠️' : r.action === 'wish' ? '✨' : r.action === 'claim' ? '🎯' : r.action === 'complete' ? '🏆' : '⭐'}
+                    {r.action === 'checkin' ? '🔥' : r.action === 'knowledge' ? '📚' : r.action === 'ai-tool' ? '🛠️' : r.action === 'wish' ? '✨' : r.action === 'claim' ? '🎯' : r.action === 'complete' ? '🏆' : r.action === 'wish_completed' ? '🏆' : r.action === 'wish_completed_ai_tool' ? '🛠️' : '⭐'}
                   </span>
                   <div>
                     <div className="text-sm font-medium text-[var(--color-text-primary)]">
-                      {r.action === 'checkin' ? '每日打卡' : r.action === 'knowledge' ? '知識投稿' : r.action === 'ai-tool' ? 'AI 工具投稿' : r.action === 'wish' ? '許願' : r.action === 'claim' ? '認領任務' : r.action === 'complete' ? '完成任務' : r.action}
+                      {r.action === 'checkin' ? '每日打卡' : r.action === 'knowledge' ? '知識投稿' : r.action === 'ai-tool' ? 'AI 工具投稿' : r.action === 'wish' ? '許願' : r.action === 'claim' ? '認領任務' : r.action === 'complete' ? '完成任務' : r.action === 'wish_completed' ? '完成許願' : r.action === 'wish_completed_ai_tool' ? '完成許願（AI工具）' : r.action}
                     </div>
                     <div className="text-xs text-[var(--color-text-muted)]">
                       {new Date(r.createdAt).toLocaleString('zh-TW')}

--- a/src/components/wishlist/WishBoard.tsx
+++ b/src/components/wishlist/WishBoard.tsx
@@ -811,7 +811,7 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
       {/* Action buttons */}
       {user && !isCompleted && (
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {wish.status === 'pending' && !isWisher && !isClaimer && (
+          {(wish.status === 'pending' || wish.status === 'claimed') && !isWisher && !isClaimer && (
             <button
               onClick={() => handleAction('claim')}
               disabled={actionLoading}
@@ -842,6 +842,25 @@ function WishCard({ wish, user, onRefresh, onDelete }: { wish: Wish; user: Retur
               }}
             >
               {actionLoading ? '處理中...' : '🔨 開始實作'}
+            </button>
+          )}
+          {(wish.status === 'claimed' || wish.status === 'in-progress') && isClaimer && (
+            <button
+              onClick={() => handleAction('unclaim')}
+              disabled={actionLoading}
+              style={{
+                fontSize: '0.8rem',
+                padding: '0.4rem 0.875rem',
+                borderRadius: '0.75rem',
+                border: '1px solid rgba(255,100,100,0.4)',
+                background: 'rgba(255,100,100,0.1)',
+                color: '#ff8888',
+                cursor: 'pointer',
+                fontWeight: 600,
+                opacity: actionLoading ? 0.6 : 1,
+              }}
+            >
+              {actionLoading ? '處理中...' : '↩️ 取消認領'}
             </button>
           )}
           {(wish.status === 'in-progress' || wish.status === 'claimed') && activeClaimers.length > 0 && (isWisher || isAdminUser) && (

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,16 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-21',
     changes: [
+      'fix(#60): 多人認領 — 認領按鈕條件修正，claimed 狀態也可認領',
+      'fix(#60): 取消認領 — 後端 unclaim action + 前端取消按鈕',
+      'fix(#60): 積分榜總分 — total_points 改從 points_ledger 計算，含所有積分來源',
+      'fix(#60): 積分紀錄中文 — wish_completed 顯示「完成許願」',
+    ],
+  },
+  {
+    version: '',
+    date: '2026-04-21',
+    changes: [
       'feat(#90): 知識庫留言回饋 — 整合 ResourceComments 元件，支援留言/刪除/積分 +2',
     ],
   },


### PR DESCRIPTION
## Summary
- **多人認領**：認領按鈕條件從 `pending` 改為 `pending | claimed`，第二人以後也可認領
- **取消認領**：後端新增 `unclaim` action + 前端取消按鈕，最後認領者取消時 wish 恢復 `pending`
- **積分榜總分**：`total_points` 改從 `points_ledger` SUM，包含 wish_completed / knowledge / ai-tool 等所有積分來源
- **積分紀錄中文**：`wish_completed` →「完成許願」、`wish_completed_ai_tool` →「完成許願（AI工具）」

Fixes #60

## Test plan
- [ ] 一人認領後，其他人仍可認領同一張許願卡
- [ ] 認領者可點「取消認領」，取消後 wish 恢復 pending（若無其他認領者）
- [ ] 積分榜 total_points 包含 wish_completed 積分
- [ ] 個人儀表板積分紀錄顯示中文而非英文 key
- [ ] `bun run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)