### PR TITLE
fix(#5): 管家對話隱私強化 Tier 1

### DIFF
--- a/docs/superpowers/plans/2026-05-18-issue5-agent-privacy-hardening.md
+++ b/docs/superpowers/plans/2026-05-18-issue5-agent-privacy-hardening.md
@@ -1,0 +1,484 @@
+# 管家對話隱私強化(Tier 1)Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 堵掉 `/api/agent/history` 公開資料外洩(P1),杜絕 `userId` 偽造,並補上 footer 隱私聲明與 `/agent` 誠實措辭。
+
+**Architecture:** 管家對話維持公開可聊;歷史查詢改為需登入且 self-scoped(`WHERE user_id = ?` 綁 session)。`userId` 一律由伺服器端 `getSessionUser` 推導,前端不再傳。共用單一 Letta agent 不動(Tier 2 另開 issue)。
+
+**Tech Stack:** Astro 6(static)、Cloudflare Pages Functions、React 19、Turso(libSQL)、vitest(`tests/`)、Playwright(`e2e/`)。
+
+**測試現況說明:** 專案 `functions/` 無單元測試框架(僅 `e2e/` Playwright + `tests/` vitest 元件測試)。本計畫 API 行為以 E2E 驗證(對 `https://cyclone.tw`,部署前紅、部署後綠)+ 嚴格 code review;ChatBox 401 處理另加 vitest 元件測試(可即時紅綠)。
+
+---
+
+## File Structure
+
+| 檔案 | 動作 | 責任 |
+|---|---|---|
+| `src/layouts/Layout.astro` | 修改 footer | 加隱私聲明一行 |
+| `functions/api/agent/history.ts` | 修改 | 加登入驗證 + `WHERE user_id` self-scope |
+| `functions/api/agent/chat.ts` | 修改 | 移除 body `userId`,改用 session;匿名不存歷史 |
+| `src/components/agent/ChatBox.tsx` | 修改 | 移除假 `USER_ID`;歷史分頁處理 401 |
+| `src/pages/agent/index.astro` | 修改 | 措辭軟化,不過度承諾私人記憶 |
+| `tests/components/ChatBox.test.tsx` | 新增 | 驗證 401 → 登入提示 |
+| `e2e/agent-privacy.spec.ts` | 新增 | 匿名點歷史見登入提示 / 匿名可聊 / footer 文字 |
+| `src/lib/changelog.ts` | 修改 | 加 changelog 條目 |
+
+---
+
+## Task 1: Footer 隱私聲明
+
+**Files:**
+- Modify: `src/layouts/Layout.astro:220-231`
+
+- [ ] **Step 1: 在 footer 容器內、flex 列之後加一行隱私說明**
+
+把現有 footer 區塊改為:
+
+```astro
+    <!-- Footer -->
+    <footer class="border-t border-[var(--color-border)] mt-20">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-[var(--color-text-muted)]">
+          <p>2026 Q2 — Cyclone 隊長 × 生活黑客共學團</p>
+          <p>
+            <a href="/changelog" class="hover:text-[var(--color-primary)] transition-colors">{VERSION}</a>
+            · Built with Astro + Cloudflare Pages
+          </p>
+        </div>
+        <p class="mt-4 text-center text-xs text-[var(--color-text-muted)] leading-relaxed">
+          本站前台僅顯示成員自願提供的公開資訊(暱稱、代表色、角色、自介),不對外公開其他個資。
+        </p>
+      </div>
+    </footer>
+```
+
+- [ ] **Step 2: 驗證 build**
+
+Run: `bun run build`
+Expected: build 成功,無新錯誤。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/layouts/Layout.astro
+git commit -m "feat(issue-5): footer 加隱私聲明"
+```
+
+---
+
+## Task 2: history.ts 加登入驗證 + self-scope(B1 — P1 修補)
+
+**Files:**
+- Modify: `functions/api/agent/history.ts`
+
+- [ ] **Step 1: import `getSessionUser`**
+
+在檔案最上方 import 後加:
+
+```ts
+import { getSessionUser } from '../../../src/lib/auth.ts';
+```
+
+- [ ] **Step 2: `onRequestGet` 開頭加登入檢查**
+
+在 `try {` 之後、`createClient` 之前插入:
+
+```ts
+    const sessionUser = await getSessionUser(context.request, context.env);
+    if (!sessionUser) {
+      return new Response(JSON.stringify({ ok: false, error: '請先登入' }), {
+        status: 401, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+```
+
+- [ ] **Step 3: 查詢一律 self-scope 到 `sessionUser.id`**
+
+把原本的 query 建構區塊(`let countSql = ...` 到 `args.push(limit, offset);`)整段換成:
+
+```ts
+    let countSql = 'SELECT COUNT(*) as total FROM chat_history WHERE user_id = ?';
+    let dataSql = 'SELECT * FROM chat_history WHERE user_id = ?';
+    const args: (string | number)[] = [sessionUser.id];
+    const countArgs: (string | number)[] = [sessionUser.id];
+
+    if (search) {
+      const searchParam = `%${search}%`;
+      const and = ' AND (user_message LIKE ? OR agent_reply LIKE ?)';
+      countSql += and;
+      countArgs.push(searchParam, searchParam);
+      dataSql += and;
+      args.push(searchParam, searchParam);
+    }
+
+    dataSql += ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
+    args.push(limit, offset);
+```
+
+> 注意:search 條件用 `AND (… OR …)` 加括號,避免 `WHERE user_id = ? AND a OR b` 的運算子優先序漏洞。
+
+- [ ] **Step 4: 驗證**
+
+Run: `bunx tsc --noEmit -p .` (或 `bun run build`)
+Expected: 無型別錯誤。行為驗證見 Task 7 的 E2E。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/api/agent/history.ts
+git commit -m "fix(issue-5): /api/agent/history 加登入驗證 + self-scope 修補 P1 外洩"
+```
+
+---
+
+## Task 3: chat.ts 杜絕 userId 偽造(B2)
+
+**Files:**
+- Modify: `functions/api/agent/chat.ts`
+
+- [ ] **Step 1: import `getSessionUser`**
+
+在頂部 import `createClient` 後加:
+
+```ts
+import { getSessionUser } from '../../../src/lib/auth.ts';
+```
+
+- [ ] **Step 2: 移除 body 取 `userId`**
+
+把 `onRequestPost` 內:
+
+```ts
+    const { message, userId = 'anonymous' } = await context.request.json() as { message?: string; userId?: string };
+```
+
+改為:
+
+```ts
+    const { message } = await context.request.json() as { message?: string };
+```
+
+- [ ] **Step 3: 用 session 決定是否寫入歷史(核心隱私決策)**
+
+把結尾的 `context.waitUntil(saveChat(context.env, userId, message, finalReply));` 換成:
+
+```ts
+    // 隱私決策:只有登入成員的對話寫入可辨識歷史;匿名訪客可聊但不留紀錄。
+    const sessionUser = await getSessionUser(context.request, context.env);
+    if (sessionUser) {
+      context.waitUntil(saveChat(context.env, sessionUser.id, message, finalReply));
+    }
+```
+
+- [ ] **Step 4: 驗證**
+
+Run: `bun run build`
+Expected: 無型別錯誤(`userId` 已無未用變數警告)。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/api/agent/chat.ts
+git commit -m "fix(issue-5): /api/agent/chat 改用 session 身份,匿名對話不留歷史"
+```
+
+---
+
+## Task 4: ChatBox.tsx 移除假 userId + 處理 401(B3)
+
+**Files:**
+- Modify: `src/components/agent/ChatBox.tsx`
+- Create: `tests/components/ChatBox.test.tsx`
+
+- [ ] **Step 1: 寫失敗測試 — 401 顯示登入提示**
+
+建立 `tests/components/ChatBox.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ChatBox from '@/components/agent/ChatBox';
+
+describe('ChatBox 歷史分頁', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ ok: false, error: '請先登入' }), { status: 401 }),
+      ),
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('history 回 401 時顯示登入提示', async () => {
+    render(<ChatBox />);
+    fireEvent.click(screen.getByText(/📜 歷史/));
+    // getByText 找不到會 throw,waitFor 內即為斷言
+    await waitFor(() => screen.getByText(/登入後即可查看/));
+  });
+});
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `bun run test -- tests/components/ChatBox.test.tsx`
+Expected: FAIL — 目前 `HistoryPanel` 不處理 401,不會出現「登入後即可查看」。
+
+- [ ] **Step 3: 移除假 `USER_ID`**
+
+刪除第 20 行:
+
+```tsx
+const USER_ID = 'user-' + Math.random().toString(36).slice(2, 9);
+```
+
+並把 `sendMessage` 內的 fetch body:
+
+```tsx
+        body: JSON.stringify({ message: text, userId: USER_ID }),
+```
+
+改為:
+
+```tsx
+        body: JSON.stringify({ message: text }),
+```
+
+- [ ] **Step 4: `HistoryPanel` 加 `needLogin` 狀態**
+
+在 `HistoryPanel` 的 state 宣告區加:
+
+```tsx
+  const [needLogin, setNeedLogin] = useState(false);
+```
+
+把 `fetchHistory` 改為:
+
+```tsx
+  const fetchHistory = async (p: number, q: string) => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(p) });
+      if (q) params.set('search', q);
+      const res = await fetch(`/api/agent/history?${params}`);
+      if (res.status === 401) {
+        setNeedLogin(true);
+        setHistory([]);
+        return;
+      }
+      setNeedLogin(false);
+      const data = await res.json();
+      if (data.ok) {
+        setHistory(data.history);
+        setTotalPages(data.totalPages);
+        setTotal(data.total);
+      }
+    } catch { /* ignore */ } finally { setLoading(false); }
+  };
+```
+
+- [ ] **Step 5: `HistoryPanel` render 加 needLogin 分支**
+
+在 `HistoryPanel` 的 `return (` 之後、最外層 `<div>` 內,把 search bar 那段之前插入早返判斷 —— 即把整個 return 改為:當 `needLogin` 為真,只渲染登入提示:
+
+```tsx
+  if (needLogin) {
+    return (
+      <div className="flex flex-col items-center justify-center text-center" style={{ minHeight: '380px' }}>
+        <div className="text-3xl mb-3">🔒</div>
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>登入後即可查看你的對話紀錄</p>
+        <p className="text-xs mt-1" style={{ color: 'var(--color-text-muted)' }}>對話紀錄僅本人可見</p>
+      </div>
+    );
+  }
+
+  return (
+```
+
+(其餘原本的 return 內容不變。)
+
+- [ ] **Step 6: 跑測試確認通過**
+
+Run: `bun run test -- tests/components/ChatBox.test.tsx`
+Expected: PASS。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/agent/ChatBox.tsx tests/components/ChatBox.test.tsx
+git commit -m "fix(issue-5): ChatBox 移除偽造 userId,歷史分頁處理未登入 401"
+```
+
+---
+
+## Task 5: /agent 頁面措辭軟化(C)
+
+**Files:**
+- Modify: `src/pages/agent/index.astro`
+
+原則:移除「跨對話記住你的偏好 / 越用越懂你」這類在共用 agent 下不屬實、且暗示私人記憶的措辭。保留屬實描述。改後 card 3 反而能誠實寫出「僅本人可見」這個修補成果。
+
+- [ ] **Step 1: 改 meta description(`:6`)**
+
+```astro
+<Layout title="Cyclone 管家" description="共學團專屬 AI 管家 — 隨時為你解答 AI 工作流問題、推薦工具">
+```
+
+- [ ] **Step 2: 改 header 介紹段(`:19-21`)**
+
+```astro
+        共學團的專屬 AI 管家,幫你把 AI 真的用起來。推薦工具、解答疑問、陪你規劃學習方向。<br />
+        隨時提問、尋求建議,或讓她幫你整理共學資料。
+```
+
+- [ ] **Step 3: 改三張資訊卡(`:30-52`)**
+
+卡 1:
+
+```astro
+      <div class="glass rounded-xl p-5 card-hover">
+        <div class="text-2xl mb-3">🧠</div>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-primary-light)">Letta 驅動</h3>
+        <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
+          管家由 <span style="color: var(--color-primary-light)">Letta 平台</span>驅動,協助你設計與優化 AI 工作流。
+        </p>
+      </div>
+```
+
+卡 2:
+
+```astro
+      <div class="glass rounded-xl p-5 card-hover">
+        <div class="text-2xl mb-3">💬</div>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-blue)">即時問答</h3>
+        <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
+          工具推薦、流程串接,還是學習方向 —— 隨時都能問管家,給你具體可行的建議。
+        </p>
+      </div>
+```
+
+卡 3:
+
+```astro
+      <div class="glass rounded-xl p-5 card-hover">
+        <div class="text-2xl mb-3">🔒</div>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-green)">對話僅本人可見</h3>
+        <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
+          登入後,你的對話紀錄安全存於 <span style="color: var(--color-neon-green)">Turso 資料庫</span>,且僅你本人查得到。
+        </p>
+      </div>
+```
+
+- [ ] **Step 4: 改底部說明(`:57-58`)**
+
+```astro
+    <p class="text-center text-xs mt-6" style="color: var(--color-text-muted)">
+      Cyclone 管家由 Letta 驅動 · 登入後對話紀錄存於 Turso 且僅本人可見 · 專為共學團打造
+    </p>
+```
+
+- [ ] **Step 5: 驗證 build + Commit**
+
+```bash
+bun run build
+git add src/pages/agent/index.astro
+git commit -m "feat(issue-5): /agent 措辭軟化,不過度承諾私人記憶"
+```
+
+---
+
+## Task 6: E2E 測試 — 管家隱私
+
+**Files:**
+- Create: `e2e/agent-privacy.spec.ts`
+
+- [ ] **Step 1: 寫 E2E spec**
+
+```ts
+import { test, expect } from './lambdatest-setup';
+
+test.describe('管家隱私(issue #5)', () => {
+  test('未登入訪客點「歷史」分頁 → 看到登入提示,看不到對話資料', async ({ page }) => {
+    await page.goto('/agent');
+    // 切到歷史分頁
+    await page.getByRole('button', { name: /歷史/ }).click();
+    // 應出現登入提示,而非任何人的對話紀錄
+    await expect(page.getByText(/登入後即可查看/)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('匿名訪客可使用聊天輸入框(管家維持公開)', async ({ page }) => {
+    await page.goto('/agent');
+    const input = page.getByplaceholder(/跟管家說點什麼/);
+    await expect(input).toBeVisible();
+    await expect(input).toBeEnabled();
+  });
+
+  test('footer 顯示隱私聲明', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('footer')).toContainText('不對外公開其他個資');
+  });
+});
+```
+
+- [ ] **Step 2: 跑 E2E(部署前 — 預期紅)**
+
+Run: `bun run test:e2e -- e2e/agent-privacy.spec.ts`
+Expected: FAIL(對 `https://cyclone.tw` 跑,目前線上是舊版:歷史會顯示資料、footer 無隱私聲明)。記錄此為「部署前紅」基準。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/agent-privacy.spec.ts
+git commit -m "test(e2e): issue-5 管家隱私 — 歷史登入閘 / 匿名可聊 / footer 聲明"
+```
+
+> 部署後綠化驗證見 Task 7。
+
+---
+
+## Task 7: changelog + Task 3 驗證 + 交付
+
+**Files:**
+- Modify: `src/lib/changelog.ts`
+
+- [ ] **Step 1: 加 changelog 條目**
+
+讀 `src/lib/changelog.ts`,比照現有 `ChangelogEntry` 格式,在 `CHANGELOG` 陣列**最前面**加一筆(`version` 用今日 `v20260518.xxxx` 格式,`date` 用 UTC+8 `2026-05-18`),內容涵蓋:管家對話歷史隱私修補、footer 隱私聲明、/agent 措辭調整。
+
+```bash
+git add src/lib/changelog.ts
+git commit -m "docs(issue-5): 更新 changelog"
+```
+
+- [ ] **Step 2: Task 3 驗證(無程式碼)**
+
+Code trace 確認:`functions/api/auth/callback.ts:156-164` 真・新使用者建為 `status='pending'` → `src/lib/auth.ts:216-221` `requireAuth` 對 pending 回 403。結論:非名單 Google 帳號登入無法取得陪跑員存取權。記錄於 issue 回報(Step 6)。
+
+- [ ] **Step 3: 完整驗證**
+
+Run: `bun run build && bun run test`
+Expected: build 成功;vitest 全綠(含新的 ChatBox 測試)。
+
+- [ ] **Step 4: 開 PR(draft)**
+
+推分支 `fix-5-agent-privacy-hardening`,以 `gh pr create --draft` 開 PR,標題 `fix(issue-5): 管家對話隱私強化 Tier 1`,body 連結 issue #5、列出變更與稽核發現。
+
+- [ ] **Step 5: local deploy**
+
+依 `project_deploy-workflow.md` 執行 local deploy(`local_deploy.sh` 或專案現行流程)。無 DB schema 變更,不需 `/api/db/init`。
+
+- [ ] **Step 6: 部署後綠化 + issue 回報**
+
+- 對 `https://cyclone.tw` 重跑 `bun run test:e2e -- e2e/agent-privacy.spec.ts`,確認三條全綠(錄 video 供 PR)。
+- 於 issue #5 留言 @tboydar:回報 Task 3 早已修復、本次新發現的 history 外洩與 Tier 1 修補、Tier 2(每人專屬 agent)建議另開 issue。
+
+---
+
+## Self-Review 註記
+
+- **Spec 覆蓋:** A→Task1、B1→Task2、B2→Task3、B3→Task4、C→Task5、D→Task7 Step2、測試→Task4+6、部署→Task7。全覆蓋。
+- **共用 agent 殘留風險:** 已知,Tier 1 範圍外,Task7 Step6 會建議另開 Tier 2 issue。
+- **舊 `chat_history` 亂數資料:** Task2 self-scope 後 API 已不可達,不另清理(YAGNI)。

--- a/docs/superpowers/specs/2026-05-18-issue5-agent-privacy-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue5-agent-privacy-hardening-design.md
@@ -1,0 +1,103 @@
+# Issue #5 — 管家對話隱私強化(Tier 1)設計
+
+- **狀態:** 已核准(2026-05-18,user 於 brainstorming 拍板)
+- **Issue:** #5 🔒 隱私與成員資料公開:同意機制與資料安全盤點
+- **範圍:** Tier 1 止血。Tier 2(每位成員專屬 Letta agent)另開 issue。
+
+## 背景
+
+#5 稽核發現管家(`/agent`)對話有 P1 等級資料外洩:
+
+1. **`/api/agent/history` 公開外洩** — 無登入驗證、無 user 過濾,`SELECT * FROM chat_history`
+   回傳全部成員的對話。`/agent` 是公開靜態頁,任何人點「📜 歷史」分頁即可分頁 + 搜尋
+   全員與管家的私人對話。(`history.ts:29`、`ChatBox.tsx:44`)
+2. **`userId` 可偽造** — `chat.ts` 的 `userId` 來自 request body、預設 `'anonymous'`;
+   `ChatBox.tsx:20` 的 `USER_ID` 是前端 `Math.random()` 亂數。`chat_history.user_id`
+   整欄無意義,無法對應真實成員。
+3. **共用單一 agent** — 19 位成員共用同一個 Letta agent + memory block
+   (`chat.ts:73` 寫死 `agent-0f132a48…`)。
+
+附帶確認:Task 3(非名單 Google 帳號自動取得陪跑員)在 `callback.ts:157` 已修復
+(真・新使用者建為 `status='pending'`,`auth.ts:216` `requireAuth` 回 403)。本次僅驗證,不改碼。
+
+## 目標
+
+- 堵掉 `/api/agent/history` 外洩孔(P1)。
+- 杜絕 `userId` 偽造 — 一律由伺服器端 session 推導。
+- 管家對話**維持公開**(匿名訪客可聊),但匿名對話不寫入可辨識歷史。
+- Footer 加隱私聲明。
+- `/agent` 頁面措辭軟化,避免過度承諾跨成員「長期記憶」。
+
+## 不做(YAGNI / 另開 issue)
+
+- 每位成員專屬 Letta agent(Tier 2 — 真記憶隔離)。
+- 清理舊 `chat_history` 亂數資料(self-scoped 查詢後已 API 不可達;若要清,另備份處理)。
+- 共用 agent memory block 混用問題。
+
+## 變更項目
+
+### A. Footer 隱私聲明
+- 檔案:`src/layouts/Layout.astro`(footer `:221-231`)。
+- 新增一行隱私說明,沿用既有 `text-sm text-[var(--color-text-muted)]` 樣式。
+- 文案:**「本站前台僅顯示成員自願提供的公開資訊(暱稱、代表色、角色、自介),不對外公開其他個資。」**
+  - 採精準版。owner 範本原文為「不收集敏感個資」,但 owner 在 #5 亦說明「詳細個資僅後台管理可見」
+    — 代表敏感資料有收集只是不公開,故改為「不對外公開」以免與事實矛盾。
+
+### B1. `functions/api/agent/history.ts` — 堵 P1 外洩
+- import `getSessionUser` from `../../../src/lib/auth.ts`。
+- 未登入 → 回 401 `{ ok: false, error: '請先登入' }`。
+- `countSql` 與 `dataSql` 一律加上 `WHERE user_id = ?`(與既有 search 條件以 AND 串接)。
+- 綁定 `sessionUser.id`。效果:登入者只看得到自己的對話;舊的亂數 `user_id` 資料對不到
+  任何真實 user → API 不可達。
+
+### B2. `functions/api/agent/chat.ts` — 杜絕 userId 偽造
+- 移除「從 request body 取 `userId`」整段。
+- 改用 `getSessionUser`(**非** `requireAuth` — 維持公開可聊)。
+- 登入者 → `saveChat` 以 `sessionUser.id` 寫入。
+- 未登入者 → **不呼叫 `saveChat`**(匿名對話不留可辨識歷史)。
+- chat 端點對所有人開放不變;Letta 呼叫邏輯不變。
+
+### B3. `src/components/agent/ChatBox.tsx`
+- 移除 `USER_ID = Math.random()` 常數;`sendMessage` 的 request body 不再帶 `userId`。
+- `HistoryPanel.fetchHistory`:處理 401 回應 → 設 `needLogin` 狀態 →
+  歷史分頁顯示「登入後即可查看你的對話紀錄」(非錯誤、非空白)。
+
+### C. `/agent` 頁面措辭軟化
+- 檔案:`src/pages/agent/index.astro`。
+- 現有「長期記憶 / 越用越懂你 / 記住你的偏好」等措辭會讓使用者誤以為已有跨成員隔離的私人記憶。
+- 原則:措辭調整為**不承諾跨成員私人記憶**(共用 agent 下不屬實);保留「對話紀錄存於 Turso」
+  等屬實描述。實作時定稿具體字句(UI 文案)。
+
+### D. Task 3 驗證(無程式碼)
+- 程式碼追蹤確認 `callback.ts` pending 流程 + `requireAuth` 403。
+- E2E 確認 pending 狀態 user 被導向 `/pending`。
+- 完成後於 issue #5 留言回報 owner:Task 3 早已修復;並揭露本次新發現的 history 外洩與修補。
+
+## 資料流(修補後)
+
+```
+匿名訪客  → 聊天 ✓  → Letta 回覆 ✓  → 不存 DB
+登入成員  → 聊天 ✓  → Letta 回覆 ✓  → saveChat(user_id = session.id)
+登入成員  → 歷史分頁 → WHERE user_id = session.id → 只有自己的對話
+未登入    → 歷史分頁 → 401 → 「登入後即可查看你的對話紀錄」
+```
+
+## 錯誤處理
+
+- `/api/agent/history` 401:`ChatBox` 友善提示,不顯示錯誤紅框。
+- `/api/agent/chat` 對未登入者:正常回覆,`saveChat` 跳過。
+- `saveChat` 既有 best-effort `try/catch` 維持不變。
+
+## 測試
+
+- E2E(`e2e/`)三條:
+  1. 未登入點「歷史」→ 看到登入提示。
+  2. 登入後「歷史」→ 只有自己的對話(self-scoped)。
+  3. 匿名聊天 → 可正常運作。
+- `bun run build` + 既有 test 綠燈。
+
+## 部署
+
+- 走 PR:branch `fix-5-agent-privacy-hardening`。
+- **無 DB schema 變更**,不需 migration / `/api/db/init`。
+- 完成後 local deploy。

--- a/e2e/agent-privacy.spec.ts
+++ b/e2e/agent-privacy.spec.ts
@@ -3,8 +3,13 @@ import { test, expect } from './lambdatest-setup';
 test.describe('管家隱私(issue #5)', () => {
   test('未登入訪客點「歷史」分頁 → 看到登入提示,而非他人對話', async ({ page }) => {
     await page.goto('/agent');
-    await page.getByRole('button', { name: /歷史/ }).click();
-    await expect(page.getByText(/登入後即可查看/)).toBeVisible({ timeout: 10_000 });
+    const historyTab = page.getByRole('button', { name: /歷史/ });
+    // ChatBox 是 client:load React 元件 — 首次點擊可能早於 hydration,
+    // 用 toPass 重試「點擊 + 斷言」直到 hydration 完成,避免時序 flake。
+    await expect(async () => {
+      await historyTab.click();
+      await expect(page.getByText(/登入後即可查看/)).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 20_000 });
   });
 
   test('匿名訪客可使用聊天輸入框(管家維持公開)', async ({ page }) => {

--- a/e2e/agent-privacy.spec.ts
+++ b/e2e/agent-privacy.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from './lambdatest-setup';
+
+test.describe('管家隱私(issue #5)', () => {
+  test('未登入訪客點「歷史」分頁 → 看到登入提示,而非他人對話', async ({ page }) => {
+    await page.goto('/agent');
+    await page.getByRole('button', { name: /歷史/ }).click();
+    await expect(page.getByText(/登入後即可查看/)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('匿名訪客可使用聊天輸入框(管家維持公開)', async ({ page }) => {
+    await page.goto('/agent');
+    const input = page.getByPlaceholder(/跟管家說點什麼/);
+    await expect(input).toBeVisible();
+    await expect(input).toBeEnabled();
+  });
+
+  test('footer 顯示隱私聲明', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('footer')).toContainText('不對外公開其他個資');
+  });
+});

--- a/functions/api/agent/chat.ts
+++ b/functions/api/agent/chat.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { getSessionUser } from '../../../src/lib/auth.ts';
 
 interface Env {
   LETTA_API_KEY: string;
@@ -130,7 +131,7 @@ async function syncPersona(apiKey: string, agentId: string): Promise<void> {
 
 export const onRequestPost: PagesFunction<Env> = async (context) => {
   try {
-    const { message, userId = 'anonymous' } = await context.request.json() as { message?: string; userId?: string };
+    const { message } = await context.request.json() as { message?: string };
 
     if (!message?.trim()) {
       return new Response(JSON.stringify({ error: '請輸入訊息' }), {
@@ -172,8 +173,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
 
     const finalReply = reply || '（管家正在思考中...）';
 
-    // Save to DB (non-blocking)
-    context.waitUntil(saveChat(context.env, userId, message, finalReply));
+    // 隱私決策:只有登入成員的對話寫入可辨識歷史;匿名訪客可聊但不留紀錄。
+    const sessionUser = await getSessionUser(context.request, context.env);
+    if (sessionUser) {
+      context.waitUntil(saveChat(context.env, sessionUser.id, message, finalReply));
+    }
 
     return new Response(
       JSON.stringify({ reply: finalReply, thoughts, agentId }),

--- a/functions/api/agent/history.ts
+++ b/functions/api/agent/history.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@libsql/client/web';
+import { getSessionUser } from '../../../src/lib/auth.ts';
 
 interface Env {
   TURSO_DATABASE_URL: string;
@@ -7,6 +8,13 @@ interface Env {
 
 export const onRequestGet: PagesFunction<Env> = async (context) => {
   try {
+    const sessionUser = await getSessionUser(context.request, context.env);
+    if (!sessionUser) {
+      return new Response(JSON.stringify({ ok: false, error: '請先登入' }), {
+        status: 401, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     const db = createClient({ url: context.env.TURSO_DATABASE_URL, authToken: context.env.TURSO_AUTH_TOKEN });
 
     await db.execute({
@@ -26,17 +34,17 @@ export const onRequestGet: PagesFunction<Env> = async (context) => {
     const limit = 10;
     const offset = (page - 1) * limit;
 
-    let countSql = 'SELECT COUNT(*) as total FROM chat_history';
-    let dataSql = 'SELECT * FROM chat_history';
-    const args: (string | number)[] = [];
-    const countArgs: string[] = [];
+    let countSql = 'SELECT COUNT(*) as total FROM chat_history WHERE user_id = ?';
+    let dataSql = 'SELECT * FROM chat_history WHERE user_id = ?';
+    const args: (string | number)[] = [sessionUser.id];
+    const countArgs: string[] = [sessionUser.id];
 
     if (search) {
-      const where = ' WHERE user_message LIKE ? OR agent_reply LIKE ?';
       const searchParam = `%${search}%`;
-      countSql += where;
+      const and = ' AND (user_message LIKE ? OR agent_reply LIKE ?)';
+      countSql += and;
       countArgs.push(searchParam, searchParam);
-      dataSql += where;
+      dataSql += and;
       args.push(searchParam, searchParam);
     }
 

--- a/src/components/agent/ChatBox.tsx
+++ b/src/components/agent/ChatBox.tsx
@@ -17,8 +17,6 @@ const WELCOME_MESSAGE: Message = {
   timestamp: new Date(),
 };
 
-const USER_ID = 'user-' + Math.random().toString(36).slice(2, 9);
-
 interface HistoryItem {
   id: number;
   user_id: string;
@@ -35,6 +33,7 @@ function HistoryPanel() {
   const [search, setSearch] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [loading, setLoading] = useState(true);
+  const [needLogin, setNeedLogin] = useState(false);
 
   const fetchHistory = async (p: number, q: string) => {
     setLoading(true);
@@ -42,6 +41,12 @@ function HistoryPanel() {
       const params = new URLSearchParams({ page: String(p) });
       if (q) params.set('search', q);
       const res = await fetch(`/api/agent/history?${params}`);
+      if (res.status === 401) {
+        setNeedLogin(true);
+        setHistory([]);
+        return;
+      }
+      setNeedLogin(false);
       const data = await res.json();
       if (data.ok) {
         setHistory(data.history);
@@ -54,6 +59,16 @@ function HistoryPanel() {
   useEffect(() => { fetchHistory(page, search); }, [page, search]);
 
   const handleSearch = () => { setPage(1); setSearch(searchInput); };
+
+  if (needLogin) {
+    return (
+      <div className="flex flex-col items-center justify-center text-center" style={{ minHeight: '380px' }}>
+        <div className="text-3xl mb-3">🔒</div>
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>登入後即可查看你的對話紀錄</p>
+        <p className="text-xs mt-1" style={{ color: 'var(--color-text-muted)' }}>對話紀錄僅本人可見</p>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col" style={{ minHeight: '380px' }}>
@@ -156,7 +171,7 @@ export default function ChatBox() {
       const res = await fetch('/api/agent/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text, userId: USER_ID }),
+        body: JSON.stringify({ message: text }),
       });
 
       if (!res.ok) throw new Error(`HTTP ${res.status}`);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -227,6 +227,9 @@ const currentPath = Astro.url.pathname;
             · Built with Astro + Cloudflare Pages
           </p>
         </div>
+        <p class="mt-4 text-center text-xs text-[var(--color-text-muted)] leading-relaxed">
+          本站前台僅顯示成員自願提供的公開資訊（暱稱、代表色、角色、自介），不對外公開其他個資。
+        </p>
       </div>
     </footer>
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,15 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-05-18',
+    changes: [
+      'fix(#5): 管家對話歷史隱私修補 — /api/agent/history 加登入驗證,僅顯示本人對話(原本無驗證、外洩全員對話)',
+      'fix(#5): /api/agent/chat 改用 session 身份,杜絕前端偽造 userId;匿名對話不寫入歷史',
+      'feat(#5): footer 加隱私聲明;/agent 頁面措辭調整,不過度承諾私人記憶',
+    ],
+  },
+  {
+    version: '',
     date: '2026-05-04',
     changes: [
       'feat(#165): 討論區留言內容過長時加入展開 / 收納效果 — Mirror 既有 AI 工具箱 / 知識庫卡片 pattern',

--- a/src/pages/agent/index.astro
+++ b/src/pages/agent/index.astro
@@ -3,7 +3,7 @@ import Layout from '@/layouts/Layout.astro';
 import ChatBox from '@/components/agent/ChatBox';
 ---
 
-<Layout title="Cyclone 管家" description="共學團專屬 AI 管家 — 記住你的對話與偏好，隨時為你服務">
+<Layout title="Cyclone 管家" description="共學團專屬 AI 管家 — 隨時為你解答 AI 工作流問題、推薦工具">
   <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
 
     <!-- Header -->
@@ -16,7 +16,7 @@ import ChatBox from '@/components/agent/ChatBox';
         <span class="gradient-text">🏠 Cyclone 管家</span>
       </h1>
       <p class="text-[var(--color-text-secondary)] max-w-lg mx-auto leading-relaxed">
-        共學團的專屬 AI 管家，幫你把 AI 真的用起來。記住你的學習目標、推薦工具、追蹤進度。<br />
+        共學團的專屬 AI 管家，幫你把 AI 真的用起來。推薦工具、解答疑問、陪你規劃學習方向。<br />
         隨時提問、尋求建議，或讓她幫你整理共學資料。
       </p>
     </div>
@@ -29,25 +29,25 @@ import ChatBox from '@/components/agent/ChatBox';
 
       <div class="glass rounded-xl p-5 card-hover">
         <div class="text-2xl mb-3">🧠</div>
-        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-primary-light)">長期記憶</h3>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-primary-light)">Letta 驅動</h3>
         <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
-          管家使用 <span style="color: var(--color-primary-light)">Letta 平台</span>的長期記憶架構，能跨對話記住你的習慣、偏好與重要資訊。
+          管家由 <span style="color: var(--color-primary-light)">Letta 平台</span>驅動，協助你設計與優化 AI 工作流。
         </p>
       </div>
 
       <div class="glass rounded-xl p-5 card-hover">
         <div class="text-2xl mb-3">💬</div>
-        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-blue)">記住你的偏好</h3>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-blue)">即時問答</h3>
         <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
-          不管是學習風格、對話語氣，或是特定的任務習慣，管家都會主動記錄，越用越懂你。
+          工具推薦、流程串接，還是學習方向 —— 隨時都能問管家，給你具體可行的建議。
         </p>
       </div>
 
       <div class="glass rounded-xl p-5 card-hover">
-        <div class="text-2xl mb-3">🗄️</div>
-        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-green)">資料安全存儲</h3>
+        <div class="text-2xl mb-3">🔒</div>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-green)">對話僅本人可見</h3>
         <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
-          對話記錄與記憶資料儲存於 <span style="color: var(--color-neon-green)">Turso 資料庫</span>，速度快、安全可靠。
+          登入後，你的對話紀錄安全存於 <span style="color: var(--color-neon-green)">Turso 資料庫</span>，且僅你本人查得到。
         </p>
       </div>
 
@@ -55,7 +55,7 @@ import ChatBox from '@/components/agent/ChatBox';
 
     <!-- Bottom note -->
     <p class="text-center text-xs mt-6" style="color: var(--color-text-muted)">
-      Cyclone 管家由 Letta + Cloudflare Workers AI 驅動 · 記憶存於 Turso · 專為共學團打造
+      Cyclone 管家由 Letta 驅動 · 登入後對話紀錄存於 Turso 且僅本人可見 · 專為共學團打造
     </p>
 
   </div>

--- a/src/pages/agent/index.astro
+++ b/src/pages/agent/index.astro
@@ -45,7 +45,7 @@ import ChatBox from '@/components/agent/ChatBox';
 
       <div class="glass rounded-xl p-5 card-hover">
         <div class="text-2xl mb-3">🔒</div>
-        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-green)">對話僅本人可見</h3>
+        <h3 class="font-semibold text-sm mb-2" style="color: var(--color-neon-green)">對話紀錄僅本人可見</h3>
         <p class="text-xs leading-relaxed" style="color: var(--color-text-secondary)">
           登入後，你的對話紀錄安全存於 <span style="color: var(--color-neon-green)">Turso 資料庫</span>，且僅你本人查得到。
         </p>

--- a/tests/unit/agent/history.test.ts
+++ b/tests/unit/agent/history.test.ts
@@ -1,0 +1,57 @@
+import './mock-db.ts';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { resetDb, seedUsers, seedChatHistory } from './mock-db.ts';
+
+const BASE = 'http://localhost:4321';
+type MockEnv = { TURSO_DATABASE_URL: string; TURSO_AUTH_TOKEN: string };
+
+function makeCtx(path: string, token?: string) {
+  return {
+    request: new Request(`${BASE}${path}`, {
+      method: 'GET',
+      headers: { ...(token ? { Cookie: `session=${token}` } : {}) },
+    }),
+    env: {} as MockEnv,
+    params: {},
+  };
+}
+
+interface HistoryResponse {
+  ok: boolean;
+  history: Array<{ user_id: string }>;
+  total: number;
+}
+
+describe('GET /api/agent/history — issue #5 隱私 self-scope', () => {
+  beforeEach(() => {
+    resetDb();
+    seedUsers();
+    seedChatHistory();
+  });
+
+  it('未登入應回 401,不外洩任何對話', async () => {
+    const { onRequestGet } = await import('../../../functions/api/agent/history.ts');
+    const res = await onRequestGet(makeCtx('/api/agent/history') as any);
+    expect(res.status).toBe(401);
+  });
+
+  it('登入者只看得到自己的對話,看不到其他成員的', async () => {
+    const { onRequestGet } = await import('../../../functions/api/agent/history.ts');
+    const res = await onRequestGet(makeCtx('/api/agent/history', 'valid-member-token') as any);
+    expect(res.status).toBe(200);
+    const data = await res.json() as HistoryResponse;
+    expect(data.ok).toBe(true);
+    expect(data.total).toBe(2);
+    expect(data.history.every((h) => h.user_id === 'member-1')).toBe(true);
+    expect(data.history.some((h) => h.user_id === 'member-2')).toBe(false);
+  });
+
+  it('看不到其他成員或修補前留下的亂數 user_id 對話', async () => {
+    const { onRequestGet } = await import('../../../functions/api/agent/history.ts');
+    const res = await onRequestGet(makeCtx('/api/agent/history', 'valid-other-token') as any);
+    const data = await res.json() as HistoryResponse;
+    expect(data.total).toBe(1);
+    expect(data.history[0].user_id).toBe('member-2');
+    expect(data.history.some((h) => h.user_id === 'user-legacyxx')).toBe(false);
+  });
+});

--- a/tests/unit/agent/mock-db.ts
+++ b/tests/unit/agent/mock-db.ts
@@ -1,0 +1,132 @@
+import { vi } from 'vitest';
+
+interface DbRow {
+  id: string | number;
+  [key: string]: unknown;
+}
+
+export const tables: Record<string, DbRow[]> = {
+  sessions: [],
+  users: [],
+  user_roles: [],
+  chat_history: [],
+};
+
+let _nextId = 100;
+
+export function resetDb() {
+  tables.sessions = [];
+  tables.users = [];
+  tables.user_roles = [];
+  tables.chat_history = [];
+  _nextId = 100;
+}
+
+export function seedUsers() {
+  tables.users = [
+    { id: 'member-1', name: 'Test Member', status: 'active', archived_at: null, discord_id: null },
+    { id: 'member-2', name: 'Other Member', status: 'active', archived_at: null, discord_id: null },
+  ];
+  tables.user_roles = [
+    { id: 'role-1', user_id: 'member-1', role: 'member' },
+    { id: 'role-2', user_id: 'member-2', role: 'member' },
+  ];
+  tables.sessions = [
+    {
+      id: 'sess-1',
+      user_id: 'member-1',
+      token: 'valid-member-token',
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      id: 'sess-2',
+      user_id: 'member-2',
+      token: 'valid-other-token',
+      expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+  ];
+}
+
+/**
+ * 種 chat_history:member-1 兩筆、member-2 一筆,外加一筆舊的亂數 user_id 資料
+ * (模擬修補前 ChatBox 用 Math.random() 寫入的歷史)。
+ */
+export function seedChatHistory() {
+  tables.chat_history = [
+    { id: 1, user_id: 'member-1', user_message: 'm1-a', agent_reply: 'r1', created_at: '2026-05-01T00:00:00Z' },
+    { id: 2, user_id: 'member-1', user_message: 'm1-b', agent_reply: 'r2', created_at: '2026-05-03T00:00:00Z' },
+    { id: 3, user_id: 'member-2', user_message: 'm2-a', agent_reply: 'r3', created_at: '2026-05-02T00:00:00Z' },
+    { id: 4, user_id: 'user-legacyxx', user_message: '舊亂數', agent_reply: 'r4', created_at: '2026-04-01T00:00:00Z' },
+  ];
+}
+
+/** chat_history 查詢都以 args[0] 為 user_id 過濾(對應 WHERE user_id = ?)。 */
+function filterChatHistory(args: unknown[]): DbRow[] {
+  const userId = args[0];
+  return tables.chat_history.filter((r) => r.user_id === userId);
+}
+
+vi.mock('@libsql/client/web', () => ({
+  createClient: () => ({
+    execute: vi.fn(async ({ sql, args = [] }: { sql: string; args?: unknown[] }) => {
+      // getSessionUser:session + user lookup
+      if (sql.includes('FROM sessions s') && sql.includes('JOIN users')) {
+        const token = args[0];
+        const session = tables.sessions.find((s) => s.token === token);
+        if (!session) return { rows: [], columns: [] };
+        const user = tables.users.find((u) => u.id === session.user_id);
+        if (!user) return { rows: [], columns: [] };
+        return {
+          rows: [{
+            user_id: user.id,
+            user_name: user.name,
+            user_discord_id: user.discord_id,
+            user_status: user.status,
+            user_archived_at: user.archived_at,
+            expires_at: session.expires_at,
+          }],
+          columns: [],
+        };
+      }
+
+      // 角色查詢
+      if (sql.includes('SELECT role FROM user_roles')) {
+        const userId = args[0];
+        return {
+          rows: tables.user_roles.filter((r) => r.user_id === userId).map((r) => ({ role: r.role })),
+          columns: [],
+        };
+      }
+
+      // CREATE TABLE — no-op
+      if (sql.includes('CREATE TABLE IF NOT EXISTS')) {
+        return { rows: [], columns: [] };
+      }
+
+      // COUNT chat_history(self-scoped)
+      if (sql.includes('SELECT COUNT(*)') && sql.includes('FROM chat_history')) {
+        return { rows: [{ total: filterChatHistory(args).length }], columns: [] };
+      }
+
+      // SELECT chat_history(self-scoped)
+      if (sql.includes('FROM chat_history')) {
+        return { rows: filterChatHistory(args), columns: [] };
+      }
+
+      // INSERT chat_history
+      if (sql.includes('INSERT INTO chat_history')) {
+        tables.chat_history.push({
+          id: _nextId++,
+          user_id: args[0] as string,
+          user_message: args[1] as string,
+          agent_reply: args[2] as string,
+          created_at: new Date().toISOString(),
+        });
+        return { rows: [], columns: [] };
+      }
+
+      return { rows: [], columns: [] };
+    }),
+    batch: vi.fn(async () => []),
+  }),
+}));


### PR DESCRIPTION
## 背景

Issue #5 稽核發現管家(`/agent`)對話有 **P1 等級資料外洩**:
`/api/agent/history` 無登入驗證、無 user 過濾,任何人在公開的 `/agent`
頁面點「📜 歷史」即可分頁 + 搜尋**全部成員**與管家的私人對話 —— 連登入都不用。

## 變更(Tier 1 止血)

- **`functions/api/agent/history.ts`** — 加 `getSessionUser` 驗證,未登入回 401;
  查詢一律 `WHERE user_id = ?` self-scope 到 session user。
- **`functions/api/agent/chat.ts`** — 移除前端可偽造的 body `userId`,改用 session 身份;
  匿名訪客仍可聊,但對話不寫入可辨識歷史。
- **`ChatBox.tsx`** — 移除 `Math.random()` 假 `USER_ID`;歷史分頁處理 401 顯示登入提示。
- **footer** — 加隱私聲明一行。
- **`/agent` 頁面** — 措辭調整,不過度承諾跨成員私人記憶。

## 測試

- 新增 `tests/unit/agent/history.test.ts` — 單元測試覆蓋 401 + self-scope(3 案例)。
- 新增 `e2e/agent-privacy.spec.ts` — 歷史登入閘 / 匿名可聊 / footer 聲明。
- `bun run test` ✓ 62 passed · `bun run build` ✓ 80 pages

## Task 3(非名單帳號自動取得陪跑員)

經 code trace 確認**已修復**:`callback.ts` 真・新使用者建為 `pending`,
`requireAuth` 回 403。本 PR 不含相關程式碼變更。

## 範圍外(建議另開 issue)

**Tier 2 — 每位成員專屬 Letta agent**。目前 19 人共用單一 agent + memory block,
管家「長期記憶」仍可能跨成員;本 PR 已堵住「讀取他人歷史」,真正的記憶隔離需 Tier 2。

設計 / 計畫:`docs/superpowers/specs/` 與 `docs/superpowers/plans/`。

Refs #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)