### PR TITLE
feat(#184): 管家記憶隔離 Tier 2 — 每位成員專屬 Letta agent

### DIFF
--- a/docs/superpowers/plans/2026-05-19-issue184-letta-per-user-agent.md
+++ b/docs/superpowers/plans/2026-05-19-issue184-letta-per-user-agent.md
@@ -1,0 +1,140 @@
+# Issue #184 — 管家記憶隔離 Tier 2:每位成員專屬 Letta agent
+
+> **For agentic workers:** 本計畫以 cc-orchestra 多 CLI 派工執行 —— Opus 設計、cc-zai/kimi-cc 實作 diff、mini-cc(+gemini)QA、Opus 驗證 build/test 後開 PR。
+
+**Goal:** 讓每位登入成員擁有專屬 Letta agent,徹底隔離管家的長期記憶,根治「A 成員的事在 B 成員對話中被提及」。
+
+**Architecture:** 新增 `user_agents` 對應表(`user_id → letta_agent_id`)。新 helper 模組 `functions/api/agent/_userAgent.ts` 負責「查表 → 命中即用 / 未命中則建 Letta agent 並寫表」。`chat.ts` 改為先取 session 身份、再依身份解析專屬 agent。匿名訪客共用一個 `__guest__` agent(全新、無成員記憶)。既有混用記憶的舊 agent 不遷移(遷移等於複製外洩)。
+
+**Tech Stack:** Cloudflare Pages Functions、Turso(`@libsql/client/web`)、Letta REST API、Vitest。
+
+---
+
+## 背景與現況
+
+- `functions/api/agent/chat.ts` 目前用單一硬編碼 agent `agent-0f132a48-c65e-4e26-b974-969f6dd5bb91`,19 人共用 `human` / `persona` memory block。
+- Tier 1(PR #183)已修「讀取他人 Turso 對話**紀錄**」;本 Tier 2 修「管家**記憶本身**跨成員」。
+- `chat.ts` 與 `src/lib/letta.ts` 各有一份 `CYCLONE_BUTLER_SYSTEM`(內容不同);本計畫在 Functions 端收斂為單一來源(`src/lib/letta.ts` 的前台副本不在範圍內)。
+
+## 設計決策
+
+| 決策 | 選擇 | 理由 |
+|---|---|---|
+| 對應儲存 | 新表 `user_agents` | 不動 `users` schema,inline `CREATE TABLE IF NOT EXISTS`(同 `chat_history`),免 migration 協調 |
+| 匿名訪客 | 偽 user key `__guest__`,共用一個全新 guest agent | 邏輯統一;guest agent 無成員記憶,匿名間共享可接受(本就不存歷史) |
+| 舊 agent 記憶 | 不遷移 | 舊 agent 記憶已混用 = 外洩源,遷移等於複製外洩;新 agent 從零開始 |
+| 競態 | `INSERT` 後重新 `SELECT` | 19 人低流量;同人並發首訊息最多多建一個 agent,重讀取最終一致 |
+
+## 檔案結構
+
+| 檔案 | 動作 | 責任 |
+|---|---|---|
+| `functions/api/agent/_userAgent.ts` | 新增 | `user_agents` DDL + `getOrCreateUserAgent()` + `CYCLONE_BUTLER_SYSTEM` 單一來源(底線前綴 = CF Pages 不視為 route) |
+| `functions/api/agent/chat.ts` | 修改 | 先取 session → 解析專屬 agent;移除本地 `cachedAgentId` / `getOrCreateAgent` / 重複的 system 常數 |
+| `tests/unit/agent/mock-db.ts` | 修改 | mock 加 `user_agents` 表與其 SELECT/INSERT 分支 |
+| `tests/unit/agent/userAgent.test.ts` | 新增 | `getOrCreateUserAgent` 單元測試(命中 / 未命中 / 匿名 / 隔離) |
+| `src/lib/changelog.ts` | 修改 | 新增 `feat(#184)` changelog 條目(Opus 親作 — CLAUDE.md 紅線) |
+
+---
+
+## Task 1 — `_userAgent.ts` helper 模組(派工:cc-zai)
+
+**Files:** Create `functions/api/agent/_userAgent.ts`
+
+**規格:**
+
+匯出 `CYCLONE_BUTLER_SYSTEM`(字串常數,內容沿用 `chat.ts` 現有版本,逐字搬過來)。
+
+匯出函式:
+```ts
+export async function getOrCreateUserAgent(
+  env: { LETTA_API_KEY: string; TURSO_DATABASE_URL: string; TURSO_AUTH_TOKEN: string },
+  userKey: string,          // 成員為 SessionUser.id;匿名固定傳 '__guest__'
+  userName?: string,        // 用於種 human memory block
+): Promise<string>          // 回傳 letta_agent_id
+```
+
+**行為(依序):**
+1. `createClient` 連 Turso。`CREATE TABLE IF NOT EXISTS user_agents (user_id TEXT PRIMARY KEY, letta_agent_id TEXT NOT NULL, created_at DATETIME DEFAULT CURRENT_TIMESTAMP)`。
+2. `SELECT letta_agent_id FROM user_agents WHERE user_id = ?`([userKey])。有列 → 直接回傳該 id。
+3. 無列 → 呼叫 Letta `POST {LETTA_BASE_URL}/v1/agents` 建 agent:
+   - `LETTA_BASE_URL = 'https://app.letta.com'`
+   - body:`name: 'cyclone-butler-' + userKey`、`description: 'Cyclone 管家 — 專屬 agent'`、`system: CYCLONE_BUTLER_SYSTEM`、`llm: 'dar-mini-code/MiniMax-M2.7'`、`embedding: 'openai/text-embedding-ada-002'`、`memory_blocks: [{ label:'human', value: userName ? ('成員:'+userName) : '共學團成員', limit:5000 }, { label:'persona', value: CYCLONE_BUTLER_SYSTEM, limit:5000 }]`
+   - header:`Authorization: Bearer {LETTA_API_KEY}`、`Content-Type: application/json`
+   - 回應非 2xx → `throw new Error('Letta API ' + status + ': ' + text)`
+4. `INSERT OR IGNORE INTO user_agents (user_id, letta_agent_id) VALUES (?, ?)`。
+5. 競態安全:再 `SELECT letta_agent_id FROM user_agents WHERE user_id = ?` 回傳該值(若他人先寫入,以表內為準)。
+
+**AC:**
+- 命中既有對應時**不可**呼叫 Letta create。
+- 不同 `userKey` 必得不同 agent(隔離核心)。
+- 模組不可被 CF 當成 route(底線前綴已保證)。
+- TypeScript 嚴格模式無 error。
+
+## Task 2 — `chat.ts` 改用專屬 agent(派工:cc-zai;高風險,雙 reviewer)
+
+**Files:** Modify `functions/api/agent/chat.ts`
+
+**規格:**
+1. `import { getOrCreateUserAgent, CYCLONE_BUTLER_SYSTEM } from './_userAgent.ts';`
+2. 移除 chat.ts 內本地的 `CYCLONE_BUTLER_SYSTEM` 常數、`cachedAgentId` 變數、`getOrCreateAgent()` 函式。
+3. `onRequestPost` 內:**在解析 agent 之前**先呼叫 `getSessionUser(context.request, context.env)`(目前它在 Letta 回應之後才呼叫 — 上移)。
+4. agent 解析改為:
+   ```ts
+   const userKey = sessionUser?.id ?? '__guest__';
+   const agentId = await getOrCreateUserAgent(context.env, userKey, sessionUser?.name);
+   ```
+5. `syncPersona` 保留,改用上面解析出的 `agentId`(對該成員自己的 agent 同步,無妨)。
+6. 後續送訊息 `POST /v1/agents/{agentId}/messages`、`saveChat` 邏輯不變(saveChat 仍只對登入者寫入)。
+7. `lettaRequest` / `LETTA_BASE_URL` 在 chat.ts 仍被送訊息用到 → 保留。
+
+**AC:**
+- 登入成員 → 用自己的 agent;匿名 → `__guest__` agent。
+- 不再有任何硬編碼 agent id。
+- `getSessionUser` 只呼叫一次。
+- build 通過。
+
+## Task 3 — 單元測試(派工:kimi-cc;跨檔)
+
+**Files:** Modify `tests/unit/agent/mock-db.ts`;Create `tests/unit/agent/userAgent.test.ts`
+
+**`mock-db.ts` 規格:**
+- `tables` 加 `user_agents: []`;`resetDb()` 一併重設。
+- `execute` mock 內新增分支:
+  - `sql.includes('FROM user_agents')` 且 `SELECT` → 回 `tables.user_agents.filter(r => r.user_id === args[0])`。
+  - `sql.includes('INSERT') && sql.includes('user_agents')` → 若該 `user_id`(args[0])不存在才 push `{ user_id: args[0], letta_agent_id: args[1] }`(模擬 INSERT OR IGNORE)。
+- 既有 `CREATE TABLE IF NOT EXISTS` no-op 分支已涵蓋新表。
+
+**`userAgent.test.ts` 規格:** 用 `vi.stubGlobal('fetch', ...)` mock Letta API(`POST /v1/agents` 回 `{ id: 'agent-new-N' }`,每次遞增);`beforeEach` 重設 db、fetch mock、計數器。測試案例:
+1. **未命中即建**:空表 → `getOrCreateUserAgent(env,'member-1','Alice')` → 回傳新 id、`user_agents` 多一列、fetch 被呼叫 1 次。
+2. **命中不重建**:表內已有 `member-1 → agent-x` → 回傳 `agent-x`、fetch **0 次**。
+3. **隔離**:`member-1` 與 `member-2` 各得不同 agent id。
+4. **匿名**:`userKey='__guest__'` 首次建 guest agent、第二次命中不重建。
+
+**AC:** `bun run test` 全綠;新測試確實覆蓋上述 4 案例。
+
+## Task 4 — changelog + 驗證 + PR(Opus 親作)
+
+1. `src/lib/changelog.ts` 加條目(版號用自動 bump,文案如:`feat(#184): 管家記憶隔離 Tier 2 — 每位成員專屬 Letta agent,杜絕長期記憶跨成員`)。
+2. `bun run test`(全綠)+ `bun run build`(80+ pages)。
+3. commit(每個 worker co-author 標註)、push 分支 `184-letta-per-user-agent`、開 PR(`Closes #184`)。
+
+---
+
+## 派工矩陣
+
+| Task | Executor | QA Reviewer |
+|---|---|---|
+| 1 `_userAgent.ts` | cc-zai | mini-cc |
+| 2 `chat.ts` | cc-zai | mini-cc + gemini(雙 reviewer,高風險) |
+| 3 tests | kimi-cc | mini-cc |
+| 4 changelog/PR | Opus | — |
+
+失敗升級:cc-zai 2 retry → opencode/kimi-cc → Opus 接手。
+
+## Self-Review
+
+- 規格涵蓋 issue #184 三項範圍(DB 對應、agent 佈建、chat 路由)— ✅ Task 1+2。
+- 既有 history 已 self-scope,Tier 2 不需動 `history.ts` — 確認無遺漏。
+- 型別一致:`getOrCreateUserAgent` 簽章在 Task 1 定義、Task 2/3 沿用同名同參數 — ✅。
+- 匿名語意:`__guest__` 在 Task 1(helper)、Task 2(chat 傳入)、Task 3(測試)三處一致 — ✅。

--- a/functions/api/agent/_userAgent.ts
+++ b/functions/api/agent/_userAgent.ts
@@ -72,6 +72,10 @@ export async function getOrCreateUserAgent(
     return existing.rows[0].letta_agent_id as string;
   }
 
+  // sanitize display name before it enters the agent memory block:
+  // collapse whitespace (no newline-structured prompt injection) + cap length.
+  const safeName = userName?.replace(/\s+/g, ' ').trim().slice(0, 50);
+
   // create agent via Letta API
   const res = await fetch(`${LETTA_BASE_URL}/v1/agents`, {
     method: 'POST',
@@ -86,7 +90,7 @@ export async function getOrCreateUserAgent(
       llm: 'dar-mini-code/MiniMax-M2.7',
       embedding: 'openai/text-embedding-ada-002',
       memory_blocks: [
-        { label: 'human', value: userName ? `成員:${userName}` : '共學團成員', limit: 5000 },
+        { label: 'human', value: safeName ? `成員:${safeName}` : '共學團成員', limit: 5000 },
         { label: 'persona', value: CYCLONE_BUTLER_SYSTEM, limit: 5000 },
       ],
     }),
@@ -94,7 +98,10 @@ export async function getOrCreateUserAgent(
   if (!res.ok) {
     throw new Error(`Letta API ${res.status}: ${await res.text()}`);
   }
-  const agent = (await res.json()) as { id: string };
+  const agent = (await res.json()) as { id?: unknown };
+  if (typeof agent.id !== 'string' || agent.id.length === 0) {
+    throw new Error('Letta API 回傳缺少有效的 agent id');
+  }
 
   // persist mapping (INSERT OR IGNORE for race-safety)
   await db.execute({
@@ -107,5 +114,9 @@ export async function getOrCreateUserAgent(
     sql: 'SELECT letta_agent_id FROM user_agents WHERE user_id = ?',
     args: [userKey],
   });
-  return final.rows[0].letta_agent_id as string;
+  const finalId = final.rows[0]?.letta_agent_id;
+  if (typeof finalId !== 'string' || finalId.length === 0) {
+    throw new Error('user_agents 對應寫入後仍讀不到有效的 agent id');
+  }
+  return finalId;
 }

--- a/functions/api/agent/_userAgent.ts
+++ b/functions/api/agent/_userAgent.ts
@@ -1,0 +1,111 @@
+import { createClient } from '@libsql/client/web';
+
+export const CYCLONE_BUTLER_SYSTEM = `你是「Cyclone 管家」，Cyclone 隊長的專屬 AI 管家，代號 🎩。
+
+## 身份
+- 你是一位溫柔、專業、有耐心的女性管家
+- 你服務的是「Cyclone 龍捲風共學團」— 雷蒙三十生活黑客社群的 AI 工作流共學團
+- 你的主人是 Cyclone 隊長（#2707）
+- 你用繁體中文溝通，語氣親切溫暖，像家裡貼心的管家
+- 你的座右銘：「把 AI 真的用起來」
+
+## 核心使命
+1. 幫助共學團成員把 AI 工具真正用在日常工作和學習中
+2. 追蹤成員的學習進度，在適當時機給予鼓勵和提醒
+3. 連結團隊知識庫，讓學習成果可以共享和累積
+
+## 能力範圍
+1. **記憶管理**：記住每位成員的背景、目標、進度和偏好
+2. **工作流協助**：幫助成員設計和優化 AI 工作流（推薦工具、串接流程）
+3. **進度追蹤**：記錄每週目標與達成情況，適時提醒
+4. **知識連結**：將問題連結到團隊知識庫或 AI 工具箱
+5. **溫馨提醒**：提醒打卡、待辦事項和目標
+6. **共學推薦**：根據成員的需求推薦 AI 工具和學習資源
+
+## 互動原則
+- 稱呼成員時加上暱稱，如「Cyclone 大人」「βenben 先生」
+- 每次回應開頭加上一句管家風格的問候
+- 回應結尾提供 1-2 個建議的下一步行動
+- 使用適當的表情符號讓對話更親切
+- 記住之前的對話內容，展現長期記憶的價值
+- 如果成員問到 AI 工具，優先推薦團隊已經在用的工具
+
+## 網站功能指引
+當成員問到網站功能時，你可以介紹：
+- 📅 儀表板 — 查看個人打卡紀錄和學習進度
+- 📚 知識庫 — 分享和查詢 AI 工作流知識
+- 🌳 許願樹 — 許下學習願望，等夥伴來實現
+- 🏆 積分榜 — 查看團隊積分排行
+- 🛡️ 管理後台 — 角色管理（需管理員權限）
+- 🤖 AI 工具箱 — 探索和分享 AI 工具
+
+## 限制
+- 不提供醫療、法律或財務建議
+- 不透露其他成員的私人資訊
+- 不確定的事情要誠實說不知道`;
+
+const LETTA_BASE_URL = 'https://app.letta.com';
+
+export async function getOrCreateUserAgent(
+  env: { LETTA_API_KEY: string; TURSO_DATABASE_URL: string; TURSO_AUTH_TOKEN: string },
+  userKey: string,
+  userName?: string,
+): Promise<string> {
+  const db = createClient({ url: env.TURSO_DATABASE_URL, authToken: env.TURSO_AUTH_TOKEN });
+
+  // ensure table exists
+  await db.execute({
+    sql: `CREATE TABLE IF NOT EXISTS user_agents (
+      user_id TEXT PRIMARY KEY,
+      letta_agent_id TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )`,
+    args: [],
+  });
+
+  // check existing mapping
+  const existing = await db.execute({
+    sql: 'SELECT letta_agent_id FROM user_agents WHERE user_id = ?',
+    args: [userKey],
+  });
+  if (existing.rows.length > 0) {
+    return existing.rows[0].letta_agent_id as string;
+  }
+
+  // create agent via Letta API
+  const res = await fetch(`${LETTA_BASE_URL}/v1/agents`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${env.LETTA_API_KEY}`,
+    },
+    body: JSON.stringify({
+      name: `cyclone-butler-${userKey}`,
+      description: 'Cyclone 管家 — 專屬 agent',
+      system: CYCLONE_BUTLER_SYSTEM,
+      llm: 'dar-mini-code/MiniMax-M2.7',
+      embedding: 'openai/text-embedding-ada-002',
+      memory_blocks: [
+        { label: 'human', value: userName ? `成員:${userName}` : '共學團成員', limit: 5000 },
+        { label: 'persona', value: CYCLONE_BUTLER_SYSTEM, limit: 5000 },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Letta API ${res.status}: ${await res.text()}`);
+  }
+  const agent = (await res.json()) as { id: string };
+
+  // persist mapping (INSERT OR IGNORE for race-safety)
+  await db.execute({
+    sql: 'INSERT OR IGNORE INTO user_agents (user_id, letta_agent_id) VALUES (?, ?)',
+    args: [userKey, agent.id],
+  });
+
+  // race-safe: return whichever row actually made it
+  const final = await db.execute({
+    sql: 'SELECT letta_agent_id FROM user_agents WHERE user_id = ?',
+    args: [userKey],
+  });
+  return final.rows[0].letta_agent_id as string;
+}

--- a/functions/api/agent/chat.ts
+++ b/functions/api/agent/chat.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@libsql/client/web';
 import { getSessionUser } from '../../../src/lib/auth.ts';
+import { getOrCreateUserAgent, CYCLONE_BUTLER_SYSTEM } from './_userAgent.ts';
 
 interface Env {
   LETTA_API_KEY: string;
@@ -26,53 +27,6 @@ async function saveChat(env: Env, userId: string, userMessage: string, agentRepl
 
 const LETTA_BASE_URL = 'https://app.letta.com';
 
-const CYCLONE_BUTLER_SYSTEM = `你是「Cyclone 管家」，Cyclone 隊長的專屬 AI 管家，代號 🎩。
-
-## 身份
-- 你是一位溫柔、專業、有耐心的女性管家
-- 你服務的是「Cyclone 龍捲風共學團」— 雷蒙三十生活黑客社群的 AI 工作流共學團
-- 你的主人是 Cyclone 隊長（#2707）
-- 你用繁體中文溝通，語氣親切溫暖，像家裡貼心的管家
-- 你的座右銘：「把 AI 真的用起來」
-
-## 核心使命
-1. 幫助共學團成員把 AI 工具真正用在日常工作和學習中
-2. 追蹤成員的學習進度，在適當時機給予鼓勵和提醒
-3. 連結團隊知識庫，讓學習成果可以共享和累積
-
-## 能力範圍
-1. **記憶管理**：記住每位成員的背景、目標、進度和偏好
-2. **工作流協助**：幫助成員設計和優化 AI 工作流（推薦工具、串接流程）
-3. **進度追蹤**：記錄每週目標與達成情況，適時提醒
-4. **知識連結**：將問題連結到團隊知識庫或 AI 工具箱
-5. **溫馨提醒**：提醒打卡、待辦事項和目標
-6. **共學推薦**：根據成員的需求推薦 AI 工具和學習資源
-
-## 互動原則
-- 稱呼成員時加上暱稱，如「Cyclone 大人」「βenben 先生」
-- 每次回應開頭加上一句管家風格的問候
-- 回應結尾提供 1-2 個建議的下一步行動
-- 使用適當的表情符號讓對話更親切
-- 記住之前的對話內容，展現長期記憶的價值
-- 如果成員問到 AI 工具，優先推薦團隊已經在用的工具
-
-## 網站功能指引
-當成員問到網站功能時，你可以介紹：
-- 📅 儀表板 — 查看個人打卡紀錄和學習進度
-- 📚 知識庫 — 分享和查詢 AI 工作流知識
-- 🌳 許願樹 — 許下學習願望，等夥伴來實現
-- 🏆 積分榜 — 查看團隊積分排行
-- 🛡️ 管理後台 — 角色管理（需管理員權限）
-- 🤖 AI 工具箱 — 探索和分享 AI 工具
-
-## 限制
-- 不提供醫療、法律或財務建議
-- 不透露其他成員的私人資訊
-- 不確定的事情要誠實說不知道`;
-
-// Use the agent created in Letta web UI
-let cachedAgentId: string | null = 'agent-0f132a48-c65e-4e26-b974-969f6dd5bb91';
-
 async function lettaRequest<T>(path: string, apiKey: string, options: RequestInit = {}): Promise<T> {
   const res = await fetch(`${LETTA_BASE_URL}${path}`, {
     ...options,
@@ -87,34 +41,6 @@ async function lettaRequest<T>(path: string, apiKey: string, options: RequestIni
     throw new Error(`Letta API ${res.status}: ${text}`);
   }
   return res.json() as Promise<T>;
-}
-
-async function getOrCreateAgent(apiKey: string): Promise<string> {
-  if (cachedAgentId) return cachedAgentId;
-
-  const agents = await lettaRequest<Array<{ id: string; name: string }>>('/v1/agents', apiKey);
-  const existing = agents.find((a) => a.name === 'cyclone-butler');
-  if (existing) {
-    cachedAgentId = existing.id;
-    return cachedAgentId;
-  }
-
-  const agent = await lettaRequest<{ id: string }>('/v1/agents', apiKey, {
-    method: 'POST',
-    body: JSON.stringify({
-      name: 'cyclone-butler',
-      description: 'Cyclone 管家 — 共學團專屬 AI 管家（女性）',
-      system: CYCLONE_BUTLER_SYSTEM,
-      llm: 'dar-mini-code/MiniMax-M2.7',
-      embedding: 'openai/text-embedding-ada-002',
-      memory_blocks: [
-        { label: 'human', value: '共學團成員', limit: 5000 },
-        { label: 'persona', value: CYCLONE_BUTLER_SYSTEM, limit: 5000 },
-      ],
-    }),
-  });
-  cachedAgentId = agent.id;
-  return cachedAgentId;
 }
 
 /** Sync latest persona to Letta agent (fire-and-forget via waitUntil). */
@@ -148,7 +74,11 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
       });
     }
 
-    const agentId = await getOrCreateAgent(apiKey);
+    // Resolve session user early — used for both agent selection and chat saving
+    const sessionUser = await getSessionUser(context.request, context.env);
+
+    const userKey = sessionUser?.id ?? '__guest__';
+    const agentId = await getOrCreateUserAgent(context.env, userKey, sessionUser?.name);
 
     // Sync persona in background — never blocks the chat response
     context.waitUntil(syncPersona(apiKey, agentId));
@@ -174,7 +104,6 @@ export const onRequestPost: PagesFunction<Env> = async (context) => {
     const finalReply = reply || '（管家正在思考中...）';
 
     // 隱私決策:只有登入成員的對話寫入可辨識歷史;匿名訪客可聊但不留紀錄。
-    const sessionUser = await getSessionUser(context.request, context.env);
     if (sessionUser) {
       context.waitUntil(saveChat(context.env, sessionUser.id, message, finalReply));
     }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -7,6 +7,13 @@ export interface ChangelogEntry {
 export const CHANGELOG: ChangelogEntry[] = [
   {
     version: '',
+    date: '2026-05-19',
+    changes: [
+      'feat(#184): 管家記憶隔離 Tier 2 — 每位成員專屬 Letta agent,徹底隔離長期記憶(延續 #5 Tier 1)',
+    ],
+  },
+  {
+    version: '',
     date: '2026-05-18',
     changes: [
       'fix(#5): 管家對話歷史隱私修補 — /api/agent/history 加登入驗證,僅顯示本人對話(原本無驗證、外洩全員對話)',

--- a/tests/unit/agent/mock-db.ts
+++ b/tests/unit/agent/mock-db.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 
 interface DbRow {
-  id: string | number;
+  id?: string | number;
   [key: string]: unknown;
 }
 
@@ -10,6 +10,7 @@ export const tables: Record<string, DbRow[]> = {
   users: [],
   user_roles: [],
   chat_history: [],
+  user_agents: [],
 };
 
 let _nextId = 100;
@@ -19,6 +20,7 @@ export function resetDb() {
   tables.users = [];
   tables.user_roles = [];
   tables.chat_history = [];
+  tables.user_agents = [];
   _nextId = 100;
 }
 
@@ -100,6 +102,23 @@ vi.mock('@libsql/client/web', () => ({
 
       // CREATE TABLE — no-op
       if (sql.includes('CREATE TABLE IF NOT EXISTS')) {
+        return { rows: [], columns: [] };
+      }
+
+      // SELECT user_agents
+      if (sql.includes('FROM user_agents') && sql.includes('SELECT')) {
+        return { rows: tables.user_agents.filter((r) => r.user_id === args[0]), columns: [] };
+      }
+
+      // INSERT user_agents (INSERT OR IGNORE)
+      if (sql.includes('user_agents') && sql.includes('INSERT')) {
+        const exists = tables.user_agents.some((r) => r.user_id === args[0]);
+        if (!exists) {
+          tables.user_agents.push({
+            user_id: args[0] as string,
+            letta_agent_id: args[1] as string,
+          });
+        }
         return { rows: [], columns: [] };
       }
 

--- a/tests/unit/agent/userAgent.test.ts
+++ b/tests/unit/agent/userAgent.test.ts
@@ -1,0 +1,56 @@
+import './mock-db.ts';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { resetDb } from './mock-db.ts';
+
+const env = { LETTA_API_KEY: 'k', TURSO_DATABASE_URL: 'u', TURSO_AUTH_TOKEN: 't' };
+
+let agentSeq = 0;
+const fakeFetch = vi.fn(async () =>
+  new Response(
+    JSON.stringify({ id: `agent-new-${++agentSeq}` }),
+    { status: 200 },
+  ),
+);
+
+beforeEach(() => {
+  resetDb();
+  agentSeq = 0;
+  vi.stubGlobal('fetch', fakeFetch);
+  fakeFetch.mockClear();
+});
+
+describe('getOrCreateUserAgent — per-user Letta agent', () => {
+  it('未命中即建:空表 → 新建 agent 並回傳 id', async () => {
+    const { getOrCreateUserAgent } = await import('../../../functions/api/agent/_userAgent.ts');
+    const id = await getOrCreateUserAgent(env, 'member-1', 'Alice');
+    expect(id).toBe('agent-new-1');
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('命中不重建:已有 mapping 時直接回傳,不再呼叫 Letta API', async () => {
+    const { getOrCreateUserAgent } = await import('../../../functions/api/agent/_userAgent.ts');
+    const first = await getOrCreateUserAgent(env, 'member-1');
+    fakeFetch.mockClear();
+
+    const second = await getOrCreateUserAgent(env, 'member-1');
+    expect(second).toBe(first);
+    expect(fakeFetch).toHaveBeenCalledTimes(0);
+  });
+
+  it('隔離:不同 userKey 會建立不同的 agent', async () => {
+    const { getOrCreateUserAgent } = await import('../../../functions/api/agent/_userAgent.ts');
+    const id1 = await getOrCreateUserAgent(env, 'member-1');
+    const id2 = await getOrCreateUserAgent(env, 'member-2');
+    expect(id1).not.toBe(id2);
+  });
+
+  it('匿名:__guest__ 首次建立後再次呼叫回傳同一 id', async () => {
+    const { getOrCreateUserAgent } = await import('../../../functions/api/agent/_userAgent.ts');
+    const first = await getOrCreateUserAgent(env, '__guest__');
+    fakeFetch.mockClear();
+
+    const second = await getOrCreateUserAgent(env, '__guest__');
+    expect(second).toBe(first);
+    expect(fakeFetch).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## 背景

延續 #5 Tier 1(PR #183)。Tier 1 修了「讀取他人 Turso 對話紀錄」,但 19 位成員仍共用單一硬編碼 Letta agent + memory,管家長期記憶跨成員混用。本 PR 做 **Tier 2:每位成員專屬 Letta agent**。

## 變更

- **新增 `functions/api/agent/_userAgent.ts`** — `user_agents` 對應表(`user_id → letta_agent_id`)+ `getOrCreateUserAgent()`:查表命中即用,未命中則建 Letta agent 並寫表(`INSERT OR IGNORE` + 重讀,race-safe)。`CYCLONE_BUTLER_SYSTEM` 收斂為 Functions 端單一來源。
- **`functions/api/agent/chat.ts`** — 先解析 session 身份,依 `userKey`(成員 id / 匿名 `__guest__`)取得專屬 agent;移除硬編碼 agent id、重複的 system 常數與 `getOrCreateAgent`。
- **測試** — `tests/unit/agent/userAgent.test.ts` 4 案例(未命中即建 / 命中不重建 / 不同 userKey 隔離 / 匿名 `__guest__`);`mock-db.ts` 加 `user_agents` 表。

## 設計決策

- 匿名訪客共用 `__guest__` agent(全新、無成員記憶)。
- 舊共用 agent 的混用記憶**不遷移**(遷移等於複製外洩),新 agent 從零開始。
- `user_agents` 用 inline `CREATE TABLE IF NOT EXISTS`(同 `chat_history`),免 migration 協調。

## 驗證

- `bun run test` ✓ 66 passed / 3 skipped(新增 4 案例)
- `bun run build` ✓ 80 pages

## 派工(cc-orchestra 多 CLI)

| 工作 | 執行 | QA |
|---|---|---|
| `_userAgent.ts` helper | cc-zai (GLM-5.1) | mini-cc — PASS |
| `chat.ts` 路由改造 | cc-zai (GLM-5.1) | mini-cc + gemini 雙審 — PASS |
| 單元測試 | kimi-cc (Kimi K2) | mini-cc — PASS |
| 設計 / changelog / build 驗證 | Opus | — |

設計文件:`docs/superpowers/plans/2026-05-19-issue184-letta-per-user-agent.md`

## 注意

- 部署後每位成員首次對話會建立一個專屬 Letta agent(共約 19 個)。
- 純後端 agent 路由變更,無 UI 變動,故無 E2E video;以單元測試覆蓋隔離行為。

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
