### PR TITLE
fix(#90): 預載知識庫與 AI 工具箱留言數

### DIFF
--- a/functions/api/ai-tools/index.ts
+++ b/functions/api/ai-tools/index.ts
@@ -81,6 +81,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       contributor_name: row.contributor_name || row.author,
       contributor_avatar: row.contributor_avatar,
       tags: [] as { id: string; name: string; color: string }[],
+      comment_count: 0,
     }));
 
     // Fetch tags for all returned tools
@@ -103,6 +104,18 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           tool.tags.push({ id: tr.tag_id as string, name: tr.name as string, color: tr.color as string });
         }
       }
+
+      // Fetch comment counts for all tools so cards do not show 0 before expansion.
+      try {
+        const commentResult = await db.execute({
+          sql: `SELECT resource_id, COUNT(*) AS cnt FROM resource_comments WHERE resource_type = 'ai-tool' AND resource_id IN (${placeholders}) GROUP BY resource_id`,
+          args: ids,
+        });
+        for (const cr of commentResult.rows) {
+          const tool = toolMap.get(String(cr.resource_id));
+          if (tool) tool.comment_count = Number(cr.cnt);
+        }
+      } catch { /* resource_comments table may not exist yet */ }
     }
 
     // Attach is_favorited for logged-in users

--- a/functions/api/knowledge/index.ts
+++ b/functions/api/knowledge/index.ts
@@ -88,6 +88,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
       updated_at: row.updated_at,
       tags: [] as { id: string; name: string; color: string }[],
       urls: [] as { id: string; url: string; label: string }[],
+      comment_count: 0,
     }));
 
     if (entries.length > 0) {
@@ -122,6 +123,18 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
           }
         }
       } catch { /* resource_urls table may not exist yet */ }
+
+      // Fetch comment counts for all entries so cards do not show 0 before expansion.
+      try {
+        const commentResult = await db.execute({
+          sql: `SELECT resource_id, COUNT(*) AS cnt FROM resource_comments WHERE resource_type = 'knowledge' AND resource_id IN (${placeholders}) GROUP BY resource_id`,
+          args: ids,
+        });
+        for (const cr of commentResult.rows) {
+          const entry = entries.find((e) => e.id === cr.resource_id);
+          if (entry) entry.comment_count = Number(cr.cnt);
+        }
+      } catch { /* resource_comments table may not exist yet */ }
     }
 
     // Attach is_favorited for logged-in users

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { timeAgo } from '@/lib/time';
 
 interface Comment {
@@ -24,6 +24,7 @@ interface ResourceCommentsProps {
   resourceId: string;
   user: User | null;
   color?: string;
+  initialCommentCount?: number;
 }
 
 const inputStyle: React.CSSProperties = {
@@ -80,14 +81,21 @@ function Avatar({ name, avatarUrl, size = 24 }: { name: string; avatarUrl: strin
   );
 }
 
-export default function ResourceComments({ resourceType, resourceId, user, color = '#6C63FF' }: ResourceCommentsProps) {
+export default function ResourceComments({ resourceType, resourceId, user, color = '#6C63FF', initialCommentCount = 0 }: ResourceCommentsProps) {
   const [open, setOpen] = useState(false);
   const [comments, setComments] = useState<Comment[]>([]);
+  const [commentCount, setCommentCount] = useState(initialCommentCount);
   const [loading, setLoading] = useState(false);
   const [content, setContent] = useState('');
   const [submitting, setSubmitting] = useState(false);
 
   const isAdmin = user ? ['captain', 'tech', 'admin'].includes(user.effectiveRole) : false;
+
+  useEffect(() => {
+    if (!open && comments.length === 0) {
+      setCommentCount(initialCommentCount);
+    }
+  }, [comments.length, initialCommentCount, open]);
 
   const loadComments = useCallback(async () => {
     if (comments.length > 0) return;
@@ -95,7 +103,11 @@ export default function ResourceComments({ resourceType, resourceId, user, color
     try {
       const res = await fetch(`/api/${resourceType === 'knowledge' ? 'knowledge' : 'ai-tools'}/${resourceId}/comments`);
       const data = await res.json();
-      if (data.ok) setComments(data.comments || []);
+      if (data.ok) {
+        const nextComments = data.comments || [];
+        setComments(nextComments);
+        setCommentCount(nextComments.length);
+      }
     } catch { /* ignore */ }
     setLoading(false);
   }, [comments.length, resourceType, resourceId]);
@@ -119,7 +131,11 @@ export default function ResourceComments({ resourceType, resourceId, user, color
         setContent('');
         const reloadRes = await fetch(`/api/${resourceType === 'knowledge' ? 'knowledge' : 'ai-tools'}/${resourceId}/comments`);
         const reloadData = await reloadRes.json();
-        if (reloadData.ok) setComments(reloadData.comments || []);
+        if (reloadData.ok) {
+          const nextComments = reloadData.comments || [];
+          setComments(nextComments);
+          setCommentCount(nextComments.length);
+        }
       }
     } catch { /* ignore */ }
     setSubmitting(false);
@@ -131,7 +147,11 @@ export default function ResourceComments({ resourceType, resourceId, user, color
       const res = await fetch(`/api/comments/${commentId}`, { method: 'DELETE' });
       const data = await res.json();
       if (data.ok) {
-        setComments(prev => prev.filter(c => c.id !== commentId));
+        setComments(prev => {
+          const nextComments = prev.filter(c => c.id !== commentId);
+          setCommentCount(nextComments.length);
+          return nextComments;
+        });
       }
     } catch { /* ignore */ }
   };
@@ -155,7 +175,7 @@ export default function ResourceComments({ resourceType, resourceId, user, color
           justifyContent: 'space-between',
         }}
       >
-        <span>💬 留言 ({comments.length})</span>
+        <span>💬 留言 ({commentCount})</span>
         <span style={{ transform: open ? 'rotate(180deg)' : 'rotate(0deg)', transition: 'transform 0.2s' }}>▼</span>
       </button>
 

--- a/src/components/ai-tools/ToolCardBoard.tsx
+++ b/src/components/ai-tools/ToolCardBoard.tsx
@@ -35,6 +35,7 @@ interface Tool {
   tags: Tag[];
   is_favorited?: boolean;
   github_url?: string;
+  comment_count?: number;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -566,6 +567,7 @@ function ToolCard({ tool, canEdit, loggedIn, user, onEdit, onDelete, onToggleFav
         resourceId={String(tool.id)}
         user={user}
         color={cfg.color}
+        initialCommentCount={tool.comment_count ?? 0}
       />
 
       {/* Footer */}

--- a/src/components/knowledge/KnowledgeBoard.tsx
+++ b/src/components/knowledge/KnowledgeBoard.tsx
@@ -32,6 +32,7 @@ interface KnowledgeEntry {
   updated_at: string;
   tags: Tag[];
   urls: { id: string; url: string; label: string }[];
+  comment_count?: number;
   is_favorited?: boolean;
 }
 
@@ -661,6 +662,7 @@ function EntryCard({
         resourceId={entry.id}
         user={user}
         color={cfg.color}
+        initialCommentCount={entry.comment_count ?? 0}
       />
 
       {/* Footer */}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-29',
+    changes: [
+      'fix(#90): 知識庫與 AI 工具箱卡片留言數預載，重整後不再歸 0',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-26',
     changes: [
       'fix(#148): 留言區顯示自訂暱稱 — 全站 comment API 改用 COALESCE(display_name, name)',


### PR DESCRIPTION
## Summary
- GET /api/knowledge 預載 knowledge resource comment_count
- GET /api/ai-tools 預載 ai-tool resource comment_count
- ResourceComments 支援 initialCommentCount，卡片展開前不再顯示 0
- 新增/刪除留言後同步更新顯示數字
- 更新 changelog

## Test plan
- [x] bun run build
- [x] 本機 http://localhost:8788/knowledge 確認有留言卡片重整後不歸 0
- [x] 本機 http://localhost:8788/ai-tools 確認有留言卡片重整後不歸 0

## Notes
- 只處理 #90 留言數預載問題
- 不處理 soft-delete placeholder / 積分歸零 / GA4 權限

Closes #90