### PR TITLE
fix(e2e): nav-rwd 「更多」 dropdown expects 10 items

### DIFF
--- a/e2e/nav-rwd.spec.ts
+++ b/e2e/nav-rwd.spec.ts
@@ -98,7 +98,7 @@ for (const vp of viewports) {
         await expect(moreBtn).toBeVisible();
       });
 
-      test('"更多" dropdown opens with all 9 items', async ({ page }) => {
+      test('"更多" dropdown opens with all 10 items', async ({ page }) => {
         await page.goto('/');
 
         const moreBtn = page.locator('#more-menu-btn');
@@ -111,10 +111,10 @@ for (const vp of viewports) {
         await moreBtn.click();
         await expect(morePanel).toBeVisible();
 
-        // Should contain 9 dropdown links (5 功能 + 4 許願&反饋)
+        // Should contain 10 dropdown links (5 功能 + 5 許願&反饋)
         const dropdownLinks = morePanel.locator('a');
         const count = await dropdownLinks.count();
-        expect(count).toBe(9);
+        expect(count).toBe(10);
 
         // Verify group headers exist
         await expect(morePanel.getByText('功能')).toBeVisible();


### PR DESCRIPTION
## Summary
- 「許願 & 反饋」分組由 4 條增為 5 條後 (`Layout.astro` 現為 5 + 5),`e2e/nav-rwd.spec.ts:101` 仍硬編碼 `expect(count).toBe(9)`,Laptop 與 Desktop viewport 兩個 spec 因此 fail。
- 將斷言改成 10、註解同步 5 + 5,測試 title 也由「9 items」改成「10 items」。

## Test plan
- [x] `bun run playwright test e2e/nav-rwd.spec.ts -g "更多.*dropdown opens"` → 2 passed (Laptop + Desktop)

## Context
- 出自 2026-05-08 手動 deploy 後的 e2e 健檢
- 部署 URL: https://596199fb.cyclone-26.pages.dev (production: https://cyclone.tw)
- Tracking issue: #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)