### PR TITLE
chore: cluster C 續 — IssueBoard / WishBoard / KnowledgeBoard smoke

### DIFF
--- a/tests/components/AdminPanel.test.tsx
+++ b/tests/components/AdminPanel.test.tsx
@@ -32,13 +32,14 @@ describe('AdminPanel — auth gate smoke', () => {
     };
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockImplementation((url: string) => {
-        if (url.includes('/stats')) return Promise.resolve(makeJsonResponse({ stats: emptyStats }));
-        if (url.includes('/users')) return Promise.resolve(makeJsonResponse({ users: [] }));
-        if (url.includes('/analytics')) return Promise.resolve(makeJsonResponse({ analytics: null }));
-        if (url.includes('/announcements')) return Promise.resolve(makeJsonResponse({ announcements: [] }));
-        if (url.includes('/messages')) return Promise.resolve(makeJsonResponse({ messages: [], total: 0 }));
-        if (url.includes('/reports')) return Promise.resolve(makeJsonResponse({ reports: [], total: 0 }));
+      vi.fn().mockImplementation((url: unknown) => {
+        const u = typeof url === 'string' ? url : url instanceof Request ? url.url : String(url);
+        if (u.includes('/stats')) return Promise.resolve(makeJsonResponse({ stats: emptyStats }));
+        if (u.includes('/users')) return Promise.resolve(makeJsonResponse({ users: [] }));
+        if (u.includes('/analytics')) return Promise.resolve(makeJsonResponse({ analytics: null }));
+        if (u.includes('/announcements')) return Promise.resolve(makeJsonResponse({ announcements: [] }));
+        if (u.includes('/messages')) return Promise.resolve(makeJsonResponse({ messages: [], total: 0 }));
+        if (u.includes('/reports')) return Promise.resolve(makeJsonResponse({ reports: [], total: 0 }));
         return Promise.resolve(makeJsonResponse({}));
       }),
     );

--- a/tests/components/IssueBoard.test.tsx
+++ b/tests/components/IssueBoard.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import IssueBoard from '../../src/components/issues/IssueBoard';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/components/auth/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function jsonOk(body: object) {
+  return Promise.resolve(
+    new Response(JSON.stringify({ ok: true, ...body }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('IssueBoard — smoke', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: unknown) => {
+        const u = typeof url === 'string' ? url : url instanceof Request ? url.url : String(url);
+        if (u.includes('/api/issues')) return jsonOk({ issues: [] });
+        if (u.includes('/api/github/issues')) return jsonOk({ issues: [] });
+        return jsonOk({});
+      }),
+    );
+  });
+
+  it('renders without crashing while auth is loading', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true, login: vi.fn() });
+    render(<IssueBoard />);
+    // Empty / loading variant — at least the body shouldn't throw.
+    // Component shows "載入中…" when issues are loading; auth-loading does not block render.
+    expect(document.body.firstChild).toBeTruthy();
+  });
+
+  it('shows empty state text when no issues returned', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false, login: vi.fn() });
+    render(<IssueBoard />);
+    expect(
+      await screen.findByText('目前沒有符合條件的 Issues', {}, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show create-issue button when user is not logged in', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false, login: vi.fn() });
+    render(<IssueBoard />);
+    await screen.findByText('目前沒有符合條件的 Issues', {}, { timeout: 4000 });
+    // Logged-out: "新增 Issue" button must NOT be present.
+    expect(screen.queryByRole('button', { name: /新增 Issue/ })).not.toBeInTheDocument();
+  });
+
+  it('shows create-issue button when user is logged in', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', name: 'Alice', effectiveRole: 'member' },
+      loading: false, login: vi.fn(),
+    });
+    render(<IssueBoard />);
+    expect(
+      await screen.findByRole('button', { name: /新增 Issue/ }, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/tests/components/KnowledgeBoard.test.tsx
+++ b/tests/components/KnowledgeBoard.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import KnowledgeBoard from '../../src/components/knowledge/KnowledgeBoard';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/components/auth/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function jsonOk(body: object) {
+  return Promise.resolve(
+    new Response(JSON.stringify({ ok: true, ...body }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('KnowledgeBoard — smoke', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: string) => {
+        if (url.includes('/api/knowledge')) return jsonOk({ entries: [] });
+        if (url.includes('/api/tags')) return jsonOk({ tags: [] });
+        if (url.includes('/api/members')) return jsonOk({ members: [] });
+        return jsonOk({});
+      }),
+    );
+  });
+
+  it('shows empty state when no knowledge entries', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<KnowledgeBoard />);
+    expect(
+      await screen.findByText(/還沒有知識條目/, {}, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows logged-out empty hint when user is not logged in', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<KnowledgeBoard />);
+    await screen.findByText(/還沒有知識條目/, {}, { timeout: 4000 });
+    // Two elements match — the empty-state hint AND the CTA card. Both are
+    // logged-out indicators, so just assert at least one rendered.
+    expect(screen.getAllByText(/登入後即可投稿到知識庫/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows logged-in empty hint when user is logged in', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', name: 'Alice', effectiveRole: 'member' },
+      loading: false,
+    });
+    render(<KnowledgeBoard />);
+    await screen.findByText(/還沒有知識條目/, {}, { timeout: 4000 });
+    expect(screen.getByText(/點擊.*投稿到知識庫.*來分享你的知識/)).toBeInTheDocument();
+  });
+
+  it('renders without crashing while auth is loading', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    render(<KnowledgeBoard />);
+    expect(document.body.firstChild).toBeTruthy();
+  });
+});

--- a/tests/components/WishBoard.test.tsx
+++ b/tests/components/WishBoard.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import WishBoard from '../../src/components/wishlist/WishBoard';
+
+const mockUseAuth = vi.fn();
+vi.mock('../../src/components/auth/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+function jsonOk(body: object) {
+  return Promise.resolve(
+    new Response(JSON.stringify({ ok: true, ...body }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+}
+
+describe('WishBoard — smoke', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation((url: unknown) => {
+        const u = typeof url === 'string' ? url : url instanceof Request ? url.url : String(url);
+        if (u.includes('/api/wishes')) return jsonOk({ wishes: [] });
+        return jsonOk({});
+      }),
+    );
+  });
+
+  it('shows empty state when no wishes returned', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<WishBoard />);
+    expect(
+      await screen.findByText(/目前還沒有願望/, {}, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show 許願 button when user is not logged in', async () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: false });
+    render(<WishBoard />);
+    await screen.findByText(/目前還沒有願望/, {}, { timeout: 4000 });
+    expect(screen.queryByRole('button', { name: '許願' })).not.toBeInTheDocument();
+  });
+
+  it('shows 許願 button when user is logged in', async () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 'u1', name: 'Alice', effectiveRole: 'member' },
+      loading: false,
+    });
+    render(<WishBoard />);
+    expect(
+      await screen.findByRole('button', { name: '許願' }, { timeout: 4000 }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders without crashing while auth is loading', () => {
+    mockUseAuth.mockReturnValue({ user: null, loading: true });
+    render(<WishBoard />);
+    expect(document.body.firstChild).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Why

接著 #170 建立的 RTL + jsdom 框架,把 audit Top 10 剩餘 3 個大元件補上 smoke test。完工後 cluster C 全收。

## Changes

3 個 test 檔,每個 4 個 smoke check(共 12 新測試):

### `tests/components/IssueBoard.test.tsx`
- loading auth → 不 crash
- 空 issues → 顯示「目前沒有符合條件的 Issues」
- logged-out → 不顯示「新增 Issue」按鈕
- logged-in → 顯示「新增 Issue」按鈕

### `tests/components/WishBoard.test.tsx`
- 空 wishes → 顯示「目前還沒有願望...」
- logged-out → 不顯示「許願」按鈕
- logged-in → 顯示「許願」按鈕
- loading auth → 不 crash

### `tests/components/KnowledgeBoard.test.tsx`
- 空 entries → 顯示「還沒有知識條目」
- logged-out → 顯示「登入後即可投稿到知識庫」(2 處皆 OK)
- logged-in → 顯示「點擊投稿到知識庫來分享你的知識」
- loading auth → 不 crash

每檔都 mirror `tests/components/AdminPanel.test.tsx` pattern:`vi.mock('@/components/auth/useAuth')` + `vi.stubGlobal('fetch')` + `afterEach(cleanup)`。

## Stack

Base = `chore/cluster-c-test-infra`(PR #170)。等 #170 merge 後可一鍵 rebase 到 main。

## Verification

- [x] `bun run test` —— **59 passed | 3 skipped**(從 47 → +12)
- [x] `bun run build` —— 0 errors

## Audit Top 10 收尾

| # | 題目 | PR |
|---|---|---|
| 1 | IssueBoard tests | 本 PR |
| 2 | WishBoard tests | 本 PR |
| 3 | KnowledgeBoard tests | 本 PR |
| 4 | e2e auth silent skip | #169 |
| 5 | e2e announcements skip | #169 |
| 6 | admin requireRole | false positive(skip) |
| 7 | github cache cast | #168 |
| 8 | AdminPanel smoke | #170 |
| 9 | messages dynamic import | #168 |
| 10 | changelog backfill | #168 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)