### PR TITLE
chore(ci): scale down GitHub Actions to avoid account-level disable

### DIFF
--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -6,6 +6,17 @@ on:
       - main
     paths-ignore:
       - 'src/lib/version.ts'
+      - '**.md'
+      - 'docs/**'
+      - '.archive/**'
+      - 'pm/**'
+      - 'qa1/**'
+      - 'shipper/**'
+      - 'super/**'
+      - 'eng1/**'
+      - '.claude/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -1,9 +1,6 @@
 name: Tauri Release
 
 on:
-  push:
-    tags:
-      - 'desktop-v*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Closes #186

## Summary

`cyclone-tw` 帳號之前被 GitHub disable Actions(Ticket #4293377),剛恢復。本 PR 縮減 workflow 觸發,避免再踩雷。

## Changes

- [x] **Tauri release**:移除 tag 自動觸發,改 `workflow_dispatch` only(原 4 平台 matrix 單次 ~150 min)
- [x] **Cloudflare deploy**:加 `paths-ignore`(`**.md`、`docs/**`、`.archive/**`、`pm/qa1/shipper/super/eng1/**`、`.claude/**`、`AGENTS.md`、`CLAUDE.md`)
- [ ] ❌ 取消 30 個 queued Copilot review run — **API 拒絕(HTTP 500),Copilot 內建 run 外部不能 cancel**
- [ ] ⏳ (手動)Repo Settings → Code & automation → Copilot → 關掉 auto code review(只有這條能止血 queued)

## Test plan

- [x] YAML 語法通過(`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Push 純文件改動不觸發 Cloudflare deploy(merge 後才能驗)
- [ ] Push code 改動仍觸發 Cloudflare deploy(merge 後才能驗)
- [ ] `gh workflow run tauri-release.yml` 仍可手動觸發

## Follow-up(本 PR 外)

1. 手動到 https://github.com/cyclone-tw/cyclone-workflow/settings → Code & automation → Copilot 關掉 auto code review
2. 確認本月 Actions usage:https://github.com/settings/billing/summary
3. 之後 Tauri 發版改用 `gh workflow run tauri-release.yml` 手動觸發

🤖 Generated with [Claude Code](https://claude.com/claude-code)