### PR TITLE
fix(#51): 討論區軟刪除 placeholder 刷新後消失

### DIFF
--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -51,7 +51,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
               WHERE parent_id IS NOT NULL AND deleted_at IS NULL
               GROUP BY parent_id
             ) rc ON rc.parent_id = m.id
-            WHERE m.deleted_at IS NULL AND m.parent_id IS NULL
+            WHERE m.parent_id IS NULL
             ORDER BY m.pinned DESC, m.created_at DESC LIMIT 100`,
       args: [],
     });
@@ -75,8 +75,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
                   WHERE status = 'pending'
                   GROUP BY message_id
                 ) mr ON mr.message_id = m.id
-                WHERE m.deleted_at IS NULL
-                  AND m.parent_id IN (${topLevelIds.map(() => '?').join(', ')})
+                WHERE m.parent_id IN (${topLevelIds.map(() => '?').join(', ')})
                 ORDER BY m.created_at ASC`,
           args: topLevelIds,
         })

--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -96,7 +96,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     // Strip content/author from soft-deleted messages (privacy)
     const stripDeleted = (row: Record<string, unknown>) => {
       if (row.deleted_at) {
-        return { ...row, content: null, author: null, tag: null };
+        return { ...row, content: null, author: null, author_id: null, tag: null };
       }
       return row;
     };

--- a/functions/api/messages/index.ts
+++ b/functions/api/messages/index.ts
@@ -93,18 +93,26 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       }
     }
 
+    // Strip content/author from soft-deleted messages (privacy)
+    const stripDeleted = (row: Record<string, unknown>) => {
+      if (row.deleted_at) {
+        return { ...row, content: null, author: null, tag: null };
+      }
+      return row;
+    };
+
     // Group replies by parent_id
     const repliesByParent = new Map<number, any[]>();
     for (const row of repliesResult.rows) {
       const pid = row.parent_id as number;
       if (!repliesByParent.has(pid)) repliesByParent.set(pid, []);
-      repliesByParent.get(pid)!.push({
+      repliesByParent.get(pid)!.push(stripDeleted({
         ...row,
         reported_by_me: reportedByMe.has(row.id as number),
-      });
+      }));
     }
 
-    const messages = result.rows.map((row) => ({
+    const messages = result.rows.map((row) => stripDeleted({
       ...row,
       reported_by_me: reportedByMe.has(row.id as number),
       reply_count: Number(row.reply_count ?? 0),

--- a/src/components/discuss/MessageCard.tsx
+++ b/src/components/discuss/MessageCard.tsx
@@ -170,11 +170,11 @@ export default function MessageCard({
               className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
               style={{ background: `${color}20`, color }}
             >
-              {msg.author[0]}
+              {msg.author?.[0] || '?'}
             </span>
             <div className="min-w-0">
               <span className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
-                {msg.author}
+                {msg.author || '已刪除'}
               </span>
               {msg.tag && (
                 <span className="text-xs ml-1" style={{ color: 'var(--color-text-muted)' }}>{msg.tag}</span>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-22',
+    changes: [
+      'fix(#51): 討論區軟刪除 placeholder 刷新後消失 — GET messages 不再過濾 deleted_at，保留已刪除留言的 placeholder 顯示',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-21',
     changes: [
       'fix(#60): 多人認領 — 認領按鈕條件修正，claimed 狀態也可認領',


### PR DESCRIPTION
## Summary
- GET /api/messages 移除頂層留言與回覆的 `deleted_at IS NULL` 過濾條件
- 已軟刪除的留言在頁面刷新後仍可顯示「此留言已被刪除」placeholder
- `reply_count` 子查詢與回覆驗證仍保留 `deleted_at IS NULL`（不計算已刪除回覆、不能回覆已刪除留言）

## Root Cause
後端 `functions/api/messages/index.ts` 兩處 `WHERE deleted_at IS NULL` 把軟刪除的留言完全過濾掉，前端 MessageCard 雖然有 placeholder 渲染邏輯，但刷新後拿不到這些記錄所以消失。

## Changes
| 檔案 | 改動 |
|------|------|
| `functions/api/messages/index.ts` | 頂層留言查詢(L54)、回覆查詢(L78) 移除 `deleted_at IS NULL` |
| `src/lib/changelog.ts` | 新增 changelog 條目 |

## Test plan
- [x] `npm run build` 通過
- [ ] 部署後測試：刪除一則留言 → 刷新頁面 → placeholder 仍顯示
- [ ] 驗證 reply_count 不包含已刪除的回覆
- [ ] 驗證無法回覆已刪除的留言

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)