### PR TITLE
fix: sitemap.xml redirect + knowledge category migration

### DIFF
--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -320,6 +320,31 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       });
     } catch { /* no legacy claimers to migrate */ }
 
+    // --- Migrate knowledge_entries: add 'concept' to CHECK constraint ---
+    try {
+      await db.execute({ sql: `CREATE TABLE IF NOT EXISTS knowledge_entries_new (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        content TEXT NOT NULL,
+        category TEXT DEFAULT 'template' CHECK(category IN ('template', 'best-practice', 'qa', 'concept', 'other')),
+        icon TEXT DEFAULT '📘',
+        contributor_id TEXT NOT NULL REFERENCES users(id),
+        upvotes INTEGER DEFAULT 0,
+        url TEXT DEFAULT '',
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )`, args: [] });
+      await db.execute({ sql: `INSERT OR IGNORE INTO knowledge_entries_new (id, title, content, category, icon, contributor_id, upvotes, url, created_at, updated_at)
+        SELECT id, title, content, category, icon, contributor_id, upvotes, url, created_at, updated_at
+        FROM knowledge_entries`, args: [] });
+      const newCount = await db.execute({ sql: `SELECT count(*) as cnt FROM knowledge_entries_new`, args: [] });
+      const oldCount = await db.execute({ sql: `SELECT count(*) as cnt FROM knowledge_entries`, args: [] });
+      if (Number(newCount.rows[0].cnt) >= Number(oldCount.rows[0].cnt)) {
+        await db.execute({ sql: `DROP TABLE knowledge_entries`, args: [] });
+        await db.execute({ sql: `ALTER TABLE knowledge_entries_new RENAME TO knowledge_entries`, args: [] });
+      }
+    } catch { /* already migrated or no old table */ }
+
     // --- Migrate wish categories: site → feature ---
     // Must rebuild table because CHECK(category IN ('personal','site')) blocks UPDATE to 'feature'
     try {

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/sitemap.xml /sitemap-index.xml 301


### PR DESCRIPTION
## Summary
- `/sitemap.xml` → `/sitemap-index.xml` 301 redirect (Cloudflare `_redirects`)
- Knowledge entries table migration: add `'concept'` to CHECK constraint
- DB 已備份至 `backups/20260427/cyclone-26.sql`（1216 行，18 張表）

## Cyclone 老闆回報的問題
1. `/sitemap.xml` 顯示首頁而非 XML → **修正：加 301 redirect**
2. 知識庫選「概念補充」提交失敗 `CHECK constraint failed` → **修正：migration 重建 table**

## Test plan
- [x] Build 通過
- [ ] `/sitemap.xml` 回傳 XML（301 redirect to sitemap-index.xml）
- [ ] 知識庫選「概念補充」可正常提交
- [ ] merge 後需跑 `/api/db/init` 執行 migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)