### PR TITLE
fix(e2e): auth /admin 重導測試需等 React hydrate

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -20,6 +20,10 @@ test.describe('Authentication', () => {
   test('protected pages redirect when not logged in', async ({ page }) => {
     // Try accessing admin page
     await page.goto('/admin');
+    // /admin redirects to /admin/, then AdminPanel hydrates client-side and
+    // renders 登入 / 權限 text. Without networkidle, body is captured before
+    // React mounts and the assertion sees neither word.
+    await page.waitForLoadState('networkidle');
 
     // Should either redirect or show unauthorized
     const url = page.url();


### PR DESCRIPTION
## Summary
- `/admin` SSR 只送骨架(loading 動畫),「登入 / 權限」文字由 LoginButton 與 AdminPanel 在 client-side 注入。
- 原測試 `goto('/admin')` 後立刻 `body.textContent()`,React 還沒 mount,assertion `includes('權限') || includes('登入')` 拿到 false → fail。
- 加 `waitForLoadState('networkidle')` 等水合完成,補解釋註解。

## Test plan
- [x] `bun run playwright test e2e/auth.spec.ts -g "protected pages redirect"` → 1 passed

## Refs
- Tracking issue: #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)