### PR TITLE
fix(e2e): messages-auth 登入按鈕 strict locator violation

### DIFF
--- a/e2e/messages-auth.spec.ts
+++ b/e2e/messages-auth.spec.ts
@@ -74,7 +74,9 @@ test.describe('Messages Auth — E2E', () => {
     if (!authDeployed) test.skip();
     await page.goto('/discuss');
     await page.waitForLoadState('networkidle');
-    const loginBtn = page.getByRole('button', { name: /登入/i });
+    // Multiple "登入" buttons exist on the page (nav LoginButton + in-page CTA);
+    // verify at least one is visible.
+    const loginBtn = page.getByRole('button', { name: /登入/i }).first();
     await expect(loginBtn).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary
- `/discuss` 同時有 nav LoginButton + 頁內「請先登入再留言」按鈕,`getByRole('button', { name: /登入/i })` 命中 2 個,strict mode fail。
- 改用 `.first()` 對齊測試意圖「至少一個登入按鈕可見」,並補註解。

## Test plan
- [x] `bun run playwright test e2e/messages-auth.spec.ts -g "顯示登入按鈕"` → 1 passed

## Refs
- Tracking issue: #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)