### PR TITLE
feat(#135): Link response headers — Agent 發現機制 (RFC 8288)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Link: </.well-known/api-catalog>; rel="api-catalog"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,7 +9,7 @@ export const CHANGELOG: ChangelogEntry[] = [
     version: '',
     date: '2026-04-23',
     changes: [
-      'feat(#134): 新增 sitemap.xml — 安裝 @astrojs/sitemap，整合至 astro.config.mjs，build 自動生成 sitemap-index.xml',
+      'feat(#135): 新增 HTTP Link header — public/_headers 設定所有頁面帶 Link: </.well-known/api-catalog>; rel="api-catalog"',
     ],
   },
   {


### PR DESCRIPTION
## Summary
在首頁 HTTP 回應加入 Link header，引導 AI Agent 發現 API 資源。

## 實作需求
1. 在 Astro middleware 或 Cloudflare Pages `_headers` 檔案加入：
   - `Link: </.well-known/api-catalog>; rel="api-catalog"`
2. 確保首頁回應包含正確的 Link header

## 關聯
- Closes #135
- 配合 #139 (API catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)