### PR TITLE
chore(deploy): untrack local_deploy.sh + upgrade to wrangler-action@v3

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -49,13 +49,11 @@ jobs:
         run: bun run build
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: cyclone-26
-          directory: dist
-          gitSource: false
+          command: pages deploy dist --project-name cyclone-26 --branch main --commit-dirty=true
 
       - name: Commit version bump
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,14 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Claude / OMC state
 .omc/
+
+# Multi-CLI worker output (ephemeral)
+.claude/work/
+
+# Local manual deploy script (personal; auto-deploy via GitHub Actions)
+local_deploy.sh
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/local_deploy.sh
+++ b/local_deploy.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -e
-echo "Bumping version..."
-bun run bump:version
-echo "Building..."
-bun run build
-echo "Deploying to Cloudflare Pages..."
-bunx wrangler pages deploy dist --project-name=cyclone-26
-echo "Done!"


### PR DESCRIPTION
## Summary

- `local_deploy.sh` untracked via `.gitignore` + `git rm --cached` (personal fallback script, not for VCS)
- `cloudflare/pages-action@v1` (deprecated) → `cloudflare/wrangler-action@v3` with consistent `wrangler pages deploy` CLI invocation matching `local_deploy.sh`
- Root cause documented: CI was stalled because **GitHub Actions was disabled for this repository** (`HTTP 422: Actions has been disabled for this repository`). Must re-enable at: https://github.com/cyclone-tw/cyclone-workflow/settings/actions → "Allow all actions and reusable workflows"

## Test plan

- [ ] Merge this PR and verify the `Cloudflare Pages Deploy` workflow runs (after re-enabling Actions in repo settings)
- [ ] Confirm deploy succeeds via wrangler-action@v3 logs
- [ ] Verify `local_deploy.sh` is no longer tracked (`git ls-files local_deploy.sh` returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)