### PR TITLE
fix(#163): /admin GA 面板 UI/UX 修正

### DIFF
--- a/src/components/admin/tabs/AdminAnalytics.tsx
+++ b/src/components/admin/tabs/AdminAnalytics.tsx
@@ -5,6 +5,43 @@ interface Props {
   analytics: Analytics | null;
 }
 
+function formatDuration(secondsStr: string): string {
+  const totalSeconds = Math.round(parseFloat(secondsStr));
+  if (isNaN(totalSeconds) || totalSeconds <= 0) return '0 秒';
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0 ? `${minutes} 分 ${seconds} 秒` : `${seconds} 秒`;
+}
+
+function formatBounceRate(rateStr: string): string {
+  const rate = parseFloat(rateStr);
+  if (isNaN(rate)) return '0%';
+  return `${(rate * 100).toFixed(2)}%`;
+}
+
+function translateSource(source: string): string {
+  const map: Record<string, string> = {
+    'Unassigned': '未分類',
+    '(not set)': '未分類',
+    '(direct)': '直接連結',
+    'Organic Search': '自然搜尋',
+    'Direct': '直接連結',
+    'Referral': '引薦',
+    'Social': '社群',
+    'Paid Search': '付費搜尋',
+    'Email': '電子郵件',
+    'Affiliated': '聯盟',
+    'Display': '多媒體廣告',
+  };
+  return map[source] ?? source;
+}
+
+function formatNumber(numStr: string): string {
+  const num = parseInt(numStr, 10);
+  if (isNaN(num)) return '0';
+  return num.toLocaleString();
+}
+
 export default function AdminAnalytics({ analytics }: Props) {
   if (!analytics) return null;
 
@@ -30,15 +67,15 @@ export default function AdminAnalytics({ analytics }: Props) {
         </div>
         <div className="rounded-xl p-4" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)', borderLeftWidth: '3px', borderLeftColor: '#00F5A0' }}>
           <div className="text-xs font-medium mb-1" style={{ color: 'var(--color-text-muted)' }}>工作階段</div>
-          <p className="text-2xl font-bold" style={{ color: '#00F5A0' }}>{analytics.activeUsers.sessions}</p>
+          <p className="text-2xl font-bold" style={{ color: '#00F5A0' }}>{formatNumber(analytics.activeUsers.sessions)}</p>
         </div>
         <div className="rounded-xl p-4" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)', borderLeftWidth: '3px', borderLeftColor: '#00D9FF' }}>
-          <div className="text-xs font-medium mb-1" style={{ color: 'var(--color-text-muted)' }}>平均工作階段</div>
-          <p className="text-2xl font-bold" style={{ color: '#00D9FF' }}>{analytics.activeUsers.avgSessionDuration}</p>
+          <div className="text-xs font-medium mb-1" style={{ color: 'var(--color-text-muted)' }}>平均停留時間</div>
+          <p className="text-2xl font-bold" style={{ color: '#00D9FF' }}>{formatDuration(analytics.activeUsers.avgSessionDuration)}</p>
         </div>
         <div className="rounded-xl p-4" style={{ background: 'var(--color-bg-card)', border: '1px solid var(--color-border)', borderLeftWidth: '3px', borderLeftColor: '#E94560' }}>
           <div className="text-xs font-medium mb-1" style={{ color: 'var(--color-text-muted)' }}>跳出率</div>
-          <p className="text-2xl font-bold" style={{ color: '#E94560' }}>{analytics.activeUsers.bounceRate}%</p>
+          <p className="text-2xl font-bold" style={{ color: '#E94560' }}>{formatBounceRate(analytics.activeUsers.bounceRate)}</p>
         </div>
       </div>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
@@ -47,7 +84,9 @@ export default function AdminAnalytics({ analytics }: Props) {
           <div className="space-y-1">
             {analytics.topPages.slice(0, 5).map((p) => (
               <div key={p.path} className="flex items-center justify-between text-sm">
-                <span className="truncate flex-1" style={{ color: 'var(--color-text-primary)' }}>{p.path}</span>
+                <span className="truncate flex-1" style={{ color: 'var(--color-text-primary)' }}>
+                  <a href={`https://cyclone.tw${p.path}`} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'underline', textUnderlineOffset: '2px' }}>{p.path}</a>
+                </span>
                 <span className="ml-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{parseInt(p.views).toLocaleString()} 瀏覽</span>
               </div>
             ))}
@@ -58,8 +97,8 @@ export default function AdminAnalytics({ analytics }: Props) {
           <div className="space-y-1">
             {analytics.trafficSources.slice(0, 5).map((s) => (
               <div key={s.source} className="flex items-center justify-between text-sm">
-                <span className="truncate flex-1" style={{ color: 'var(--color-text-primary)' }}>{s.source}</span>
-                <span className="ml-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{parseInt(s.sessions).toLocaleString()}  session</span>
+                <span className="truncate flex-1" style={{ color: 'var(--color-text-primary)' }}>{translateSource(s.source)}</span>
+                <span className="ml-2 text-xs" style={{ color: 'var(--color-text-muted)' }}>{formatNumber(s.sessions)} 工作階段</span>
               </div>
             ))}
           </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-05-02',
+    changes: [
+      'fix(#163): /admin GA 面板 UI/UX — 數字格式化、跳出率修正、流量來源中文化、路徑可點擊',
+    ],
+  },
+  {
+    version: '',
     date: '2026-05-01',
     changes: [
       'feat(#23): GA 趨勢圖表 — 30 日活躍用戶與瀏覽量線圖（Recharts）+ 後端 dailyTrend API',


### PR DESCRIPTION
## Summary
- 平均停留時間：原始秒數 `236.38...` → `3 分 56 秒`
- 跳出率：`0.52...%` → 乘以 100 顯示正確百分比 `52.89%`
- 流量來源中文化：`Unassigned` → `未分類`、`Referral` → `引薦` 等
- 工作階段數字千分位格式化
- 熱門頁面路徑改為可點擊連結
- `session` → `工作階段`

Closes #163

cc @tboydar

## Test plan
- [ ] `/admin` 頁面 GA 面板確認數字格式化正確
- [ ] 確認跳出率顯示為百分比（如 52.89%）
- [ ] 確認流量來源顯示中文
- [ ] 確認熱門頁面路徑可點擊開啟新分頁
- [ ] 錄製 E2E video

🤖 Generated with [Claude Code](https://claude.com/claude-code)