### PR TITLE
fix(#90): 積分防洗分 — 同一投稿每人僅首次留言加分

### DIFF
--- a/functions/api/ai-tools/[id]/comments.ts
+++ b/functions/api/ai-tools/[id]/comments.ts
@@ -92,9 +92,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       args: [commentId, id, user.id, content.trim()],
     });
 
-    // Award +2 points to contributor (skip if commenting on own post)
+    // Award +2 points to contributor only on the user's first comment per resource
+    const prior = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM resource_comments WHERE resource_id = ? AND user_id = ? AND resource_type = 'ai-tool'`,
+      args: [id, user.id],
+    });
+    const isFirstComment = Number(prior.rows[0]?.cnt) <= 1;
+
     const contributorId = toolResult.rows[0].contributor_id as string;
-    if (contributorId && contributorId !== user.id) {
+    if (isFirstComment && contributorId && contributorId !== user.id) {
       const ledgerId = crypto.randomUUID();
       await db.execute({
         sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, 'resource_comment', ?)`,

--- a/functions/api/knowledge/[id]/comments.ts
+++ b/functions/api/knowledge/[id]/comments.ts
@@ -92,9 +92,15 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       args: [commentId, id, user.id, content.trim()],
     });
 
-    // Award +2 points to contributor (skip if commenting on own post)
+    // Award +2 points to contributor only on the user's first comment per resource
+    const prior = await db.execute({
+      sql: `SELECT COUNT(*) AS cnt FROM resource_comments WHERE resource_id = ? AND user_id = ? AND resource_type = 'knowledge'`,
+      args: [id, user.id],
+    });
+    const isFirstComment = Number(prior.rows[0]?.cnt) <= 1;
+
     const contributorId = entryResult.rows[0].contributor_id as string;
-    if (contributorId && contributorId !== user.id) {
+    if (isFirstComment && contributorId && contributorId !== user.id) {
       const ledgerId = crypto.randomUUID();
       await db.execute({
         sql: `INSERT INTO points_ledger (id, user_id, action, points, ref_type, ref_id) VALUES (?, ?, ?, ?, 'resource_comment', ?)`,

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,7 +9,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-22',
     changes: [
-      'fix(#51): 討論區軟刪除 placeholder 刷新後消失 — GET messages 不再過濾 deleted_at，保留已刪除留言的 placeholder 顯示',
+      'fix(#90): 知識庫/AI工具箱留言積分 — 同一 user 對同一 resource 僅第一次留言才 +2 分，避免重複刷分',
     ],
   },
   {


### PR DESCRIPTION
## Summary
修正 Cyclone 驗收回報的積分洗分問題：目前每留一則 comment 都 +2，應改為同一 user 對同一 resource 只有第一次留言時加分。

## Bug 描述
> 目前是「每留一則對方就 +2 分」，所以只要朋友互留留言就能互相刷分。
> 原始規劃：對他人的投稿留言者，一則投稿只有第一次留言加分，第二次以上不加分。

## 修改檔案
- `functions/api/knowledge/[id]/comments.ts` (line ~95)
- `functions/api/ai-tools/[id]/comments.ts` (line ~95)

## Fix 方案
在 INSERT points_ledger 前，先查 resource_comments 是否已有該 user 對該 resource 的留言。若已存在則 skip 積分。

## Test plan
- [ ] 留第一則 comment → 投稿者 +2
- [ ] 留第二則（同一投稿）→ 不再加分
- [ ] 不同 user 留言 → 各自首次才加分
- [ ] 留言刪除後再留言 → 仍只算首次

🤖 Generated with [Claude Code](https://claude.com/claude-code)