### PR TITLE
fix(e2e): homepage 對齊現行 title 與 desktop nav 結構

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -4,8 +4,8 @@ test.describe('Homepage', () => {
   test('loads and shows title', async ({ page }) => {
     await page.goto('/');
 
-    // Title contains "Cyclone"
-    await expect(page).toHaveTitle(/Cyclone/);
+    // Title format: "<page> | AI 工作流共學團" — match the product name suffix.
+    await expect(page).toHaveTitle(/AI 工作流共學團/);
 
     // Nav bar is visible
     await expect(page.locator('nav')).toBeVisible();
@@ -14,10 +14,14 @@ test.describe('Homepage', () => {
   test('navigation links work', async ({ page }) => {
     await page.goto('/');
 
-    // Check key nav links exist
-    const nav = page.locator('nav');
-    await expect(nav.getByText('討論區')).toBeVisible();
-    await expect(nav.getByText('團隊')).toBeVisible();
+    // Desktop nav has 3 top-level items (首頁 / 說明 / 儀表板) plus a 「更多」 dropdown
+    // for the rest. Mobile/tablet collapses everything into the hamburger menu.
+    // Assert the 3 visible top-level links exist on a desktop viewport.
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const desktopNav = page.getByTestId('desktop-nav');
+    await expect(desktopNav.getByRole('link', { name: '首頁' })).toBeVisible();
+    await expect(desktopNav.getByRole('link', { name: '說明' })).toBeVisible();
+    await expect(desktopNav.getByRole('link', { name: '儀表板' })).toBeVisible();
   });
 
   test('theme toggle exists', async ({ page }) => {


### PR DESCRIPTION
## Summary
- **`:4` title**:現行 title 格式 `<page> | AI 工作流共學團`,不含 「Cyclone」。regex 從 `/Cyclone/` 改為 `/AI 工作流共學團/`。
- **`:14` navigation**:PR #24 後 desktop nav 改成 3 個 top-level 項(首頁 / 說明 / 儀表板)+「更多」dropdown;「團隊」「討論」都進了 dropdown 預設隱藏。改成在 1280×720 viewport 下檢查 3 個 top-level link 各自 visible,行為與 `nav-rwd.spec.ts` desktop 區段一致。

## Test plan
- [x] `bun run playwright test e2e/homepage.spec.ts` → 3 passed (含原本就 pass 的 `:23` theme toggle)

## Refs
- Tracking issue: #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)