### PR TITLE
chore: audit cluster B — E2E silent skip → strict mode

### DIFF
--- a/e2e/announcements.spec.ts
+++ b/e2e/announcements.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from './lambdatest-setup';
 // Feature detection — announcement-dependent tests skip in dev (default) but
 // FAIL when E2E_STRICT=1 is set in CI. Silent skip used to mask the gap
 // between "table missing" and "feature green"; strict mode catches regressions.
+// TODO: Set E2E_STRICT=1 in CI once E2E workflow is added.
 let featureAvailable = false;
 const strictMode = process.env.E2E_STRICT === '1';
 
@@ -45,6 +46,7 @@ test.describe('Announcements — E2E', () => {
 
   // ── Public API — requires feature deployed ──────────────────────────────────
 
+  // In strict mode, beforeAll throws — these skips only fire in non-strict dev mode
   test('GET /api/announcements 回傳正確結構', async ({ page }) => {
     if (!featureAvailable) test.skip();
 

--- a/e2e/announcements.spec.ts
+++ b/e2e/announcements.spec.ts
@@ -1,11 +1,19 @@
 import { test, expect } from './lambdatest-setup';
 
-// Feature detection — skip API-dependent tests if announcements table not yet deployed
+// Feature detection — announcement-dependent tests skip in dev (default) but
+// FAIL when E2E_STRICT=1 is set in CI. Silent skip used to mask the gap
+// between "table missing" and "feature green"; strict mode catches regressions.
 let featureAvailable = false;
+const strictMode = process.env.E2E_STRICT === '1';
 
 test.beforeAll(async ({ request }) => {
   const res = await request.get('/api/announcements');
   featureAvailable = res.status() === 200;
+  if (!featureAvailable) {
+    const reason = `[announcements] feature not available (probe got ${res.status()}, expected 200)`;
+    if (strictMode) throw new Error(reason);
+    console.warn(`${reason} — feature-gated tests will skip. Set E2E_STRICT=1 in CI to fail.`);
+  }
 });
 
 test.describe('Announcements — E2E', () => {

--- a/e2e/messages-auth.spec.ts
+++ b/e2e/messages-auth.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from './lambdatest-setup';
 
-// Feature detection — skip auth-gated tests if not yet deployed
+// Feature detection — auth-gated tests skip in dev (default) but FAIL when
+// E2E_STRICT=1 is set in CI. Silent skip masked the gap between
+// "feature works" and "feature absent"; strict mode surfaces it.
 let authDeployed = false;
+const strictMode = process.env.E2E_STRICT === '1';
 
 test.beforeAll(async ({ request }) => {
   // If POST without session returns 401, the auth gate is live
@@ -9,6 +12,11 @@ test.beforeAll(async ({ request }) => {
     data: { content: 'probe' },
   });
   authDeployed = res.status() === 401;
+  if (!authDeployed) {
+    const reason = `[messages-auth] auth gate not deployed (probe got ${res.status()}, expected 401)`;
+    if (strictMode) throw new Error(reason);
+    console.warn(`${reason} — auth-gated tests will skip. Set E2E_STRICT=1 in CI to fail.`);
+  }
 });
 
 test.describe('Messages Auth — E2E', () => {

--- a/e2e/messages-auth.spec.ts
+++ b/e2e/messages-auth.spec.ts
@@ -3,6 +3,7 @@ import { test, expect } from './lambdatest-setup';
 // Feature detection — auth-gated tests skip in dev (default) but FAIL when
 // E2E_STRICT=1 is set in CI. Silent skip masked the gap between
 // "feature works" and "feature absent"; strict mode surfaces it.
+// TODO: Set E2E_STRICT=1 in CI once E2E workflow is added.
 let authDeployed = false;
 const strictMode = process.env.E2E_STRICT === '1';
 
@@ -45,6 +46,7 @@ test.describe('Messages Auth — E2E', () => {
   });
 
   // ── Auth gate — 需 auth 部署後才有效 ───────────────────────────────────────
+  // In strict mode, beforeAll throws — these skips only fire in non-strict dev mode
 
   test('POST /api/messages 未登入應 401', async ({ page }) => {
     if (!authDeployed) test.skip();


### PR DESCRIPTION
## Why

Top 10 audit #4 + #5 —— `e2e/messages-auth.spec.ts` 與 `e2e/announcements.spec.ts` 在 feature 探測失敗時 silent `test.skip()`,CI 上即使 auth gate 或 announcements 表整個 missing 也會顯示「全綠」,實際上 4-8 條測試從未跑過,regression 漏網。

## Changes

- 探測失敗時 `console.warn(...)` 印出預期 vs 實際 status
- 新增 `E2E_STRICT=1` 環境變數:
  - **CI 設此旗標** → 探測失敗 = `throw new Error(...)` → 整批 fail-fast
  - **本機 / dev 不設** → 維持原行為(skip + warn),不阻擋本機跑

## Verification

- [x] `bun run build` —— 79 pages, 0 errors
- [x] `bun run test` —— 43 passed | 3 skipped(unaffected,不在 e2e/)

## Test plan

- [ ] 本機跑 `bun run test:e2e` —— 預期(未部署 auth)會 console.warn + skip,不會 fail
- [ ] CI 加 `E2E_STRICT=1` —— 預期 auth/announcements 沒部署時 fail-fast
- [ ] 部署環境跑 e2e —— 預期 strict mode pass,non-strict mode 也 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)