### PR TITLE
fix(#51): 知識庫留言刪除 placeholder

### DIFF
--- a/functions/api/ai-tools/[id]/comments.ts
+++ b/functions/api/ai-tools/[id]/comments.ts
@@ -24,6 +24,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         FROM resource_comments rc
         LEFT JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
         WHERE rc.resource_type = 'ai-tool' AND rc.resource_id = ?
+          AND (rc.deleted_at IS NOT NULL OR u.id IS NOT NULL)
         ORDER BY rc.created_at DESC
       `,
       args: [id],

--- a/functions/api/ai-tools/[id]/comments.ts
+++ b/functions/api/ai-tools/[id]/comments.ts
@@ -19,10 +19,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const result = await db.execute({
       sql: `
         SELECT
-          rc.id, rc.content, rc.created_at, rc.updated_at,
+          rc.id, rc.content, rc.created_at, rc.updated_at, rc.deleted_at,
           u.id AS author_id, COALESCE(u.display_name, u.name) AS author_name, u.avatar_url AS author_avatar
         FROM resource_comments rc
-        JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        LEFT JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
         WHERE rc.resource_type = 'ai-tool' AND rc.resource_id = ?
         ORDER BY rc.created_at DESC
       `,

--- a/functions/api/comments/[id].ts
+++ b/functions/api/comments/[id].ts
@@ -46,9 +46,10 @@ export const onRequestDelete: PagesFunction<Env> = async (context) => {
       args: [id],
     });
 
+    // Soft delete: set deleted_at and deleted_by instead of actually deleting
     await db.execute({
-      sql: 'DELETE FROM resource_comments WHERE id = ?',
-      args: [id],
+      sql: `UPDATE resource_comments SET deleted_at = datetime('now'), deleted_by = ? WHERE id = ?`,
+      args: [user.id, id],
     });
 
     return new Response(JSON.stringify({ ok: true }), {

--- a/functions/api/db/init.ts
+++ b/functions/api/db/init.ts
@@ -308,6 +308,8 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       { sql: `ALTER TABLE messages ADD COLUMN deleted_by TEXT`, note: 'messages.deleted_by' },
       { sql: `ALTER TABLE knowledge_entries ADD COLUMN url TEXT DEFAULT ''`, note: 'knowledge_entries.url' },
       { sql: `ALTER TABLE messages ADD COLUMN parent_id INTEGER DEFAULT NULL REFERENCES messages(id)`, note: 'messages.parent_id' },
+      { sql: `ALTER TABLE resource_comments ADD COLUMN deleted_at TEXT`, note: 'resource_comments.deleted_at' },
+      { sql: `ALTER TABLE resource_comments ADD COLUMN deleted_by TEXT`, note: 'resource_comments.deleted_by' },
     ];
 
     // --- Migrate legacy wish.claimer_id → wish_claimers ---

--- a/functions/api/knowledge/[id]/comments.ts
+++ b/functions/api/knowledge/[id]/comments.ts
@@ -19,10 +19,10 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const result = await db.execute({
       sql: `
         SELECT
-          rc.id, rc.content, rc.created_at, rc.updated_at,
+          rc.id, rc.content, rc.created_at, rc.updated_at, rc.deleted_at,
           u.id AS author_id, COALESCE(u.display_name, u.name) AS author_name, u.avatar_url AS author_avatar
         FROM resource_comments rc
-        JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
+        LEFT JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
         WHERE rc.resource_type = 'knowledge' AND rc.resource_id = ?
         ORDER BY rc.created_at DESC
       `,

--- a/functions/api/knowledge/[id]/comments.ts
+++ b/functions/api/knowledge/[id]/comments.ts
@@ -24,6 +24,7 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
         FROM resource_comments rc
         LEFT JOIN users u ON u.id = rc.user_id AND u.archived_at IS NULL AND u.status = 'active'
         WHERE rc.resource_type = 'knowledge' AND rc.resource_id = ?
+          AND (rc.deleted_at IS NOT NULL OR u.id IS NOT NULL)
         ORDER BY rc.created_at DESC
       `,
       args: [id],

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -51,12 +51,13 @@ function handleFocusOut(e: React.FocusEvent<HTMLTextAreaElement>) {
   e.target.style.boxShadow = 'none';
 }
 
-function Avatar({ name, avatarUrl, size = 24 }: { name: string; avatarUrl: string | null; size?: number }) {
+function Avatar({ name, avatarUrl, size = 24 }: { name: string | null; avatarUrl: string | null; size?: number }) {
+  const safeName = name || '?';
   if (avatarUrl) {
     return (
       <img
         src={avatarUrl}
-        alt={name}
+        alt={safeName}
         style={{ width: size, height: size, borderRadius: '50%', objectFit: 'cover' }}
       />
     );
@@ -77,7 +78,7 @@ function Avatar({ name, avatarUrl, size = 24 }: { name: string; avatarUrl: strin
         flexShrink: 0,
       }}
     >
-      {name.charAt(0).toUpperCase()}
+      {safeName.charAt(0).toUpperCase()}
     </span>
   );
 }
@@ -191,7 +192,7 @@ export default function ResourceComments({ resourceType, resourceId, user, color
                   <Avatar name={c.author_name} avatarUrl={c.author_avatar} size={24} />
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
-                      <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#F0F0FF' }}>{c.author_name}</span>
+                      <span style={{ fontSize: '0.8rem', fontWeight: 600, color: '#F0F0FF' }}>{c.author_name || '未知使用者'}</span>
                       <span style={{ fontSize: '0.65rem', color: '#505070' }}>{timeAgo(c.created_at)}</span>
                       {(c.author_id === user?.id || isAdmin) && (
                         <button

--- a/src/components/ResourceComments.tsx
+++ b/src/components/ResourceComments.tsx
@@ -6,6 +6,7 @@ interface Comment {
   content: string;
   created_at: string;
   updated_at: string;
+  deleted_at?: string | null;
   author_id: string;
   author_name: string;
   author_avatar: string | null;
@@ -134,7 +135,9 @@ export default function ResourceComments({ resourceType, resourceId, user, color
       const res = await fetch(`/api/comments/${commentId}`, { method: 'DELETE' });
       const data = await res.json();
       if (data.ok) {
-        setComments(prev => prev.filter(c => c.id !== commentId));
+        setComments(prev => prev.map(c =>
+          c.id === commentId ? { ...c, deleted_at: new Date().toISOString() } : c
+        ));
       }
     } catch { /* ignore */ }
   };
@@ -179,7 +182,11 @@ export default function ResourceComments({ resourceType, resourceId, user, color
             <div style={{ fontSize: '0.8rem', color: '#606080' }}>尚無留言，來發表第一則吧！</div>
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
-              {comments.map((c) => (
+              {comments.map((c) => c.deleted_at ? (
+                <div key={c.id} style={{ fontSize: '0.8rem', fontStyle: 'italic', color: '#606080', background: 'rgba(233,69,96,0.05)', border: '1px solid rgba(233,69,96,0.15)', borderRadius: '0.5rem', padding: '0.5rem 0.75rem' }}>
+                  此留言已被刪除
+                </div>
+              ) : (
                 <div key={c.id} style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
                   <Avatar name={c.author_name} avatarUrl={c.author_avatar} size={24} />
                   <div style={{ flex: 1, minWidth: 0 }}>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-04-29',
+    changes: [
+      'fix(#51): 知識庫留言區 soft-delete placeholder — 與討論區行為一致',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-26',
     changes: [
       'fix(#148): 留言區顯示自訂暱稱 — 全站 comment API 改用 COALESCE(display_name, name)',


### PR DESCRIPTION
$(cat <<EOF
知識庫留言區刪除留言後顯示 placeholder，與討論區行為一致。

變更內容：
- DB migration：resource_comments 新增 deleted_at / deleted_by 欄位
- API DELETE：硬刪除改為 soft delete（UPDATE deleted_at）
- API GET（knowledge + ai-tools）：SELECT 包含 deleted_at，改用 LEFT JOIN
- ResourceComments 元件：被刪除的留言顯示「此留言已被刪除」placeholder，保留在列表中

Closes #51
EOF
)