### PR TITLE
fix(e2e): issue-27 Bug 1 wishlist fixture 對齊現行 schema

### DIFF
--- a/e2e/issue-27.spec.ts
+++ b/e2e/issue-27.spec.ts
@@ -58,7 +58,12 @@ test.describe('Issue #27 — regression gate', () => {
             createdAt: sqliteNaiveUtc(30_000),
             updatedAt: sqliteNaiveUtc(30_000),
             wisher: { id: 'u1', name: '測試者', avatarUrl: null },
-            claimer: null,
+            // WishBoard.tsx now expects `claimers: WishClaimer[]` + `history`
+            // (singular `claimer` was removed in a refactor). Without these
+            // shape-correct fields the card would throw at render time and
+            // the title would never appear.
+            claimers: [],
+            history: [],
           },
         ],
       });


### PR DESCRIPTION
## Summary
issue-27 Bug 1 是 wishlist「剛剛」時間戳渲染的 regression gate,但這次失敗的根因不是 prod 退化,而是 **fixture stale**:

- `src/components/wishlist/WishBoard.tsx` 在某次 refactor 把 `claimer: WishClaimer | null` 換成 `claimers: WishClaimer[]`,並新增 `history: WishHistoryEntry[]`(都是必填)。
- 現行渲染路徑會立即讀 `wish.claimers.some(...)`、`wish.claimers.length`、`wish.history.length` (參見 line 572 / 574 / 633 / 889 等),fixture 給 `claimer: null`、缺 history,渲染時 throw,整張卡片永遠不出現。
- 測試斷言 `getByText('E2E fixture: time gate')` 因此 timeout → regression gate 變成永遠 fail 的假警報。

修法:把 fixture 換成 `claimers: []` + `history: []`,並加註解避免再被誤改回舊 shape。修好後 Bug 1 真正測得 timestamp 渲染為「剛剛」、不漂移成「N 小時前」。

## Test plan
- [x] `bun run playwright test e2e/issue-27.spec.ts -g "Bug 1"` → 1 passed (1.4s)

## Refs
- Tracking issue: #174
- Affected source(no change needed): `src/components/wishlist/WishBoard.tsx`(現行 schema 是對的,prod data 也一直是新格式)

🤖 Generated with [Claude Code](https://claude.com/claude-code)