### PR TITLE
fix(#90): 知識庫留言數重整後歸 0

### DIFF
--- a/functions/api/knowledge/index.ts
+++ b/functions/api/knowledge/index.ts
@@ -88,6 +88,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       updated_at: row.updated_at,
       tags: [] as { id: string; name: string; color: string }[],
       urls: [] as { id: string; url: string; label: string }[],
+      comment_count: 0 as number,
     }));
 
     if (entries.length > 0) {
@@ -122,6 +123,18 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           }
         }
       } catch { /* resource_urls table may not exist yet */ }
+
+        // Fetch comment counts for all entries
+        try {
+          const countResult = await db.execute({
+            sql: `SELECT resource_id, COUNT(*) as cnt FROM resource_comments WHERE resource_type = 'knowledge' AND resource_id IN (${placeholders}) GROUP BY resource_id`,
+            args: ids,
+          });
+          for (const cr of countResult.rows) {
+            const entry = entries.find((e) => e.id === cr.resource_id);
+            if (entry) entry.comment_count = Number(cr.cnt);
+          }
+        } catch { /* resource_comments table may not exist yet */ }
     }
 
     // Attach is_favorited for logged-in users

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -24,6 +24,7 @@ interface ResourceCommentsProps {
   resourceId: string;
   user: User | null;
   color?: string;
+  initialCount?: number;
 }
 
 const inputStyle: React.CSSProperties = {
@@ -80,12 +81,13 @@ function Avatar({ name, avatarUrl, size = 24 }: { name: string; avatarUrl: strin
   );
 }
 
-export default function ResourceComments({ resourceType, resourceId, user, color = '#6C63FF' }: ResourceCommentsProps) {
+export default function ResourceComments({ resourceType, resourceId, user, color = '#6C63FF', initialCount }: ResourceCommentsProps) {
   const [open, setOpen] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
   const [loading, setLoading] = useState(false);
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
 
   const isAdmin = user ? ['captain', 'tech', 'admin'].includes(user.effectiveRole) : false;
 
@@ -97,6 +99,7 @@ export default function ResourceComments({ resourceType, resourceId, user, color
       const data = await res.json();
       if (data.ok) setComments(data.comments || []);
     } catch { /* ignore */ }
+    setHasLoaded(true);
     setLoading(false);
   }, [comments.length, resourceType, resourceId]);
 
@@ -155,7 +158,7 @@ export default function ResourceComments({ resourceType, resourceId, user, color
           justifyContent: 'space-between',
         }}
       >
-        <span>💬 留言 ({comments.length})</span>
+        <span>💬 留言 ({hasLoaded ? comments.length : (initialCount ?? 0)})</span>
         <span style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>▼</span>
       </button>
 

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -32,6 +32,7 @@ interface KnowledgeEntry {
   updated_at: string;
   tags: Tag[];
   urls: { id: string; url: string; label: string }[];
+  comment_count: number;
   is_favorited?: boolean;
 }
 
@@ -684,6 +685,12 @@ function EntryCard({
         </span>
         <span style={{ color: '#2A2A4A' }}>&#183;</span>
         <span style={{ fontSize: '0.75rem', color: '#606080' }}>{timeAgo(entry.created_at)}</span>
+        {entry.comment_count > 0 && (
+          <>
+            <span style={{ color: '#2A2A4A' }}>&#183;</span>
+            <span style={{ fontSize: '0.75rem', color: '#6C63FF' }}>{entry.comment_count} 💬</span>
+          </>
+        )}
       </div>
     </article>
   );

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -662,6 +662,7 @@ function EntryCard({
         resourceId={entry.id}
         user={user}
         color={cfg.color}
+        initialCount={entry.comment_count}
       />
 
       {/* Footer */}


### PR DESCRIPTION
## Summary
- API `GET /api/knowledge` 加入 `comment_count` 欄位，透過 GROUP BY 一次查詢所有 entry 的留言數
- 前端 `KnowledgeBoard.tsx` 卡片直接顯示 `comment_count`，不再需要展開留言區才載入
- 解決頁面重整後留言數顯示 0 的問題

## Test plan
- [ ] 重整知識庫頁面，確認卡片上的 💬 留言數正確顯示（不需展開卡片）
- [ ] 發表新留言後重整，留言數更新正確
- [ ] `bun run build` 通過

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)