### PR TITLE
chore(#0): initech pipeline smoke test

### DIFF
--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-05-03',
+    changes: [
+      'chore(initech): smoke test the full dispatch pipeline — no user-facing change',
+    ],
+  },
+  {
+    version: '',
     date: '2026-04-26',
     changes: [
       'fix(#148): 留言區顯示自訂暱稱 — 全站 comment API 改用 COALESCE(display_name, name)',


### PR DESCRIPTION
## Summary
- Add smoke-test ChangelogEntry to verify full eng→qa→operator dispatch pipeline
- No user-facing change

## Test plan
- [ ] `bun run build` passes
- [ ] `bun run test` passes (6 suites, 43 tests)
- [ ] PR merged by operator
- [ ] /changelog page shows smoke-test entry after auto-deploy