### PR TITLE
fix(#120): AI Insights 元件脫鉤 GA4 analytics 錯誤

### DIFF
--- a/src/components/admin/tabs/AdminAIInsights.tsx
+++ b/src/components/admin/tabs/AdminAIInsights.tsx
@@ -11,8 +11,6 @@ export default function AdminAIInsights({ analytics }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [quotaExceeded, setQuotaExceeded] = useState(false);
 
-  if (!analytics || analytics.error) return null;
-
   async function fetchInsights() {
     setLoading(true);
     setError(null);


### PR DESCRIPTION
## Summary
- 移除 `AdminAIInsights.tsx` 中 `if (!analytics || analytics.error) return null` 的 guard
- AI Insights 元件不再依賴 GA4 analytics 狀態，即使 GA4 連線失敗也能顯示「生成分析」按鈕

## Test plan
- [ ] Admin Panel 進入 AI 分析區塊，確認「生成分析」按鈕可見（即使 GA4 API 報錯）
- [ ] 點按鈕可正常發送 `/api/admin/ai-insights` 請求
- [ ] `bun run build` 通過

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)