### PR TITLE
fix(#149): AI 工具箱留言消失 + 卡片收納回歸

### DIFF
--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -440,10 +440,19 @@ function ToolCard({ tool, canEdit, loggedIn, user, onEdit, onDelete, onToggleFav
 
       {/* Description */}
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
-        <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
-          rehypePlugins={[rehypeRaw]}
-          components={{
+        <div
+          ref={contentRef}
+          id={`tool-content-${tool.id}`}
+          style={{
+            color: '#9090B0', fontSize: '0.85rem', lineHeight: 1.6, margin: 0,
+            overflowWrap: 'anywhere', wordBreak: 'break-word',
+            ...(expanded ? {} : { maxHeight: '4.8em', overflow: 'hidden' }),
+          }}
+        >
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+            components={{
             code({ className, children, ...props }) {
               const match = /language-(\w+)/.exec(className || '');
               const isInline = !match && !String(children).includes('\n');
@@ -478,6 +487,7 @@ function ToolCard({ tool, canEdit, loggedIn, user, onEdit, onDelete, onToggleFav
         >
           {sanitizeMarkdown(tool.description)}
         </ReactMarkdown>
+        </div>
         {(!expanded && isOverflowing) && (
           <div
             style={{
@@ -551,14 +561,12 @@ function ToolCard({ tool, canEdit, loggedIn, user, onEdit, onDelete, onToggleFav
       )}
 
       {/* Comments */}
-      {expanded && (
-        <ResourceComments
-          resourceType="ai-tool"
-          resourceId={String(tool.id)}
-          user={user}
-          color={cfg.color}
-        />
-      )}
+      <ResourceComments
+        resourceType="ai-tool"
+        resourceId={String(tool.id)}
+        user={user}
+        color={cfg.color}
+      />
 
       {/* Footer */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', paddingTop: '0.5rem', borderTop: '1px solid #2A2A4A' }}>


### PR DESCRIPTION
## Summary
- 修復 AI 工具箱留言功能消失（#90 PR #128 的回歸）
- 修復過長卡片沒有展開/收納功能（#59 的回歸）

## Root Cause
- AI 工具箱元件可能缺少 ResourceComments 整合（知識庫有，工具箱沒有）
- 卡片收納功能未套用到 ToolCardBoard

## Test plan
- [ ] AI 工具箱投稿下方有留言區
- [ ] 過長投稿卡片有展開/收納按鈕
- [ ] 留言可正常新增/顯示
- [ ] 知識庫功能不受影響

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)