### PR TITLE
fix(#153): local deploy script + version bump

### DIFF
--- a/local_deploy.sh
+++ b/local_deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+echo "Bumping version..."
+bun run bump:version
+echo "Building..."
+bun run build
+echo "Deploying to Cloudflare Pages..."
+bunx wrangler pages deploy dist --project-name=cyclone-26
+echo "Done!"

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = 'v20260419.0129';
+export const VERSION = 'v20260427.2102';


### PR DESCRIPTION
## Summary
- 新增 `local_deploy.sh`（bump version + build + deploy）
- Bump 版本號到 `v20260427.2102`
- GitHub Actions 故障期間的替代部署方案

## Test plan
- [x] `./local_deploy.sh` 成功執行 bump + build + deploy
- [x] Production 版本號更新

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)